### PR TITLE
Remove 3rd party packages from test coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -10,3 +10,5 @@ omit =
     src/collective.workspace/*
     src/ploneintranet.invitations/*
     src/plone.api/*
+    src/zope.testrunner/*
+    src/collective.celery/*


### PR DESCRIPTION
Excludes 3rd party checkouts that are erroneously reducing the test coverage reporting.
