### PR TITLE
Pin collective.xmltestreport 1.3.2.

### DIFF
--- a/base.cfg
+++ b/base.cfg
@@ -160,6 +160,8 @@ sphinx.themes.plone = git https://github.com/plone/sphinx.themes.plone.git pushu
 zope.testrunner = git https://github.com/zopefoundation/zope.testrunner.git pushurl=git@github.com:zopefoundation/zope.testrunner.git
 
 [versions]
+# We need the collective.xmltestreport 1.3.2 UnicodeEncodeError fix.
+collective.xmltestreport = 1.3.2
 robotframework-selenium2library = 1.6.0
 selenium = 2.45.0
 z3c.recipe.egg = 1.3.2


### PR DESCRIPTION
I ran into a UnicodeEncodeError at the end of a test run with failures.
This was fixed in 1.3.2.
