### PR TITLE
Fix naming issues with social packages

### DIFF
--- a/src/ploneintranet/activitystream/configure.zcml
+++ b/src/ploneintranet/activitystream/configure.zcml
@@ -28,7 +28,7 @@
 
   <genericsetup:registerProfile
       name="default"
-      title="PloneIntranet Activitystream"
+      title="Plone Intranet Activitystream"
       directory="profiles/default"
       description="Installs the ploneintranet.activitystream package"
       provides="Products.GenericSetup.interfaces.EXTENSION"
@@ -37,7 +37,7 @@
 
   <genericsetup:registerProfile
       name="uninstall"
-      title="PloneIntranet Activitystream: Uninstall"
+      title="Plone Intranet Activitystream: Uninstall"
       directory="profiles/uninstall"
       description="Uninstalls the ploneintranet.activitystream package"
       provides="Products.GenericSetup.interfaces.EXTENSION"

--- a/src/ploneintranet/activitystream/locales/en/LC_MESSAGES/ploneintranet.activitystream.po
+++ b/src/ploneintranet/activitystream/locales/en/LC_MESSAGES/ploneintranet.activitystream.po
@@ -57,9 +57,9 @@ msgstr ""
 msgid "Number of updates to display"
 msgstr ""
 
-#. Default: "PloneIntranet Activitystream"
+#. Default: "Plone Intranet Activitystream"
 #: ./configure.zcml
-msgid "PloneIntranet Activitystream"
+msgid "Plone Intranet Activitystream"
 msgstr ""
 
 #: ./browser/interfaces.py:84

--- a/src/ploneintranet/activitystream/locales/es/LC_MESSAGES/ploneintranet.activitystream.po
+++ b/src/ploneintranet/activitystream/locales/es/LC_MESSAGES/ploneintranet.activitystream.po
@@ -62,10 +62,10 @@ msgstr "Mi perfil"
 msgid "Number of updates to display"
 msgstr "Número de actualizaciones a mostrar"
 
-#. Default: "PloneIntranet Activitystream"
+#. Default: "Plone Intranet Activitystream"
 #: ./configure.zcml
-msgid "PloneIntranet Activitystream"
-msgstr "PloneIntranet - Actividades recientes"
+msgid "Plone Intranet Activitystream"
+msgstr "Plone Intranet - Actividades recientes"
 
 #: ./browser/interfaces.py:84
 msgid "Show content creation"

--- a/src/ploneintranet/activitystream/locales/fr/LC_MESSAGES/ploneintranet.activitystream.po
+++ b/src/ploneintranet/activitystream/locales/fr/LC_MESSAGES/ploneintranet.activitystream.po
@@ -57,10 +57,10 @@ msgstr ""
 msgid "Number of updates to display"
 msgstr "Nombre de messages à afficher"
 
-#. Default: "PloneIntranet Activitystream"
+#. Default: "Plone Intranet Activitystream"
 #: ./configure.zcml
-msgid "PloneIntranet Activitystream"
-msgstr "Flux d'activité PloneIntranet"
+msgid "Plone Intranet Activitystream"
+msgstr "Flux d'activité Plone Intranet"
 
 #: ./browser/interfaces.py:84
 msgid "Show content creation"

--- a/src/ploneintranet/activitystream/locales/manual.pot
+++ b/src/ploneintranet/activitystream/locales/manual.pot
@@ -28,9 +28,9 @@ msgstr ""
 msgid "Social activity stream portal view with manageable portlets"
 msgstr ""
 
-#. Default: "PloneIntranet Activitystream"
+#. Default: "Plone Intranet Activitystream"
 #: ./configure.zcml
-msgid "PloneIntranet Activitystream"
+msgid "Plone Intranet Activitystream"
 msgstr ""
 
 #. Default: "Installs the ploneintranet.activitystream package"

--- a/src/ploneintranet/activitystream/locales/nl/LC_MESSAGES/ploneintranet.activitystream.po
+++ b/src/ploneintranet/activitystream/locales/nl/LC_MESSAGES/ploneintranet.activitystream.po
@@ -57,9 +57,9 @@ msgstr ""
 msgid "Number of updates to display"
 msgstr "Aantal weer te geven statusberichten"
 
-#. Default: "PloneIntranet Activitystream"
+#. Default: "Plone Intranet Activitystream"
 #: ./configure.zcml
-msgid "PloneIntranet Activitystream"
+msgid "Plone Intranet Activitystream"
 msgstr ""
 
 #: ./browser/interfaces.py:84

