### PR TITLE
Remove status update sorting

### DIFF
--- a/src/ploneintranet/activitystream/browser/tiles/stream.py
+++ b/src/ploneintranet/activitystream/browser/tiles/stream.py
@@ -89,7 +89,6 @@ class StreamTile(Tile):
                 tag=self.tag
             )
         statusupdates = self.filter_statusupdates(statusupdates)
-        statusupdates.sort(key=lambda x: x.date, reverse=True)
         return statusupdates
 
     @property


### PR DESCRIPTION
The status updates are already returned sorted
by the date of youngest status reply in the thread.

Resorting means taking in to acocunt
just the date of the parent status update
