### PR TITLE
Pin versions to a known good set

### DIFF
--- a/base.cfg
+++ b/base.cfg
@@ -2,6 +2,7 @@
 extends =
     https://raw.github.com/collective/buildout.plonetest/master/test-5.0.x.cfg
     versions.cfg
+    soft-versions.cfg
 
 package-name = ploneintranet
 package-extras = [test]

--- a/base.cfg
+++ b/base.cfg
@@ -1,6 +1,7 @@
 [buildout]
 extends =
     https://raw.github.com/collective/buildout.plonetest/master/test-5.0.x.cfg
+    versions.cfg
 
 package-name = ploneintranet
 package-extras = [test]
@@ -15,6 +16,7 @@ parts +=
     createcoverage
     coverage-report
 
+show-picked-versions = true
 
 always-checkout = true
 extensions = mr.developer
@@ -159,21 +161,3 @@ slc.docconv = git https://github.com/syslabcom/slc.docconv.git pushurl=git@githu
 sphinx.themes.plone = git https://github.com/plone/sphinx.themes.plone.git pushurl=git@github.com:plone/sphinx.themes.plone.git
 zope.testrunner = git https://github.com/zopefoundation/zope.testrunner.git pushurl=git@github.com:zopefoundation/zope.testrunner.git
 
-[versions]
-# We need the collective.xmltestreport 1.3.2 UnicodeEncodeError fix.
-collective.xmltestreport = 1.3.2
-robotframework-selenium2library = 1.6.0
-selenium = 2.45.0
-z3c.recipe.egg = 1.3.2
-zc.queue = 1.1
-Sphinx = 1.2.1
-six = 1.8.0
-pep8 = 1.5.7
-# Must pin selenium libs here, firefox was updated with the system so we 
-# must follow, even though plone pinning is not yet up to date
-selenium = 2.45.0
-robotframework-selenium2library = 1.6.0
-
-# NOTE: setuptools and zc.buildout versions must be in sync with requirements.txt
-setuptools = 14.0
-zc.buildout = 2.2.5

--- a/base.cfg
+++ b/base.cfg
@@ -24,7 +24,6 @@ auto-checkout =
     collective.celery
     slc.docconv
     sphinx.themes.plone
-    zope.testrunner
 
 test-eggs  =
     ploneintranet[test]
@@ -159,5 +158,4 @@ output = ${buildout:bin-directory}/generate-docs
 collective.celery = git https://github.com/collective/collective.celery pushurl=git@github.com:collective/collective.celery
 slc.docconv = git https://github.com/syslabcom/slc.docconv.git pushurl=git@github.com:syslabcom/slc.docconv.git
 sphinx.themes.plone = git https://github.com/plone/sphinx.themes.plone.git pushurl=git@github.com:plone/sphinx.themes.plone.git
-zope.testrunner = git https://github.com/zopefoundation/zope.testrunner.git pushurl=git@github.com:zopefoundation/zope.testrunner.git
 

--- a/coredev.cfg
+++ b/coredev.cfg
@@ -10,7 +10,6 @@ extends =
 # Due to a bug in zc.buildout we have to re-add our checkouts.
 auto-checkout +=
     collective.celery
-    zope.testrunner
 
 [sources]
 Products.CMFPlone                   = git ${remotes:plone}/Products.CMFPlone.git pushurl=${remotes:plone_push}/Products.CMFPlone.git rev=449337326218828f0ba0559fde4f9ae42490a0b3

