### PR TITLE
Moar workflow change fixing

### DIFF
--- a/src/ploneintranet/suite/tests/acceptance/workspace.robot
+++ b/src/ploneintranet/suite/tests/acceptance/workspace.robot
@@ -106,6 +106,13 @@ Christian can submit a document
       And I can create a new document    My awesome document
      Then I can submit the content item
 
+Christian can submit and retract a document
+    Given I am logged in as the user christian_stoney
+      And I go to the Open Market Committee Workspace
+      And I can create a new document    My substandard document
+     Then I can submit the content item
+      And I can retract the content item
+
 # XXX: The following tests derive from ploneintranet.workspace and still
 # need to be adapted to our current state of layout integration
 
@@ -353,4 +360,9 @@ The upload appears in the stream
 I can submit the content item
     Click element    xpath=//fieldset[@id='workflow-menu']
     Click Element    xpath=//fieldset[@id='workflow-menu']//select/option[contains(text(), 'Pending review')]
+    Wait until page contains  The workflow state has been changed
+
+I can retract the content item
+    Click element    xpath=//fieldset[@id='workflow-menu']
+    Click Element    xpath=//fieldset[@id='workflow-menu']//select/option[contains(text(), 'Private')]
     Wait until page contains  The workflow state has been changed

--- a/src/ploneintranet/suite/tests/acceptance/workspace.robot
+++ b/src/ploneintranet/suite/tests/acceptance/workspace.robot
@@ -352,5 +352,5 @@ The upload appears in the stream
 
 I can submit the content item
     Click element    xpath=//fieldset[@id='workflow-menu']
-    Click Element    xpath=//fieldset[@id='workflow-menu']//select/option[@value='submit']
+    Click Element    xpath=//fieldset[@id='workflow-menu']//select/option[contains(text(), 'Pending review')]
     Wait until page contains  The workflow state has been changed

--- a/src/ploneintranet/suite/tests/acceptance/workspace.robot
+++ b/src/ploneintranet/suite/tests/acceptance/workspace.robot
@@ -77,7 +77,7 @@ The manager can invite Alice to join the Open Market Committee Workspace from th
 Create document
     Given I am logged in as the user christian_stoney
       And I go to the Open Market Committee Workspace
-     Then I can create a new document
+     Then I can create a new document    My Humble document
 
 Create folder
     Given I am logged in as the user christian_stoney
@@ -100,6 +100,11 @@ Alice can upload a file
       And I select a file to upload
      Then the file appears in the sidebar
 
+Christian can submit a document
+    Given I am logged in as the user christian_stoney
+      And I go to the Open Market Committee Workspace
+      And I can create a new document    My awesome document
+     Then I can submit the content item
 
 # XXX: The following tests derive from ploneintranet.workspace and still
 # need to be adapted to our current state of layout integration
@@ -280,13 +285,14 @@ I can search for items
     Page Should Not Contain Element  xpath=//form[@id='items']/fieldset/label/a/strong[text()='Projection Materials']
 
 I can create a new document
+    [arguments]  ${title}
     Click link  Documents
     Click link  Functions
     Click link  Create document
     Wait Until Page Contains Element  css=.panel-content form
-    Input Text  css=.panel-content input[name=title]  text=My Humble Document
+    Input Text  css=.panel-content input[name=title]  text=${title}
     Click Button  css=#form-buttons-create
-    Wait Until Page Contains Element  css=#content input[value="My Humble Document"]
+    Wait Until Page Contains Element  css=#content input[value="${title}"]
 
 
 
@@ -343,3 +349,8 @@ The file appears in the sidebar
 
 The upload appears in the stream
     Wait until Page contains Element  xpath=//a[@href='activity-stream']//section[contains(@class, 'preview')]//img[contains(@src, 'bartige_flosser.odt')]  timeout=20 s
+
+I can submit the content item
+    Click element    css=select#workflow_action
+    Click Element    css=select#workflow_action option[value='submit']
+    Wait until page contains  The workflow state has been changed

--- a/src/ploneintranet/suite/tests/acceptance/workspace.robot
+++ b/src/ploneintranet/suite/tests/acceptance/workspace.robot
@@ -351,6 +351,6 @@ The upload appears in the stream
     Wait until Page contains Element  xpath=//a[@href='activity-stream']//section[contains(@class, 'preview')]//img[contains(@src, 'bartige_flosser.odt')]  timeout=20 s
 
 I can submit the content item
-    Click element    css=select#workflow_action
-    Click Element    css=select#workflow_action option[value='submit']
+    Click element    xpath=//fieldset[@id='workflow-menu']
+    Click Element    xpath=//fieldset[@id='workflow-menu']//select/option[@value='submit']
     Wait until page contains  The workflow state has been changed

