### PR TITLE
Handle toggle-like write via POST

### DIFF
--- a/src/ploneintranet/network/browser/likes.py
+++ b/src/ploneintranet/network/browser/likes.py
@@ -56,7 +56,11 @@ class ToggleLike(BrowserView):
         return "%s/@@toggle_like" % self.context.absolute_url()
 
     def handle_toggle(self):
-        """Perform the actual like/unlike action."""
+        """
+        Perform the actual like/unlike action.
+        Since this does a db write it cannot be called with a GET.
+        """
+        assert(self.request.get('REQUEST_METHOD') == 'POST')
         if not self.is_liked:
             self.util.like(self.like_type, self.item_id,
                            self.current_user_id)

--- a/src/ploneintranet/network/browser/likes.py
+++ b/src/ploneintranet/network/browser/likes.py
@@ -13,6 +13,10 @@ from zope.publisher.interfaces import IPublishTraverse
 import uuid
 
 
+class NotAllowed(Exception):
+    pass
+
+
 class ToggleLike(BrowserView):
     """The view 'toggle_like' callable on a normal context.
     """
@@ -60,7 +64,8 @@ class ToggleLike(BrowserView):
         Perform the actual like/unlike action.
         Since this does a db write it cannot be called with a GET.
         """
-        assert(self.request.get('REQUEST_METHOD') == 'POST')
+        if self.request.get('REQUEST_METHOD') != 'POST':
+            raise NotAllowed("Write on POST only.")
         if not self.is_liked:
             self.util.like(self.like_type, self.item_id,
                            self.current_user_id)

--- a/src/ploneintranet/network/browser/templates/toggle_like.pt
+++ b/src/ploneintranet/network/browser/templates/toggle_like.pt
@@ -7,12 +7,15 @@
                        total_likes view/total_likes;
                        datapatinject python:'source: form;; target: #functions-{0}'.format(unique_id)">
   <form id="functions-123456"
+        method="post"
         action="@@toggle_like"
         tal:attributes="action view/action;
                         id string:functions-${unique_id};
                         data-pat-inject datapatinject;"
         class="pat-inject pat-autosubmit"
         data-pat-inject="source: #functions; target: #functions-mypost_1">
+    <input type="hidden" name="item_id" value=""
+           tal:attributes="value item_id" />
     <button class="like active"
             value="like"
             name="like_button"

--- a/src/ploneintranet/network/browser/templates/toggle_like.pt
+++ b/src/ploneintranet/network/browser/templates/toggle_like.pt
@@ -14,8 +14,6 @@
                         data-pat-inject datapatinject;"
         class="pat-inject pat-autosubmit"
         data-pat-inject="source: #functions; target: #functions-mypost_1">
-    <input type="hidden" name="item_id" value=""
-           tal:attributes="value item_id" />
     <button class="like active"
             value="like"
             name="like_button"

--- a/src/ploneintranet/network/tests/test_toggle_like_view.py
+++ b/src/ploneintranet/network/tests/test_toggle_like_view.py
@@ -36,6 +36,7 @@ class TestToggleLikeView(IntegrationTestCase):
 
     def test_toggle_like(self):
         self.request.form['like_button'] = 'like'
+        self.request["REQUEST_METHOD"] = "POST"
         view = api.content.get_view('toggle_like', self.doc1, self.request)
         item_id = api.content.get_uuid(self.doc1)
 
@@ -65,6 +66,7 @@ class TestToggleLikeView(IntegrationTestCase):
         comment_id = IUUID(comment)
 
         self.request.form['like_button'] = 'like'
+        self.request["REQUEST_METHOD"] = "POST"
         view = api.content.get_view('toggle_like', comment, self.request)
 
         # Toggle like for comment on
@@ -92,6 +94,7 @@ class TestToggleLikeView(IntegrationTestCase):
         update_id = str(su.id)
 
         self.request.form['like_button'] = 'like'
+        self.request["REQUEST_METHOD"] = "POST"
         view = api.content.get_view('toggle_like_statusupdate',
                                     self.portal, self.request)
         self.assertRaises(KeyError, view)


### PR DESCRIPTION
Perform database writes for like actions only via HTTP POST.
We still need the publishTraverse GET for initial loading of the widget for StatusUpdates, so also using that for POST action.
