### PR TITLE
Fix content view robot tests

### DIFF
--- a/src/ploneintranet/suite/setuphandlers.py
+++ b/src/ploneintranet/suite/setuphandlers.py
@@ -227,10 +227,13 @@ def create_workspaces(workspaces):
 def create_ws_content(parent, contents):
     for content in contents:
         sub_contents = content.pop('contents', None)
+        state = content.pop('state', None)
         obj = api.content.create(
             container=parent,
             **content
         )
+        if state is not None:
+            api.content.transition(obj, to_state=state)
         if sub_contents is not None:
             create_ws_content(obj, sub_contents)
 
@@ -439,7 +442,8 @@ def testing(context):
                                     'information, records and knowledge is a '
                                     'key part of any Machinery of Government '
                                     'change.',
-                     'type': 'Document'},
+                     'type': 'Document',
+                     'state': 'published'},
                     {'title': 'Repurchase Agreements',
                      'description': 'A staff presentation outlined several '
                                     'approaches to raising shortterm interest '

--- a/src/ploneintranet/suite/testing.py
+++ b/src/ploneintranet/suite/testing.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from plone.app.robotframework.testing import AUTOLOGIN_LIBRARY_FIXTURE
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
@@ -48,6 +49,8 @@ class PloneIntranetSuite(PloneSandboxLayer):
         ploneintranet.microblog.statuscontainer.MAX_QUEUE_AGE = 0
 
     def setUpPloneSite(self, portal):
+        # setup the default workflow
+        portal.portal_workflow.setDefaultChain('simple_publication_workflow')
         # Install into Plone site using portal_setup
         self.applyProfile(portal, 'ploneintranet.suite:testing')
 

--- a/src/ploneintranet/suite/tests/acceptance/content_views.robot
+++ b/src/ploneintranet/suite/tests/acceptance/content_views.robot
@@ -13,84 +13,84 @@ Test Teardown  Close all browsers
 *** Test Cases ***
 
 Alice can change the title of a document
-    Given I'm logged in as a 'alice_lindstrom'
+    Given I am logged in as the user alice_lindstrom
     And I browse to a document
     And I change the title
     And I view the document
     The document has the new title
 
 Alice can change the description of a document
-    Given I'm logged in as a 'alice_lindstrom'
+    Given I am logged in as the user alice_lindstrom
     And I browse to a document
     And I change the description
     And I view the document
     Then the document has the new description
 
 Alice can tag a document
-    Given I'm logged in as a 'alice_lindstrom'
+    Given I am logged in as the user alice_lindstrom
     And I browse to a document
     And I tag the description
     And I view the document
     Then the document has the new tag
 
 Alice can change the title of an image
-    Given I'm logged in as a 'alice_lindstrom'
+    Given I am logged in as the user alice_lindstrom
     And I browse to an image
     And I change the title
     And I view the image
     Then the document has the new title
 
 Alice can change the description of an image
-    Given I'm logged in as a 'alice_lindstrom'
+    Given I am logged in as the user alice_lindstrom
     And I browse to an image
     And I change the description
     And I view the image
     Then the document has the new description
 
 Alice can tag an image
-    Given I'm logged in as a 'alice_lindstrom'
+    Given I am logged in as the user alice_lindstrom
     And I browse to an image
     And I tag the description
     And I view the image
     Then the document has the new tag
 
 Alice can change the title of a file
-    Given I'm logged in as a 'alice_lindstrom'
+    Given I am logged in as the user alice_lindstrom
     And I browse to a file
     And I change the title
     And I view the file
     Then the document has the new title
 
 Alice can change the description of a file
-    Given I'm logged in as a 'alice_lindstrom'
+    Given I am logged in as the user alice_lindstrom
     And I browse to a file
     And I change the description
     And I view the file
     Then the document has the new description
 
 Alice can tag a file
-    Given I'm logged in as a 'alice_lindstrom'
+    Given I am logged in as the user alice_lindstrom
     And I browse to a file
     And I tag the description
     And I view the file
     Then the document has the new tag
 
 # Alice can change the title of a folder
-#     Given I'm logged in as a 'alice_lindstrom'
+#     Given I am logged in as the user alice_lindstrom
 #     And I view the folder
 #     And I change the title
 #     And I view the folder
 #     Then the document has the new title
 
 # Alice can change the description of a folder
-#     Given I'm logged in as a 'alice_lindstrom'
+#     Given I am logged in as the user alice_lindstrom
 #     And I view the folder
 #     And I change the description
 #     And I view the folder
 #     Then the document has the new description
 
 # Alice can tag a folder
-#     Given I'm logged in as a 'alice_lindstrom'
+#     Given I am logged in as the user alice_lindstrom
 #     And I view the folder
 #     And I tag the description
 #     And I view the folder

--- a/src/ploneintranet/theme/content/content.py
+++ b/src/ploneintranet/theme/content/content.py
@@ -19,7 +19,9 @@ class ContentView(BrowserView):
         """Render the default template and evaluate the form when editing."""
         context = aq_inner(self.context)
         self.workspace = parent_workspace(context)
-        self.can_edit = api.user.has_permission('Edit', obj=context)
+        self.can_edit = api.user.has_permission(
+            'Modify portal content',
+            obj=context)
         if self.can_edit and title or description or tags:
             modified = False
             if title and safe_unicode(title) != context.title:

--- a/src/ploneintranet/theme/content/templates/document_view.pt
+++ b/src/ploneintranet/theme/content/templates/document_view.pt
@@ -52,7 +52,7 @@
                                     </select>
                                 </label>
                             </fieldset>
-                            <button type="submit" tal:attributes="disabled read_only" class="icon-floppy">Save</button>
+                            <button type="submit" tal:condition="not:read_only" class="icon-floppy">Save</button>
 
                         </div>
                     </div>

--- a/src/ploneintranet/theme/content/templates/event_view.pt
+++ b/src/ploneintranet/theme/content/templates/event_view.pt
@@ -62,7 +62,7 @@
                 </fieldset -->
                 <!--
  -->
-                <button type="submit" class="icon-floppy" title="Save this document">Save</button>
+                <button type="submit" tal:condition="not:read_only" class="icon-floppy" title="Save this document">Save</button>
 
             </div>
         </div>


### PR DESCRIPTION
the main point here is the change in `testing.py`:

```
portal.portal_workflow.setDefaultChain('simple_publication_workflow')
```

Since that was missing all content (except workspaces) had no workflow attached to them in tests and permissions were aquired from the parent. Since the parent was the workspace and normal employees have no permission to edit that user the fields in the content-views/forms were deactivated. Uff.
