### PR TITLE
bootstrap: support installing buildout in current dir

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -2,14 +2,18 @@ from subprocess import CalledProcessError
 from subprocess import check_call
 
 import os
+import shlex
 import sys
 
 
 python_path = sys.executable
 bin_dir = os.path.dirname(python_path)
 pip_path = os.path.join(bin_dir, "pip")
+out_path = "{0}/bin".format(os.getcwd())
 bootstrap_clean = "{0} uninstall -y zc.buildout".format(pip_path)
-bootstrap = "{0} install -r requirements.txt".format(pip_path)
+bootstrap = (
+    '{0} install -r requirements.txt --install-option="--install-scripts={1}"'
+).format(pip_path, out_path)
 
 if not os.path.exists(pip_path):
     print ("pip is not installed in your virtualenv. Reinstall your "
@@ -22,7 +26,7 @@ except CalledProcessError:
     print "Ready for bootstrap"
 try:
     print "Running bootstrap command: {0}".format(bootstrap)
-    check_call(bootstrap.split(" "))
+    check_call(shlex.split(bootstrap))
     print "Bootstrap complete"
 except CalledProcessError:
     print "Please try to bootstrap manually using: {0}".format(bootstrap)

--- a/docs/installation/development.rst
+++ b/docs/installation/development.rst
@@ -20,13 +20,8 @@ Set-up a development environment::
     git clone https://github.com/ploneintranet/ploneintranet
     cd ploneintranet
     virtualenv --no-site-packages .
-    bin/python2.7 bootstrap.py -c dev.cfg -v 1.6.3  # matching the current version pin!
+    bin/python2.7 bootstrap.py
     bin/buildout -c dev.cfg
-
-Note for virtualenvwrapper users:
-Running bootstrap will place the buildout script in your virtulenv's ``bin/`` directory.
-So if your virtualenv was created with ``mkvirtualenv`` or ``mkproject``,
-most likely you won't find the buildout script where you expect it.
 
 
 Build using the Plone 5 coredev


### PR DESCRIPTION
This should work in the case where a virtualenv is active which isn't in
the current directory. Python from the activated virtualenv will be
used, but buildout will be installed in ./bin/buildout.

@khink @do3cc @gyst what do you think?
