### PR TITLE
Add ipzope.cfg to make it easy to use the IPython shell with zope

### DIFF
--- a/ipzope.cfg
+++ b/ipzope.cfg
@@ -1,0 +1,27 @@
+# a IPython Shell for interactive use with zope.
+# It's best to use this with a zeo instance.
+[buildout]
+extends = dev.cfg
+parts += ipzope
+auto-checkout += slc.ipythonprofiles
+
+[ipzope]
+recipe = zc.recipe.egg
+eggs =
+        ipython
+        ${instance:eggs}
+initialization =
+        import sys, os
+        os.environ["SOFTWARE_HOME"] = " "
+        os.environ["INSTANCE_HOME"] = "${instance:location}"
+        os.environ["CONFIG_FILE"] = "${instance:location}/etc/zope.conf"
+        os.environ["IPYTHONDIR"] = os.path.join("${buildout:directory}", "${buildout:sources-dir}", "slc.ipythonprofiles")
+        sys.argv[1:1] = "--profile=zope".split()
+scripts = ipython=ipzope
+extra-paths = ${buildout:sources-dir}/slc.ipythonprofiles/profile_zope
+
+[sources]
+slc.ipythonprofiles = git https://github.com/syslabcom/slc.ipythonprofiles.git egg=false
+
+[versions]
+ipython = 3.0.0


### PR DESCRIPTION
This can be used by extending it from your local.cfg:

[buildout]
extends = ipzope.cfg
parts += zeo

[instance]
eggs += Products.PrintingMailHost
zeo-address = ${zeo:zeo-address}
zeo-client = on

[zeo]
recipe = plone.recipe.zeoserver
zeo-address = 8100
