### PR TITLE
For all robot tests, force the browser to a certain size 

### DIFF
--- a/src/ploneintranet/suite/tests/acceptance/content_views.robot
+++ b/src/ploneintranet/suite/tests/acceptance/content_views.robot
@@ -7,7 +7,7 @@ Resource  ../lib/keywords.robot
 Library  Remote  ${PLONE_URL}/RobotRemote
 Library  DebugLibrary
 
-Test Setup  Open test browser
+Test Setup  Prepare test browser
 Test Teardown  Close all browsers
 
 *** Test Cases ***

--- a/src/ploneintranet/suite/tests/acceptance/demo_content.robot
+++ b/src/ploneintranet/suite/tests/acceptance/demo_content.robot
@@ -7,7 +7,7 @@ Resource  ../lib/keywords.robot
 Library  Remote  ${PLONE_URL}/RobotRemote
 Library  DebugLibrary
 
-Test Setup  Open test browser
+Test Setup  Prepare test browser
 Test Teardown  Close all browsers
 
 

--- a/src/ploneintranet/suite/tests/acceptance/post_file.robot
+++ b/src/ploneintranet/suite/tests/acceptance/post_file.robot
@@ -9,7 +9,7 @@ Library  DebugLibrary
 
 Variables  variables.py
 
-Test Setup  Open test browser
+Test Setup  Prepare test browser
 Test Teardown  Close all browsers
 
 *** Test Cases ***

--- a/src/ploneintranet/suite/tests/acceptance/posting.robot
+++ b/src/ploneintranet/suite/tests/acceptance/posting.robot
@@ -7,7 +7,7 @@ Resource  ../lib/keywords.robot
 Library  Remote  ${PLONE_URL}/RobotRemote
 Library  DebugLibrary
 
-Test Setup  Open test browser
+Test Setup  Prepare test browser
 Test Teardown  Close all browsers
 
 *** Variable ***

--- a/src/ploneintranet/suite/tests/acceptance/test_hello.robot
+++ b/src/ploneintranet/suite/tests/acceptance/test_hello.robot
@@ -6,7 +6,7 @@ Resource  ../lib/keywords.robot
 
 Library  Remote  ${PLONE_URL}/RobotRemote
 
-Test Setup  Open test browser
+Test Setup  Prepare test browser
 Test Teardown  Close all browsers
 
 *** Test Cases ***

--- a/src/ploneintranet/suite/tests/acceptance/test_like.robot
+++ b/src/ploneintranet/suite/tests/acceptance/test_like.robot
@@ -7,7 +7,7 @@ Resource  ../lib/keywords.robot
 Library  Remote  ${PLONE_URL}/RobotRemote
 Library  DebugLibrary
 
-Test Setup  Open test browser
+Test Setup  Prepare test browser
 Test Teardown  Close all browsers
 
 

--- a/src/ploneintranet/suite/tests/acceptance/test_login_redirect.robot
+++ b/src/ploneintranet/suite/tests/acceptance/test_login_redirect.robot
@@ -7,7 +7,7 @@ Resource  ../lib/keywords.robot
 Library  Remote  ${PLONE_URL}/RobotRemote
 Library  DebugLibrary
 
-Test Setup  Open test browser
+Test Setup  Prepare test browser
 Test Teardown  Close all browsers
 
 *** Test Cases ***

--- a/src/ploneintranet/suite/tests/acceptance/workspace.robot
+++ b/src/ploneintranet/suite/tests/acceptance/workspace.robot
@@ -9,7 +9,7 @@ Library  DebugLibrary
 
 Variables  variables.py
 
-Test Setup  Open test browser
+Test Setup  Prepare test browser
 Test Teardown  Close all browsers
 
 *** Test Cases ***

--- a/src/ploneintranet/suite/tests/lib/keywords.robot
+++ b/src/ploneintranet/suite/tests/lib/keywords.robot
@@ -1,5 +1,9 @@
 *** Keywords ***
 
+Prepare test browser
+    Open test browser
+    Set window size  1024  900
+
 I'm logged in as a '${ROLE}'
     Enable autologin as  ${ROLE}
 


### PR DESCRIPTION
to eliminate heisenbugs caused by too narrow browser window
