### PR TITLE
176 fix empty posting

### DIFF
--- a/src/ploneintranet/microblog/browser/prototype/comment-well-said.html
+++ b/src/ploneintranet/microblog/browser/prototype/comment-well-said.html
@@ -12,14 +12,13 @@
         attachment_previews_id string:attachment-previews-${thread_id};
         action string:${here/absolute_url}/@@newpostbox.tile;
       ">
-        <div
-            id="${string:comment-trail-${thread_id}}"
-            tal:content="structure python:view.get_post_as_comment(view.post)"
-            tal:condition="view/post"
-        />
-        <div tal:condition="not:view/post">
-            You added no text!
-        </div>
+        <tal:isposting tal:condition="view/post">
+            <div
+                id="${string:comment-trail-${thread_id}}"
+                tal:define="comment python:view.get_post_as_comment(view.post)"
+                tal:content="structure comment"
+            />
+        </tal:isposting>
         <metal:block use-macro="here/@@update-social.html/main" />
     </tal:define>
 

--- a/src/ploneintranet/microblog/browser/prototype/comment-well-said.html
+++ b/src/ploneintranet/microblog/browser/prototype/comment-well-said.html
@@ -14,9 +14,12 @@
       ">
         <div
             id="${string:comment-trail-${thread_id}}"
-            tal:define="comment python:view.get_post_as_comment(view.post)"
-            tal:content="structure comment"
+            tal:content="structure python:view.get_post_as_comment(view.post)"
+            tal:condition="view/post"
         />
+        <div tal:condition="not:view/post">
+            You added no text!
+        </div>
         <metal:block use-macro="here/@@update-social.html/main" />
     </tal:define>
 

--- a/src/ploneintranet/microblog/browser/prototype/post-well-done.html
+++ b/src/ploneintranet/microblog/browser/prototype/post-well-done.html
@@ -6,9 +6,6 @@
   <metal:macro define-macro="main">
     <metal:block use-macro="here/update-social.html/main" />
     <div id="activity-stream">
-        <div tal:condition="not:view/activity_views">
-            You added no text!
-        </div>
         <metal:block tal:condition="view/activity_views" use-macro="here/activity-stream.html/main" />
     </div>
   </metal:macro>

--- a/src/ploneintranet/microblog/browser/prototype/post-well-done.html
+++ b/src/ploneintranet/microblog/browser/prototype/post-well-done.html
@@ -6,7 +6,10 @@
   <metal:macro define-macro="main">
     <metal:block use-macro="here/update-social.html/main" />
     <div id="activity-stream">
-        <metal:block use-macro="here/activity-stream.html/main" />
+        <div tal:condition="not:view/activity_views">
+            You added no text!
+        </div>
+        <metal:block tal:condition="view/activity_views" use-macro="here/activity-stream.html/main" />
     </div>
   </metal:macro>
 

--- a/src/ploneintranet/microblog/browser/tiles/newpostbox.py
+++ b/src/ploneintranet/microblog/browser/tiles/newpostbox.py
@@ -130,9 +130,16 @@ class NewPostBoxTile(Tile):
 
     def create_post(self):
         """ Return the post object or None
+
+        To really proceed in the status update creation we require at least
+        one of these two properties to evaluate to True
+         - post_text
+         - post_attachment
+
+        If not of them evaluates to True we return None
         """
