### PR TITLE
Attempt to fix issue #127 (non-ascii in filenames on stream attachments)

### DIFF
--- a/src/ploneintranet/attachments/browser/upload.py
+++ b/src/ploneintranet/attachments/browser/upload.py
@@ -3,9 +3,11 @@ from plone import api
 from plone.memoize.view import memoize
 from plone.app.contenttypes.content import File
 from plone.app.contenttypes.content import Image
+from plone.i18n.normalizer.interfaces import IURLNormalizer
 from ploneintranet.attachments import utils
 from ploneintranet.attachments.attachments import IAttachmentStorage
 from ploneintranet.docconv.client.interfaces import IDocconv
+from zope.component import getUtility
 import logging
 
 log = logging.getLogger(__name__)
@@ -88,12 +90,13 @@ class UploadAttachments(BrowserView):
     def __call__(self):
         token = self.request.get('attachment-form-token')
         attachments = self.request.get('form.widgets.attachments')
+        normalizer = getUtility(IURLNormalizer)
         self.attachments = []
         if attachments:
             temp_attachments = IAttachmentStorage(self.context)
             attachment_objs = utils.extract_attachments(attachments)
             for obj in attachment_objs:
-                obj.id = u'{0}-{1}'.format(token, obj.id)
+                obj.id = normalizer.normalize(u'{0}-{1}'.format(token, obj.id))
                 temp_attachments.add(obj)
                 obj = temp_attachments.get(obj.id)
                 if IPreviewFetcher is not None:

--- a/src/ploneintranet/attachments/utils.py
+++ b/src/ploneintranet/attachments/utils.py
@@ -1,12 +1,15 @@
 import logging
 from Acquisition import aq_base
+from Products.CMFPlone.utils import safe_unicode
 from datetime import datetime, timedelta
 from plone.dexterity.interfaces import IDexterityFTI
 from zope.component import createObject
 from zope.component import queryUtility
 from plone.namedfile import NamedBlobFile
+from plone.i18n.normalizer.interfaces import IURLNormalizer
 from ploneintranet.attachments.attachments import IAttachmentStorage
 from zope.container.interfaces import DuplicateIDError
+from zope.component import getUtility
 
 log = logging.getLogger(__name__)
 