--- a/soft-versions.cfg
+++ b/soft-versions.cfg
@@ -1,0 +1,75 @@
+# PLEASE NOTE: This file is a known-good-set of versions
+# which have been verified to work with the Plone Intranet stack.
+# You should be able to change the versions in this file without
+# too much fallout.
+# Hard version pins are controlled by versions.cfg
+[versions]
+BeautifulSoup = 3.2.1
+MarkupSafe = 0.23
+Products.UserAndGroupSelectionWidget = 2.0.4
+PyYAML = 3.11
+Sphinx = 1.2.1
+Twisted = 15.1.0
+amqp = 1.4.6
+anyjson = 0.3.3
+argh = 0.26.1
+bda.cache = 1.1.3
+beautifulsoup4 = 4.3.2
+billiard = 3.3.0.20
+celery = 3.1.18
+collective.documentviewer = 3.0.2
+collective.js.chosen = 1.4
+collective.recipe.sphinxbuilder = 0.8.2
+collective.workspace = 1.1
+collective.xmltestreport = 1.3.2
+collective.z3cform.chosen = 1.2.1
+createcoverage = 1.3.2
+demjson = 2.2.2
+fake-factory = 0.5.0
+flake8 = 2.4.0
+ipdb = 0.8
+ipython = 3.1.0
+iw.debug = 0.3
+kombu = 3.0.26
+loremipsum = 1.0.5
+mccabe = 0.3
+mincemeat = 0.1.4
+networkx = 1.9.1
+pathtools = 0.1.2
+pep8 = 1.5.7
+plone.api = 1.3.2
+plone.app.async = 1.6
+plone.app.blocks = 2.0
+plone.app.tiles = 2.0.0
+plone.principalsource = 1.0
+plone.recipe.codeanalysis = 1.1.1
+plone.recipe.command = 1.1
+plone.tiles = 1.3.0
+plonesocial.activitystream = 0.5.6
+plonesocial.microblog = 0.5.3
+plonesocial.network = 0.6.1
+plonesocial.suite = 0.5.3
+plonesocial.theme = 0.5.4
+ply = 3.6
+pyenchant = 1.6.6
+pyflakes = 0.8.1
+python-memcached = 1.54
+repoze.catalog = 0.8.3
+requests = 2.7.0
+robotframework-ride = 1.3
+six = 1.8.0
+sphinxcontrib-spelling = 2.1.1
+uuid = 1.30
+watchdog = 0.8.3
+z3c.jbot = 0.7.2
+z3c.recipe.egg = 1.3.2
+z3c.recipe.scripts = 1.0.1
+zc.async = 1.5.4
+zc.dict = 1.2.1
+zc.monitor = 0.3.1
+zc.ngi = 2.0.1
+zc.queue = 1.1
+zc.twist = 1.3.1
+zc.z3monitor = 0.8.0
+zope.bforest = 1.2
+zope.testrunner = 4.4.8

--- a/versions.cfg
+++ b/versions.cfg
@@ -41,6 +41,7 @@ watchdog = 0.8.3
 zc.dict = 1.2.1
 zc.twist = 1.3.1
 zope.bforest = 1.2
+collective.xmltestreport = 1.3.2
 
 # Required by:
 # ploneintranet==0.1

