### PR TITLE
We return and display a link to the file and the file preview image

### DIFF
--- a/src/ploneintranet/activitystream/browser/activity_provider.py
+++ b/src/ploneintranet/activitystream/browser/activity_provider.py
@@ -15,7 +15,6 @@ from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 
 from .interfaces import IPloneIntranetActivitystreamLayer
 from .interfaces import IActivityProvider
-from plone.app.contenttypes.content import File
 from plone.app.contenttypes.content import Image
 from ploneintranet.activitystream.interfaces import IStatusActivity
 from ploneintranet.activitystream.interfaces import IStatusActivityReply
@@ -273,7 +272,7 @@ class StatusActivityProvider(AbstractActivityProvider):
             docconv = IDocconv(item)
             if docconv.has_thumbs():
                 url = '/'.join((item_url, 'thumb'))
-            elif isinstance(item, (File, Image)):
+            elif isinstance(item, Image):
                 images = api.content.get_view(
                     'images',
                     item.aq_base,
@@ -284,7 +283,10 @@ class StatusActivityProvider(AbstractActivityProvider):
                     images.scale(scale='preview').url.lstrip('/')
                 ))
             else:
-                url = ''
+                # We need a better fallback image. See #See #122
+                url = '/'.join((
+                    api.portal.get().absolute_url(),
+                    '++theme++ploneintranet.theme/generated/media/logo.svg'))
             if url:
                 attachments.append(dict(img_src=url, link=item_url))
         return attachments

--- a/src/ploneintranet/activitystream/browser/prototype/comment.html
+++ b/src/ploneintranet/activitystream/browser/prototype/comment.html
@@ -34,8 +34,8 @@
 
             <section class="preview">
                 <figure tal:repeat="attachment provider/attachments">
-                    <a href="/incredibly-boring-document" tal:attributes="href attachment">
-                        <img alt="" src="/media/preview_thumb_1.jpg" alt="" tal:attributes="src string:${attachment}" />
+                    <a href="${attachment/link|attachment}">
+                        <img alt="" src="${attachment/img_src|attachment}" alt="" />
                     </a>
                 </figure>
             </section>

--- a/src/ploneintranet/attachments/browser/upload.py
+++ b/src/ploneintranet/attachments/browser/upload.py
@@ -23,6 +23,7 @@ class UploadAttachments(BrowserView):
         ''' Return a dummy image thumbnails
 
         BBB: Ask for a better image :)
+        See #122
         '''
         url = '/'.join((
             api.portal.get().absolute_url(),


### PR DESCRIPTION
Since the recent merge, the attachment returned by the provider is a dict.

Attaching a file to a comment will turn out in a broken preview.

It should contain two keys:
- link:  the link to the original file
- img_src: the link to the preview image

I am using "|attachment" as fall back for backward compatibility, i.e. to handle the case where a provider returns just a string with a link.