--- a/src/ploneintranet/activitystream/locales/ploneintranet.activitystream.pot
+++ b/src/ploneintranet/activitystream/locales/ploneintranet.activitystream.pot
@@ -60,9 +60,9 @@ msgstr ""
 msgid "Number of updates to display"
 msgstr ""
 
-#. Default: "PloneIntranet Activitystream"
+#. Default: "Plone Intranet Activitystream"
 #: ./configure.zcml
-msgid "PloneIntranet Activitystream"
+msgid "Plone Intranet Activitystream"
 msgstr ""
 
 #: ./browser/interfaces.py:84

--- a/src/ploneintranet/activitystream/locales/pt_BR/LC_MESSAGES/ploneintranet.activitystream.po
+++ b/src/ploneintranet/activitystream/locales/pt_BR/LC_MESSAGES/ploneintranet.activitystream.po
@@ -58,10 +58,10 @@ msgstr "Meu perfil"
 msgid "Number of updates to display"
 msgstr "Número de atualizações para exibir"
 
-#. Default: "PloneIntranet Activitystream"
+#. Default: "Plone Intranet Activitystream"
 #: ./configure.zcml
-msgid "PloneIntranet Activitystream"
-msgstr "Fluxo de atividade do PloneIntranet"
+msgid "Plone Intranet Activitystream"
+msgstr "Fluxo de atividade do Plone Intranet"
 
 #: ./browser/interfaces.py:84
 msgid "Show content creation"

--- a/src/ploneintranet/core/profiles.zcml
+++ b/src/ploneintranet/core/profiles.zcml
@@ -7,7 +7,7 @@
 
   <genericsetup:registerProfile
       name="default"
-      title="PloneIntranet Core: default"
+      title="Plone Intranet Social Core: default"
       directory="profiles/default"
       description="Installs shared utilities for PloneIntranet"
       provides="Products.GenericSetup.interfaces.EXTENSION"
@@ -16,7 +16,7 @@
 
   <genericsetup:registerProfile
       name="minimal"
-      title="PloneIntranet Core: minimal"
+      title="Plone Intranet Social Core: minimal"
       directory="profiles/minimal"
       description="Installs only required utilities, NOT patternslib resources"
       provides="Products.GenericSetup.interfaces.EXTENSION"

--- a/src/ploneintranet/messaging/configure.zcml
+++ b/src/ploneintranet/messaging/configure.zcml
@@ -11,7 +11,7 @@
 
   <genericsetup:registerProfile
       name="default"
-      title="PloneIntranet Messaging"
+      title="Plone Intranet Social Messaging"
       directory="profiles/default"
       description="Installs the ploneintranet.messaging package"
       provides="Products.GenericSetup.interfaces.EXTENSION"

--- a/src/ploneintranet/microblog/configure.zcml
+++ b/src/ploneintranet/microblog/configure.zcml
@@ -18,7 +18,7 @@
 
   <genericsetup:registerProfile
       name="default"
-      title="PloneIntranet Microblog"
+      title="Plone Intranet Microblog"
       directory="profiles/default"
       description="Installs the ploneintranet.microblog package"
       provides="Products.GenericSetup.interfaces.EXTENSION"

--- a/src/ploneintranet/microblog/locales/en/LC_MESSAGES/ploneintranet.microblog.po
+++ b/src/ploneintranet/microblog/locales/en/LC_MESSAGES/ploneintranet.microblog.po
@@ -55,7 +55,7 @@ msgid "Installs the ploneintranet.microblog package"
 msgstr ""
 
 #: configure.zcml
-msgid "PloneIntranet Microblog"
+msgid "Plone Intranet Microblog"
 msgstr ""
 
 #: ./portlets/microblog.py:18

--- a/src/ploneintranet/microblog/locales/es/LC_MESSAGES/ploneintranet.microblog.po
+++ b/src/ploneintranet/microblog/locales/es/LC_MESSAGES/ploneintranet.microblog.po
@@ -60,8 +60,8 @@ msgid "Installs the ploneintranet.microblog package"
 msgstr "Instala el paquete ploneintranet.microblog"
 
 #: configure.zcml
-msgid "PloneIntranet Microblog"
-msgstr "PloneIntranet - Microblogging"
+msgid "Plone Intranet Microblog"
+msgstr "Plone Intranet - Microblogging"
 
 #: ./portlets/microblog.py:18
 msgid "Title"