--- a/versions.cfg
+++ b/versions.cfg
@@ -1,0 +1,189 @@
+[versions]
+robotframework-selenium2library = 1.6.0
+selenium = 2.45.0
+z3c.recipe.egg = 1.3.2
+zc.queue = 1.1
+Sphinx = 1.2.1
+six = 1.8.0
+pep8 = 1.5.7
+# Must pin selenium libs here, firefox was updated with the system so we 
+# must follow, even though plone pinning is not yet up to date
+selenium = 2.45.0
+robotframework-selenium2library = 1.6.0
+
+# NOTE: setuptools and zc.buildout versions must be in sync with requirements.txt
+setuptools = 14.0
+zc.buildout = 2.2.5
+
+MarkupSafe = 0.23
+PyYAML = 3.11
+Twisted = 15.1.0
+amqp = 1.4.6
+anyjson = 0.3.3
+argh = 0.26.1
+billiard = 3.3.0.20
+collective.recipe.sphinxbuilder = 0.8.2
+createcoverage = 1.3.2
+ipython = 3.1.0
+iw.debug = 0.3
+kombu = 3.0.26
+mccabe = 0.3
+pathtools = 0.1.2
+plone.recipe.codeanalysis = 1.1.1
+plone.recipe.command = 1.1
+plonesocial.suite = 0.5.3
+ply = 3.6
+pyenchant = 1.6.6
+pyflakes = 0.8.1
+robotframework-ride = 1.3
+sphinxcontrib-spelling = 2.1.1
+watchdog = 0.8.3
+zc.dict = 1.2.1
+zc.twist = 1.3.1
+zope.bforest = 1.2
+
+# Required by:
+# ploneintranet==0.1
+BeautifulSoup = 3.2.1
+
+# Required by:
+# ploneintranet==0.1
+Products.UserAndGroupSelectionWidget = 2.0.4
+
+# Required by:
+# Products.UserAndGroupSelectionWidget==2.0.4
+bda.cache = 1.1.3
+
+# Required by:
+# slc.docconv==1.0b1.dev0
+beautifulsoup4 = 4.3.2
+
+# Required by:
+# collective.celery==1.0a5
+celery = 3.1.18
+
+# Required by:
+# slc.docconv==1.0b1.dev0
+collective.documentviewer = 3.0.2
+
+# Required by:
+# collective.z3cform.chosen==1.2.1
+collective.js.chosen = 1.4
+
+# Required by:
+# ploneintranet==0.1
+collective.workspace = 1.1
+
+# Required by:
+# ploneintranet==0.1
+collective.z3cform.chosen = 1.2.1
+
+# Required by:
+# collective.z3cform.chosen==1.2.1
+demjson = 2.2.2
+
+# Required by:
+# ploneintranet==0.1
+fake-factory = 0.5.0
+
+# Required by:
+# plone.recipe.codeanalysis==1.1.1
+flake8 = 2.4.0
+
+# Required by:
+# iw.debug==0.3
+ipdb = 0.8
+
+# Required by:
+# ploneintranet==0.1
+# plonesocial.suite==0.5.3
+loremipsum = 1.0.5
+
+# Required by:
+# ploneintranet==0.1
+mincemeat = 0.1.4
+
+# Required by:
+# ploneintranet==0.1
+networkx = 1.9.1
+
+# Required by:
+# collective.celery==1.0a5
+# ploneintranet==0.1
+# plonesocial.suite==0.5.3
+plone.api = 1.3.2
+
+# Required by:
+# ploneintranet==0.1
+plone.app.async = 1.6
+
+# Required by:
+# ploneintranet==0.1
+plone.app.tiles = 2.0.0
+
+# Required by:
+# ploneintranet==0.1
+plone.principalsource = 1.0
+
+# Required by:
+# plone.app.blocks==2.0.0.dev0
+# plone.app.tiles==2.0.0
+# ploneintranet==0.1
+plone.tiles = 1.3.0
+
+# Required by:
+# plonesocial.suite==0.5.3
+plonesocial.activitystream = 0.5.6
+
+# Required by:
+# plonesocial.suite==0.5.3
+plonesocial.microblog = 0.5.3
+
+# Required by:
+# plonesocial.suite==0.5.3
+plonesocial.network = 0.6.1
+
+# Required by:
+# plonesocial.suite==0.5.3
+plonesocial.theme = 0.5.4
+
+# Required by:
+# bda.cache==1.1.3
+python-memcached = 1.54
+
+# Required by:
+# collective.documentviewer==3.0.2
+repoze.catalog = 0.8.3
+
+# Required by:
+# ploneintranet==0.1
+requests = 2.7.0
+
+# Required by:
+# zc.async==1.5.4
+uuid = 1.30
+
+# Required by:
+# ploneintranet==0.1
+z3c.jbot = 0.7.2
+
+# Required by:
+# collective.xmltestreport==1.3.1
+z3c.recipe.scripts = 1.0.1
+
+# Required by:
+# plone.app.async==1.6
+zc.async = 1.5.4
+
+# Required by:
+# plone.app.async==1.6
+# zc.z3monitor==0.8.0
+zc.monitor = 0.3.1
+
+# Required by:
+# zc.monitor==0.3.1
+zc.ngi = 2.0.1
+
+# Required by:
+# plone.app.async==1.6
+zc.z3monitor = 0.8.0

--- a/versions.cfg
+++ b/versions.cfg
@@ -1,11 +1,4 @@
 [versions]
-robotframework-selenium2library = 1.6.0
-selenium = 2.45.0
-z3c.recipe.egg = 1.3.2
-zc.queue = 1.1
-Sphinx = 1.2.1
-six = 1.8.0
-pep8 = 1.5.7
 # Must pin selenium libs here, firefox was updated with the system so we 
 # must follow, even though plone pinning is not yet up to date
 selenium = 2.45.0
@@ -15,176 +8,71 @@ robotframework-selenium2library = 1.6.0
 setuptools = 14.0
 zc.buildout = 2.2.5
 
+# Known good set pins
+BeautifulSoup = 3.2.1
 MarkupSafe = 0.23
+Products.UserAndGroupSelectionWidget = 2.0.4
 PyYAML = 3.11
+Sphinx = 1.2.1
 Twisted = 15.1.0
 amqp = 1.4.6
 anyjson = 0.3.3
 argh = 0.26.1
+bda.cache = 1.1.3
+beautifulsoup4 = 4.3.2
 billiard = 3.3.0.20
+celery = 3.1.18
+collective.documentviewer = 3.0.2
+collective.js.chosen = 1.4
 collective.recipe.sphinxbuilder = 0.8.2
+collective.workspace = 1.1
+collective.xmltestreport = 1.3.2
+collective.z3cform.chosen = 1.2.1
 createcoverage = 1.3.2
+demjson = 2.2.2
+fake-factory = 0.5.0
+flake8 = 2.4.0
+ipdb = 0.8
 ipython = 3.1.0
 iw.debug = 0.3
 kombu = 3.0.26
+loremipsum = 1.0.5
 mccabe = 0.3
