### PR TITLE
fix unauthorized traceback that is always present on login robot

### DIFF
--- a/src/ploneintranet/theme/browser/dashboard.py
+++ b/src/ploneintranet/theme/browser/dashboard.py
@@ -21,7 +21,7 @@ class Dashboard(BrowserView):
     def __call__(self):
         portal = api.portal.get()
         if api.user.is_anonymous():
-            self.request.response.redirect(
+            return self.request.response.redirect(
                 '%s/login?%s' % (
                     portal.absolute_url(),
                     urllib.urlencode(


### PR DESCRIPTION
This resolves the issue where _every_ robot test has an Unauthorized traceback.