-        if not self.post_text:
-            return None
+        if not (self.post_text or self.post_attachment):
+            return
         post = StatusUpdate(
             text=self.post_text,
             context=self.post_context,

--- a/src/ploneintranet/microblog/browser/tiles/newpostbox.py
+++ b/src/ploneintranet/microblog/browser/tiles/newpostbox.py
@@ -169,18 +169,19 @@ class NewPostBoxTile(Tile):
         """ When updating we may want to process the form data and,
         if needed, create a post
         """
+        self.activity_views = []
         if self.is_posting:
             self.post = self.create_post()
-            self.activity_views = [
+        else:
+            self.post = None
+        if self.post:
+            self.activity_views.append(
                 api.content.get_view(
                     'activity_view',
                     IStatusActivity(self.post),
                     self.request
                 ).as_post
-            ]
-        else:
-            self.post = None
-            self.activity_views = []
+            )
 
     def __call__(self, *args, **kwargs):
         """ Call the multiadapter update

--- a/src/ploneintranet/suite/tests/acceptance/post_file.robot
+++ b/src/ploneintranet/suite/tests/acceptance/post_file.robot
@@ -49,6 +49,15 @@ Alice can submit a post with a UTF-8 file attachment
      Then I can see the UTF-8 file preview in the stream
       And I can open the UTF-8 file from the stream preview
 
+Alice can submit a post with a file attachment and no text
+    Given I am logged in as the user alice_lindstrom
+      And I open the Dashboard
+     When I add a file
+      And I can see the file preview in the post box
+      And I submit the new post
+    # test injection working
+     Then I can see the file preview in the stream
+
 
 *** Keywords ***
 

--- a/src/ploneintranet/suite/tests/acceptance/posting.robot
+++ b/src/ploneintranet/suite/tests/acceptance/posting.robot
@@ -37,6 +37,15 @@ Alice can post a status update
     then The message is visible as new status update    ${MESSAGE2}
     and The message is visibile after a reload    ${MESSAGE2}
 
+# Acceptance test for 176
+# ./bin/test -t "Alice can post an empty status update"
+# Alice can post an empty status update
+#    Given I am logged in as the user alice_lindstrom
+#    when I open the Dashboard
+#     and I submit the status update
+#    and Wait Until Element Is visible  ????
+#
+
 Allan can post a reply
     Given I am logged in as the user allan_neece
     when I open the Dashboard

--- a/src/ploneintranet/suite/tests/acceptance/posting.robot
+++ b/src/ploneintranet/suite/tests/acceptance/posting.robot
@@ -37,15 +37,6 @@ Alice can post a status update
     then The message is visible as new status update    ${MESSAGE2}
     and The message is visibile after a reload    ${MESSAGE2}
 
-# Acceptance test for 176
-# ./bin/test -t "Alice can post an empty status update"
-# Alice can post an empty status update
-#    Given I am logged in as the user alice_lindstrom
-#    when I open the Dashboard
-#     and I submit the status update
-#    then Wait Until Element Is visible  ????
-#
-
 Allan can post a reply
     Given I am logged in as the user allan_neece
     when I open the Dashboard
@@ -54,17 +45,6 @@ Allan can post a reply
     When I post a reply on a status update    ${MESSAGE1}    ${MESSAGE2}
     then The reply is visibile as a comment    ${MESSAGE1}    ${MESSAGE2}
     and The reply is visible after a reload    ${MESSAGE1}    ${MESSAGE2}
-
-# Acceptance test for 176
-# ./bin/test -t "Alice can post an empty status update"
-# Allan can post an empty reply
-#     Given I am logged in as the user allan_neece
-#      when I open the Dashboard
-#       and I post a status update    ${MESSAGE1}
-#      then The message is visible as new status update    ${MESSAGE1}
-#      When I post an empty reply on a status update    ${MESSAGE1}
-#      then Wait Until Element Is visible  ????
-
 
 Esmeralda can reply to a reply
     Given I am logged in as the user esmeralda_claassen
@@ -171,12 +151,6 @@ I post a reply on a status update
     Click Element  xpath=//div[@id='activity-stream']//div[@class='post item']//section[@class='post-content']//p[contains(text(), '${message}')]//..//..//../textarea[contains(@class, 'pat-content-mirror')]
     Wait Until Element Is visible  xpath=//div[@id='activity-stream']//div[@class='post item']//section[@class='post-content']//p[contains(text(), '${message}')]//..//..//../button[@name='form.buttons.statusupdate']
     Input Text  xpath=//div[@id='activity-stream']//div[@class='post item']//section[@class='post-content']//p[contains(text(), '${message}')]//..//..//../textarea[contains(@class, 'pat-content-mirror')]  ${reply_message}
-    Click button  xpath=//div[@id='activity-stream']//div[@class='post item']//section[@class='post-content']//p[contains(text(), '${message}')]//..//..//../button[@name='form.buttons.statusupdate']
-
-I post an empty reply on a status update
-    [arguments]  ${message}
-    Click Element  xpath=//div[@id='activity-stream']//div[@class='post item']//section[@class='post-content']//p[contains(text(), '${message}')]//..//..//../textarea[contains(@class, 'pat-content-mirror')]
-    Wait Until Element Is visible  xpath=//div[@id='activity-stream']//div[@class='post item']//section[@class='post-content']//p[contains(text(), '${message}')]//..//..//../button[@name='form.buttons.statusupdate']
     Click button  xpath=//div[@id='activity-stream']//div[@class='post item']//section[@class='post-content']//p[contains(text(), '${message}')]//..//..//../button[@name='form.buttons.statusupdate']
 
 The reply is visibile as a comment

--- a/src/ploneintranet/suite/tests/acceptance/posting.robot
+++ b/src/ploneintranet/suite/tests/acceptance/posting.robot
@@ -43,7 +43,7 @@ Alice can post a status update
 #    Given I am logged in as the user alice_lindstrom
 #    when I open the Dashboard
 #     and I submit the status update
-#    and Wait Until Element Is visible  ????
+#    then Wait Until Element Is visible  ????
 #
 
 Allan can post a reply
@@ -54,6 +54,17 @@ Allan can post a reply
     When I post a reply on a status update    ${MESSAGE1}    ${MESSAGE2}
     then The reply is visibile as a comment    ${MESSAGE1}    ${MESSAGE2}
     and The reply is visible after a reload    ${MESSAGE1}    ${MESSAGE2}
+
+# Acceptance test for 176
+# ./bin/test -t "Alice can post an empty status update"
+# Allan can post an empty reply
+#     Given I am logged in as the user allan_neece
+#      when I open the Dashboard
+#       and I post a status update    ${MESSAGE1}
+#      then The message is visible as new status update    ${MESSAGE1}
+#      When I post an empty reply on a status update    ${MESSAGE1}
+#      then Wait Until Element Is visible  ????
+
 
 Esmeralda can reply to a reply
     Given I am logged in as the user esmeralda_claassen
@@ -160,6 +171,12 @@ I post a reply on a status update
     Click Element  xpath=//div[@id='activity-stream']//div[@class='post item']//section[@class='post-content']//p[contains(text(), '${message}')]//..//..//../textarea[contains(@class, 'pat-content-mirror')]
     Wait Until Element Is visible  xpath=//div[@id='activity-stream']//div[@class='post item']//section[@class='post-content']//p[contains(text(), '${message}')]//..//..//../button[@name='form.buttons.statusupdate']
     Input Text  xpath=//div[@id='activity-stream']//div[@class='post item']//section[@class='post-content']//p[contains(text(), '${message}')]//..//..//../textarea[contains(@class, 'pat-content-mirror')]  ${reply_message}
+    Click button  xpath=//div[@id='activity-stream']//div[@class='post item']//section[@class='post-content']//p[contains(text(), '${message}')]//..//..//../button[@name='form.buttons.statusupdate']
+
+I post an empty reply on a status update
+    [arguments]  ${message}
+    Click Element  xpath=//div[@id='activity-stream']//div[@class='post item']//section[@class='post-content']//p[contains(text(), '${message}')]//..//..//../textarea[contains(@class, 'pat-content-mirror')]
+    Wait Until Element Is visible  xpath=//div[@id='activity-stream']//div[@class='post item']//section[@class='post-content']//p[contains(text(), '${message}')]//..//..//../button[@name='form.buttons.statusupdate']
     Click button  xpath=//div[@id='activity-stream']//div[@class='post item']//section[@class='post-content']//p[contains(text(), '${message}')]//..//..//../button[@name='form.buttons.statusupdate']
 
 The reply is visibile as a comment


### PR DESCRIPTION
I think this code is ready for merging.

I provided a robot test that demonstrates that it is possible to post a status update containing just a file (without entering text).

In addition the patch will fix injection when neither a text nor a file is provided.
But this eventually should be fixed and tested after prototype changes (that will disable the button).