+mincemeat = 0.1.4
+networkx = 1.9.1
 pathtools = 0.1.2
+pep8 = 1.5.7
+plone.api = 1.3.2
+plone.app.async = 1.6
+plone.app.tiles = 2.0.0
+plone.principalsource = 1.0
 plone.recipe.codeanalysis = 1.1.1
 plone.recipe.command = 1.1
+plone.tiles = 1.3.0
+plonesocial.activitystream = 0.5.6
+plonesocial.microblog = 0.5.3
+plonesocial.network = 0.6.1
 plonesocial.suite = 0.5.3
+plonesocial.theme = 0.5.4
 ply = 3.6
 pyenchant = 1.6.6
 pyflakes = 0.8.1
-robotframework-ride = 1.3
-sphinxcontrib-spelling = 2.1.1
-watchdog = 0.8.3
-zc.dict = 1.2.1
-zc.twist = 1.3.1
-zope.bforest = 1.2
-collective.xmltestreport = 1.3.2
-
-# Required by:
-# ploneintranet==0.1
-BeautifulSoup = 3.2.1
-
-# Required by:
-# ploneintranet==0.1
-Products.UserAndGroupSelectionWidget = 2.0.4
-
-# Required by:
-# Products.UserAndGroupSelectionWidget==2.0.4
-bda.cache = 1.1.3
-
-# Required by:
-# slc.docconv==1.0b1.dev0
-beautifulsoup4 = 4.3.2
-
-# Required by:
-# collective.celery==1.0a5
-celery = 3.1.18
-
-# Required by:
-# slc.docconv==1.0b1.dev0
-collective.documentviewer = 3.0.2
-
-# Required by:
-# collective.z3cform.chosen==1.2.1
-collective.js.chosen = 1.4
-
-# Required by:
-# ploneintranet==0.1
-collective.workspace = 1.1
-
-# Required by:
-# ploneintranet==0.1
-collective.z3cform.chosen = 1.2.1
-
-# Required by:
-# collective.z3cform.chosen==1.2.1
-demjson = 2.2.2
-
-# Required by:
-# ploneintranet==0.1
-fake-factory = 0.5.0
-
-# Required by:
-# plone.recipe.codeanalysis==1.1.1
-flake8 = 2.4.0
-
-# Required by:
-# iw.debug==0.3
-ipdb = 0.8
-
-# Required by:
-# ploneintranet==0.1
-# plonesocial.suite==0.5.3
-loremipsum = 1.0.5
-
-# Required by:
-# ploneintranet==0.1
-mincemeat = 0.1.4
-
-# Required by:
-# ploneintranet==0.1
-networkx = 1.9.1
-
-# Required by:
-# collective.celery==1.0a5
-# ploneintranet==0.1
-# plonesocial.suite==0.5.3
-plone.api = 1.3.2
-
-# Required by:
-# ploneintranet==0.1
-plone.app.async = 1.6
-
-# Required by:
-# ploneintranet==0.1
-plone.app.tiles = 2.0.0
-
-# Required by:
-# ploneintranet==0.1
-plone.principalsource = 1.0
-
-# Required by:
-# plone.app.blocks==2.0.0.dev0
-# plone.app.tiles==2.0.0
-# ploneintranet==0.1
-plone.tiles = 1.3.0
-
-# Required by:
-# plonesocial.suite==0.5.3
-plonesocial.activitystream = 0.5.6
-
-# Required by:
-# plonesocial.suite==0.5.3
-plonesocial.microblog = 0.5.3
-
-# Required by:
-# plonesocial.suite==0.5.3
-plonesocial.network = 0.6.1
-
-# Required by:
-# plonesocial.suite==0.5.3
-plonesocial.theme = 0.5.4
-
-# Required by:
-# bda.cache==1.1.3
 python-memcached = 1.54
-
-# Required by:
-# collective.documentviewer==3.0.2
 repoze.catalog = 0.8.3
-
-# Required by:
-# ploneintranet==0.1
 requests = 2.7.0
-
-# Required by:
-# zc.async==1.5.4
+robotframework-ride = 1.3
+six = 1.8.0
+sphinxcontrib-spelling = 2.1.1
 uuid = 1.30
-
-# Required by:
-# ploneintranet==0.1
+watchdog = 0.8.3
 z3c.jbot = 0.7.2
-
-# Required by:
-# collective.xmltestreport==1.3.1
+z3c.recipe.egg = 1.3.2
 z3c.recipe.scripts = 1.0.1
-
-# Required by:
-# plone.app.async==1.6
 zc.async = 1.5.4