--- a/src/ploneintranet/theme/content/content.py
+++ b/src/ploneintranet/theme/content/content.py
@@ -33,9 +33,8 @@ class ContentView(BrowserView):
     def update(self, title=None, description=None, tags=[], text=None):
         """ """
         context = aq_inner(self.context)
-        if not self.can_edit:
-            return
         modified = False
+
         if (
                 self.request.get('workflow_action') and
                 not self.request.get('form.submitted')):
@@ -47,7 +46,7 @@ class ContentView(BrowserView):
             api.portal.show_message(_(
                 "The workflow state has been changed."), request=self.request,
                 type="info")
-        if title or description or tags or text:
+        if (self.can_edit and (title or description or tags or text)):
             if title and safe_unicode(title) != context.title:
                 context.title = safe_unicode(title)
                 modified = True

--- a/src/ploneintranet/theme/content/content.py
+++ b/src/ploneintranet/theme/content/content.py
@@ -35,7 +35,9 @@ class ContentView(BrowserView):
         if not self.can_edit:
             return
         modified = False
-        if self.request.get('workflow_action'):
+        if (
+                self.request.get('workflow_action') and
+                not self.request.get('form.submitted')):
             # TODO: should we trigger any events or reindex?
             api.content.transition(
                 obj=context,

--- a/src/ploneintranet/theme/content/templates/document_view.pt
+++ b/src/ploneintranet/theme/content/templates/document_view.pt
@@ -33,7 +33,7 @@
                     <fieldset tal:condition="view/has_workflow" id="workflow-menu" class="pat-subform pat-autosubmit pat-inject"
                             tal:attributes="data-pat-inject string:target: #global-statusmessage;; url: ${here_url}/view;; source: #global-statusmessage && url: ${here_url}/view;; source: #workflow-menu;; target: #workflow-menu">
                         <label class="pat-select bare workflow" title="Change the workflow state">
-                            <select name="workflow_action">
+                            <select name="workflow_action" id="workflow_action">
                                 <option tal:repeat="state view/get_workflow_transitions"
                                     tal:attributes="title state/title; value state/action; selected state/selected|nothing"
                                     tal:content="state/title">Workflow State</option>

--- a/src/ploneintranet/theme/content/templates/document_view.pt
+++ b/src/ploneintranet/theme/content/templates/document_view.pt
@@ -33,9 +33,8 @@
                     <fieldset tal:condition="view/has_workflow" id="workflow-menu" class="pat-subform pat-autosubmit pat-inject"
                             tal:attributes="data-pat-inject string:target: #global-statusmessage;; url: ${here_url}/view;; source: #global-statusmessage && url: ${here_url}/view;; source: #workflow-menu;; target: #workflow-menu">
                         <label class="pat-select bare workflow" title="Change the workflow state">
-                            <span tal:replace="view/get_workflow_state" />
                             <select name="workflow_action">
-                                <option></option>
+                                <option tal:content="view/get_workflow_state"></option>
                                 <option tal:repeat="state view/get_workflow_transitions"
                                     tal:attributes="title state/title; value state/id"
                                     tal:content="state/name">Workflow State</option>
@@ -77,6 +76,7 @@
                 </figure>
               </article>
             </div><!-- #document-content -->
+            <input type="hidden" name="form.submitted" value="1" />
           </form>
         </div><!-- #document-body -->
         <aside class="sidebar left tagging-off" id="sidebar" data-tile="plone/new-workspace/@@sidebar.default" tal:define="container context/@@plone_context_state/folder" tal:attributes="data-tile string:${container/absolute_url}/@@sidebar.default">

--- a/src/ploneintranet/theme/content/templates/document_view.pt
+++ b/src/ploneintranet/theme/content/templates/document_view.pt
@@ -34,10 +34,9 @@
                             tal:attributes="data-pat-inject string:target: #global-statusmessage;; url: ${here_url}/view;; source: #global-statusmessage && url: ${here_url}/view;; source: #workflow-menu;; target: #workflow-menu">
                         <label class="pat-select bare workflow" title="Change the workflow state">
                             <select name="workflow_action">
-                                <option tal:content="view/get_workflow_state"></option>
                                 <option tal:repeat="state view/get_workflow_transitions"
-                                    tal:attributes="title state/title; value state/id"
-                                    tal:content="state/name">Workflow State</option>
+                                    tal:attributes="title state/title; value state/action; selected state/selected|nothing"
+                                    tal:content="state/title">Workflow State</option>
                             </select>
                         </label>
                         <span tal:replace="structure context/@@authenticator/authenticator"/>


### PR DESCRIPTION
1) Replicate correct markup from proto. Especially, the currently set workflow state must be part of the `<select>`, to fix the 2nd issue @pbauer found in #173 

2) Display as user-visible name the title of the target workflow state, not the title of the transition to fix ploneintranet/ploneintranet.prototype#30