--- a/src/ploneintranet/microblog/locales/fr/LC_MESSAGES/ploneintranet.microblog.po
+++ b/src/ploneintranet/microblog/locales/fr/LC_MESSAGES/ploneintranet.microblog.po
@@ -58,8 +58,8 @@ msgid "Installs the ploneintranet.microblog package"
 msgstr "Installe le package ploneintranet.microblog"
 
 #: configure.zcml
-msgid "PloneIntranet Microblog"
-msgstr "PloneIntranet Microblog"
+msgid "Plone Intranet Microblog"
+msgstr "Plone Intranet Microblog"
 
 #: ./portlets/microblog.py:18
 msgid "Title"

--- a/src/ploneintranet/microblog/locales/manual.pot
+++ b/src/ploneintranet/microblog/locales/manual.pot
@@ -18,7 +18,7 @@ msgstr ""
 "Domain: ploneintranet.microblog\n"
 
 #: configure.zcml
-msgid "PloneIntranet Microblog"
+msgid "Plone Intranet Microblog"
 msgstr ""
 
 #: configure.zcml

--- a/src/ploneintranet/microblog/locales/nl/LC_MESSAGES/ploneintranet.microblog.po
+++ b/src/ploneintranet/microblog/locales/nl/LC_MESSAGES/ploneintranet.microblog.po
@@ -55,7 +55,7 @@ msgid "Installs the ploneintranet.microblog package"
 msgstr ""
 
 #: configure.zcml
-msgid "PloneIntranet Microblog"
+msgid "Plone Intranet Microblog"
 msgstr ""
 
 #: ./portlets/microblog.py:18

--- a/src/ploneintranet/microblog/locales/plonesocial.microblog.pot
+++ b/src/ploneintranet/microblog/locales/plonesocial.microblog.pot
@@ -58,7 +58,7 @@ msgid "Installs the ploneintranet.microblog package"
 msgstr ""
 
 #: configure.zcml
-msgid "PloneIntranet Microblog"
+msgid "Plone Intranet Microblog"
 msgstr ""
 
 #: ./portlets/microblog.py:18

--- a/src/ploneintranet/microblog/locales/pt_BR/LC_MESSAGES/ploneintranet.microblog.po
+++ b/src/ploneintranet/microblog/locales/pt_BR/LC_MESSAGES/ploneintranet.microblog.po
@@ -52,8 +52,8 @@ msgid "Installs the ploneintranet.microblog package"
 msgstr "Instala o pacote ploneintranet.microblog"
 
 #: configure.zcml
-msgid "PloneIntranet Microblog"
-msgstr "Microblog do PloneIntranet"
+msgid "Plone Intranet Microblog"
+msgstr "Microblog do Plone Intranet"
 
 #: ./portlets/microblog.py:18
 msgid "Title"

--- a/src/ploneintranet/network/configure.zcml
+++ b/src/ploneintranet/network/configure.zcml
@@ -17,7 +17,7 @@
 
   <genericsetup:registerProfile
       name="default"
-      title="PloneIntranet Network"
+      title="Plone Intranet Social Network"
       directory="profiles/default"
       description="Installs the ploneintranet.network package"
       provides="Products.GenericSetup.interfaces.EXTENSION"
@@ -26,7 +26,7 @@
 
   <genericsetup:registerProfile
       name="uninstall"
-      title="PloneIntranet Network Uninstall"
+      title="Plone Intranet Social Network Uninstall"
       directory="profiles/uninstall"
       description="Uninstalls the ploneintranet.network package"
       provides="Products.GenericSetup.interfaces.EXTENSION"

--- a/src/ploneintranet/network/locales/manual.pot
+++ b/src/ploneintranet/network/locales/manual.pot
@@ -18,7 +18,7 @@ msgstr ""
 "Domain: ploneintranet.network\n"
 
 #: ./configure.zcml
-msgid "PloneIntranet Network"
+msgid "Plone Intranet Network"
 msgstr ""
 
 #: ./configure.zcml

--- a/src/ploneintranet/network/locales/ploneintranet.network.pot
+++ b/src/ploneintranet/network/locales/ploneintranet.network.pot
@@ -51,7 +51,7 @@ msgid "Nothing here"
 msgstr ""
 
 #: configure.zcml
-msgid "PloneIntranet Network"
+msgid "Plone Intranet Network"
 msgstr ""
 
 #: ./browser/templates/author.pt:29

--- a/src/ploneintranet/socialsuite/locales/en/LC_MESSAGES/plonesocial.suite.po
+++ b/src/ploneintranet/socialsuite/locales/en/LC_MESSAGES/plonesocial.suite.po
@@ -31,11 +31,11 @@ msgid "Microblog"
 msgstr ""
 
 #: ./configure.zcml:
-msgid "PloneIntranet Suite"
+msgid "Plone Intranet Suite"
 msgstr ""
 
 #: ./configure.zcml:
-msgid "PloneIntranet Suite (Demo)"
+msgid "Plone Intranet Suite (Demo)"
 msgstr ""
 
 #: ./browser/navigation.pt:4

--- a/src/ploneintranet/socialsuite/locales/es/LC_MESSAGES/plonesocial.suite.po
+++ b/src/ploneintranet/socialsuite/locales/es/LC_MESSAGES/plonesocial.suite.po
@@ -35,12 +35,12 @@ msgid "Microblog"
 msgstr "Microblog"
 
 #: ./configure.zcml:
-msgid "PloneIntranet Suite"
-msgstr "PloneIntranet - Suite"
+msgid "Plone Intranet Suite"
+msgstr "Plone Intranet - Suite"
 
 #: ./configure.zcml:
-msgid "PloneIntranet Suite (Demo)"
-msgstr "PloneIntranet - Suite (Demostración)"
+msgid "Plone Intranet Suite (Demo)"
+msgstr "Plone Intranet - Suite (Demostración)"
 
 #: ./browser/navigation.pt:4
 msgid "explore"

--- a/src/ploneintranet/socialsuite/locales/manual.pot
+++ b/src/ploneintranet/socialsuite/locales/manual.pot
@@ -18,7 +18,7 @@ msgstr ""
 "Domain: ploneintranet.socialsuite\n"
 
 #: ./configure.zcml:
-msgid "PloneIntranet Suite"
+msgid "Plone Intranet Suite"
 msgstr ""
 
 #: ./configure.zcml:
@@ -26,7 +26,7 @@ msgid "Installs the suite of all ploneintranet packages"
 msgstr ""
 
 #: ./configure.zcml:
-msgid "PloneIntranet Suite (Demo)"
+msgid "Plone Intranet Suite (Demo)"
 msgstr ""
 
 #: ./configure.zcml:

--- a/src/ploneintranet/socialsuite/locales/nl/LC_MESSAGES/plonesocial.suite.po
+++ b/src/ploneintranet/socialsuite/locales/nl/LC_MESSAGES/plonesocial.suite.po
@@ -31,11 +31,11 @@ msgid "Microblog"
 msgstr ""
 
 #: ./configure.zcml:
-msgid "PloneIntranet Suite"
+msgid "Plone Intranet Suite"
 msgstr ""
 
 #: ./configure.zcml:
-msgid "PloneIntranet Suite (Demo)"
+msgid "Plone Intranet Suite (Demo)"
 msgstr ""
 
 #: ./browser/navigation.pt:4

--- a/src/ploneintranet/socialsuite/locales/ploneintranet.suite.pot
+++ b/src/ploneintranet/socialsuite/locales/ploneintranet.suite.pot
@@ -34,11 +34,11 @@ msgid "Microblog"
 msgstr ""
 
 #: ./configure.zcml:
-msgid "PloneIntranet Suite"
+msgid "Plone Intranet Suite"
 msgstr ""
 
 #: ./configure.zcml:
-msgid "PloneIntranet Suite (Demo)"
+msgid "Plone Intranet Suite (Demo)"
 msgstr ""
 
 #: ./browser/navigation.pt:4

--- a/src/ploneintranet/socialtheme/configure.zcml
+++ b/src/ploneintranet/socialtheme/configure.zcml
@@ -11,7 +11,7 @@
 
   <genericsetup:registerProfile
       name="default"
-      title="PloneIntranet Theme"
+      title="Plone Intranet Social Theme"
       directory="profiles/default"
       description='Skin overrides for ploneintranet.socialtheme'
       provides="Products.GenericSetup.interfaces.EXTENSION"

--- a/src/ploneintranet/suite/configure.zcml
+++ b/src/ploneintranet/suite/configure.zcml
@@ -32,7 +32,7 @@
       name="default"
       title="Plone Intranet: Suite"
       directory="profiles/default"
-      description="Installs the full suite of PloneIntranet packages"
+      description="Installs the full suite of Plone Intranet packages"
       provides="Products.GenericSetup.interfaces.EXTENSION"
       />
 


### PR DESCRIPTION
- PloneIntranet -> Plone Intranet for consistency with existing
  packages
- Add 'Social' to some of the social eggs to remove confusion with
  existing eggs (e.g. theme)
