### PR TITLE
bootstrap_jenkins: use virtualenv --relocatable to reduce shabang length

### DIFF
--- a/bootstrap_jenkins.sh
+++ b/bootstrap_jenkins.sh
@@ -6,7 +6,7 @@ mkdir -p buildout-cache/downloads || exit 1
 
 # NOTE: we need to use virtualenv --relocatable every time new
 # console_scripts have been created in ./bin to avoid running into the
-# problem where the shabang is > 127 characters long.
+# problem where the shebang is > 127 characters long.
 virtualenv --relocatable .
 . bin/activate
 ./bin/python bootstrap.py || exit 1

--- a/bootstrap_jenkins.sh
+++ b/bootstrap_jenkins.sh
@@ -8,6 +8,7 @@ mkdir -p buildout-cache/downloads || exit 1
 # console_scripts have been created in ./bin to avoid running into the
 # problem where the shabang is > 127 characters long.
 virtualenv --relocatable .
+. bin/activate
 ./bin/python bootstrap.py || exit 1
 virtualenv --relocatable .
 ./bin/buildout -N -t 3 -c jenkins.cfg || exit 1

--- a/bootstrap_jenkins.sh
+++ b/bootstrap_jenkins.sh
@@ -1,10 +1,17 @@
 if [ ! -f bin/activate ] 
 then
-    virtualenv  .
+    virtualenv .
 fi
 mkdir -p buildout-cache/downloads || exit 1
+
+# NOTE: we need to use virtualenv --relocatable every time new
+# console_scripts have been created in ./bin to avoid running into the
+# problem where the shabang is > 127 characters long.
+virtualenv --relocatable .
 ./bin/python bootstrap.py || exit 1
+virtualenv --relocatable .
 ./bin/buildout -N -t 3 -c jenkins.cfg || exit 1
+virtualenv --relocatable .
 bundle install --path vendor/bundle --binstubs
 ./bin/develop up -f || exit 1
 make clean-stamps all || exit 1


### PR DESCRIPTION
When jenkins jobs have long names the shabang path created by virtualenv
exceeds the maximum length allowed of 127 characters. We can work around
this by using `virtualenv --relocatable .` after any console scripts are
added to ./bin.