@@ -36,7 +39,8 @@ def pop_temporary_attachment(workspace, file_field, token):
     the uploaded data
     """
     temp_attachments = IAttachmentStorage(workspace)
-    temp_id = '{0}-{1}'.format(token, file_field.filename)
+    temp_id = getUtility(IURLNormalizer).normalize(
+        u'{0}-{1}'.format(token, safe_unicode(file_field.filename)))
     if temp_id in temp_attachments.keys():
         temp_att = aq_base(temp_attachments.get(temp_id))
         temp_att.id = file_field.filename

--- a/src/ploneintranet/microblog/browser/attachments.py
+++ b/src/ploneintranet/microblog/browser/attachments.py
@@ -1,3 +1,4 @@
+from Products.CMFPlone.utils import safe_unicode
 from Products.Five.browser import BrowserView
 from plone import api
 from plone.rfc822.interfaces import IPrimaryFieldInfo
@@ -34,9 +35,10 @@ class StatusAttachments(BrowserView):
     def _prepare_imagedata(self, obj, imgdata):
         R = self.request.RESPONSE
         R.setHeader('content-type', 'image/jpeg')
-        R.setHeader('content-disposition', 'inline; '
-                    'filename="{0}_preview.jpg"'.format(
-                        self.attachment_id.encode('utf8')))
+        R.setHeader(
+            'content-disposition', 'inline; '
+            'filename="{0}_preview.jpg"'.format(
+                safe_unicode(self.attachment_id).encode('utf8')))
         if isinstance(imgdata, basestring):
             length = len(imgdata)
             R.setHeader('content-length', length)
@@ -68,7 +70,7 @@ class StatusAttachments(BrowserView):
             self.request.response.setHeader(
                 'content-disposition', 'inline; '
                 'filename="{0}"'.format(
-                    self.attachment_id.encode('utf8')))
+                    safe_unicode(self.attachment_id).encode('utf8')))
             return data
         if IDocconv is not None:
             docconv = IDocconv(attachment)

--- a/src/ploneintranet/suite/tests/acceptance/post_file.robot
+++ b/src/ploneintranet/suite/tests/acceptance/post_file.robot
@@ -28,8 +28,26 @@ Alice can submit a post with a file attachment
       And I add a file
       And I can see the file preview in the post box
       And I submit the new post
+    # injection
      Then I can see the file preview in the stream
       And I can open the file from the stream preview
+    # reload to verify
+     When I open the Dashboard
+     Then I can see the file preview in the stream
+      And I can open the file from the stream preview
+
+Alice can submit a post with a UTF-8 file attachment
+    Given I am logged in as the user alice_lindstrom
+      And I open the Dashboard
+     When I create a new post
+      And I add a UTF-8 file
+      And I can see the UTF-8 file preview in the post box
+      And I submit the new post
+    # Injection barfs UTF-8 but only in the testrunner (works fine in real site). Skip.
+    # Actual page load works fine
+     When I open the Dashboard
+     Then I can see the UTF-8 file preview in the stream
+      And I can open the UTF-8 file from the stream preview
 
 
 *** Keywords ***
@@ -57,3 +75,17 @@ I can open the file from the stream preview
    Wait Until Element Is visible   css=#activity-stream .preview a[href$='/basic.txt']
    Click Link  css=#activity-stream .preview a[href$='/basic.txt']
    Wait until page contains  Proin at congue nisl
+
+I add a UTF-8 file
+    Click Element   css=#microblog input[name='form.widgets.attachments']
+    Choose File     css=#microblog input[name='form.widgets.attachments']    ${UPLOADS}/bärtige_flößer.odt
+
+I can see the UTF-8 file preview in the post box
+    Wait Until Element Is visible   css=#microblog #post-box-attachment-previews img    timeout=60
+
+I can see the UTF-8 file preview in the stream
+    Wait Until Element Is visible   css=#activity-stream .preview img[src$='/bärtige_flößer.odt/thumb']
+
+I can open the UTF-8 file from the stream preview
+   Wait Until Element Is visible   css=#activity-stream .preview a[href$='/bärtige_flößer.odt']
+   # clicking the link downloads the .odt rather than rendering it in-browser. Skip.


### PR DESCRIPTION
This was a real bitch to track down....

The initial solution to get the upload working was pretty trivial: use Plone's standard IURLNormalizer to get a 'safe' id for the attachment.

The challenge was to find out that the same normalization needs to be applied also in pop_temporary_attachment() of ploneintranet.attachments.utils:
https://github.com/ploneintranet/ploneintranet/commit/7064738ecbf4b4da246cc44234152cf5c2d65b3c#diff-076a3598523e807f22b0c9945321bd57R42
But we're dealing with a different kind of object from which the id is generated:
In pi.attachments.upload we get the id from a p.a.contenttypes 'File' object, which is unicode: `u'Ba\u0308rtige Flo\u0308\xdfer.docx` which gets normalized to `bartige-flosser.docx` . In pop_temporary_attachment we get the id from a FileUpload instance, which is stored as utf-8 encoded string: `Ba\xcc\x88rtige Flo\xcc\x88\xc3\x9fer.docx` - normalize however makes `bairtige-floiaer.docx`out of it. Therefore this id needs to be turned into unicode again before we can apply the normalization. THEN the uploaded file is correctly found in the temporary attachment storage.

@gyst and @ale-rt This seems to fix all issues I had with non-ascii in the names of files and images. 2nd and 3rd pair of eyes much appreciated...
@reinhardt this also seems to fix the failing conversion we were looking at last week.

The test are still green...