-
-# Required by:
-# plone.app.async==1.6
-# zc.z3monitor==0.8.0
+zc.dict = 1.2.1
 zc.monitor = 0.3.1
-
-# Required by:
-# zc.monitor==0.3.1
 zc.ngi = 2.0.1
-
-# Required by:
-# plone.app.async==1.6
+zc.queue = 1.1
+zc.twist = 1.3.1
 zc.z3monitor = 0.8.0
+zope.bforest = 1.2

--- a/versions.cfg
+++ b/versions.cfg
@@ -44,6 +44,7 @@ pathtools = 0.1.2
 pep8 = 1.5.7
 plone.api = 1.3.2
 plone.app.async = 1.6
+plone.app.blocks = 2.0
 plone.app.tiles = 2.0.0
 plone.principalsource = 1.0
 plone.recipe.codeanalysis = 1.1.1

--- a/versions.cfg
+++ b/versions.cfg
@@ -1,3 +1,7 @@
+# PLEASE NOTE: This file is for *hard* versions 
+# that are required for the stack to work correctly.
+# There is a separate 'known good set' of versions maintained
+# in soft-versions.cfg
 [versions]
 # Must pin selenium libs here, firefox was updated with the system so we 
 # must follow, even though plone pinning is not yet up to date
@@ -7,74 +11,3 @@ robotframework-selenium2library = 1.6.0
 # NOTE: setuptools and zc.buildout versions must be in sync with requirements.txt
 setuptools = 14.0
 zc.buildout = 2.2.5
-
-# Known good set pins
-BeautifulSoup = 3.2.1
-MarkupSafe = 0.23
-Products.UserAndGroupSelectionWidget = 2.0.4
-PyYAML = 3.11
-Sphinx = 1.2.1
-Twisted = 15.1.0
-amqp = 1.4.6
-anyjson = 0.3.3
-argh = 0.26.1
-bda.cache = 1.1.3
-beautifulsoup4 = 4.3.2
-billiard = 3.3.0.20
-celery = 3.1.18
-collective.documentviewer = 3.0.2
-collective.js.chosen = 1.4
-collective.recipe.sphinxbuilder = 0.8.2
-collective.workspace = 1.1
-collective.xmltestreport = 1.3.2
-collective.z3cform.chosen = 1.2.1
-createcoverage = 1.3.2
-demjson = 2.2.2
-fake-factory = 0.5.0
-flake8 = 2.4.0
-ipdb = 0.8
-ipython = 3.1.0
-iw.debug = 0.3
-kombu = 3.0.26
-loremipsum = 1.0.5
-mccabe = 0.3
-mincemeat = 0.1.4
-networkx = 1.9.1
-pathtools = 0.1.2
-pep8 = 1.5.7
-plone.api = 1.3.2
-plone.app.async = 1.6
-plone.app.blocks = 2.0
-plone.app.tiles = 2.0.0
-plone.principalsource = 1.0
-plone.recipe.codeanalysis = 1.1.1
-plone.recipe.command = 1.1
-plone.tiles = 1.3.0
-plonesocial.activitystream = 0.5.6
-plonesocial.microblog = 0.5.3
-plonesocial.network = 0.6.1
-plonesocial.suite = 0.5.3
-plonesocial.theme = 0.5.4
-ply = 3.6
-pyenchant = 1.6.6
-pyflakes = 0.8.1
-python-memcached = 1.54
-repoze.catalog = 0.8.3
-requests = 2.7.0
-robotframework-ride = 1.3
-six = 1.8.0
-sphinxcontrib-spelling = 2.1.1
-uuid = 1.30
-watchdog = 0.8.3
-z3c.jbot = 0.7.2
-z3c.recipe.egg = 1.3.2
-z3c.recipe.scripts = 1.0.1
-zc.async = 1.5.4
-zc.dict = 1.2.1
-zc.monitor = 0.3.1
-zc.ngi = 2.0.1
-zc.queue = 1.1
-zc.twist = 1.3.1
-zc.z3monitor = 0.8.0
-zope.bforest = 1.2
-zope.testrunner = 4.4.8

--- a/versions.cfg
+++ b/versions.cfg
@@ -77,3 +77,4 @@ zc.queue = 1.1
 zc.twist = 1.3.1
 zc.z3monitor = 0.8.0
 zope.bforest = 1.2
+zope.testrunner = 4.4.8


### PR DESCRIPTION
I realised that we weren't pinning our versions very well, which may be the cause of unrepeatable test failures in jenkins.

This pins the versions to those I'm currently using, as the tests are passing for me. We'll see what jenkins thinks.
