### PR TITLE
Add robot test "Create structure" again

### DIFF
--- a/src/ploneintranet/suite/tests/acceptance/workspace.robot
+++ b/src/ploneintranet/suite/tests/acceptance/workspace.robot
@@ -89,13 +89,10 @@ Create image
       And I go to the Open Market Committee Workspace
      Then I can create a new image
 
-#### FIXME!!!
-###  This fails currently, because on a freshly created document, if you don't addditionally
-###  Click Save, you will get a warning about unsaved changes
-# Create structure
-#     Given I am logged in as the user christian_stoney
-#       And I go to the Open Market Committee Workspace
-#      Then I can create a structure
+Create structure
+    Given I am logged in as the user christian_stoney
+      And I go to the Open Market Committee Workspace
+     Then I can create a structure
 
 Alice can upload a file
     Given I am logged in as the user alice_lindstrom
@@ -330,8 +327,11 @@ I can create a structure
     Click Button  css=#form-buttons-create
     # This must actually test for the document content of the rendered view
     Wait Until Page Contains Element  css=#content input[value="Document in subfolder"]
+    Click Button  Save
+    Wait Until Page Contains  Your changes have been saved
     Go To  ${PLONE_URL}/workspaces/open-market-committee
-    Click Element  css=a.pat-inject[href$='/open-market-committee/another-folder/@@sidebar.default#workspace-documents']
+    Click link  Documents
+    Click element  xpath=//a/strong[contains(text(), 'Another Folder')]
     Wait Until Page Contains Element  xpath=//a[@class='pat-inject follow'][contains(@href, '/document-in-subfolder')]
 
 The file appears in the sidebar


### PR DESCRIPTION
Ok (CC @jcbrand - this makes my comment in faf31c5 obsolete):
we decided today that the "Unsaved changes" message is actually OK
if the user creates a Rich Document and then tries to leave without saving.
I commented in the robot test again, and adapted it so that the "Save" button gets clicked.
(Also, I replaced a weird selector with a saner click-path)
