### PR TITLE
Handle workflow state change correctly

### DIFF
--- a/src/ploneintranet/suite/tests/acceptance/workspace.robot
+++ b/src/ploneintranet/suite/tests/acceptance/workspace.robot
@@ -103,15 +103,20 @@ Alice can upload a file
 Christian can submit a document
     Given I am logged in as the user christian_stoney
       And I go to the Open Market Committee Workspace
-      And I can create a new document    My awesome document
-     Then I can submit the content item
+     When I can create a new document    My awesome document
+     Then I can edit the document
+     When I submit the content item
+     Then I cannot edit the document
 
 Christian can submit and retract a document
     Given I am logged in as the user christian_stoney
       And I go to the Open Market Committee Workspace
-      And I can create a new document    My substandard document
-     Then I can submit the content item
-      And I can retract the content item
+     When I can create a new document    My substandard document
+     Then I can edit the document
+     When I submit the content item
+     Then I cannot edit the document
+     When I retract the content item
+     Then I can edit the document
 
 # XXX: The following tests derive from ploneintranet.workspace and still
 # need to be adapted to our current state of layout integration
@@ -358,12 +363,23 @@ The file appears in the sidebar
 The upload appears in the stream
     Wait until Page contains Element  xpath=//a[@href='activity-stream']//section[contains(@class, 'preview')]//img[contains(@src, 'bartige_flosser.odt')]  timeout=20 s
 
-I can submit the content item
+I submit the content item
     Click element    xpath=//fieldset[@id='workflow-menu']
     Click Element    xpath=//fieldset[@id='workflow-menu']//select/option[contains(text(), 'Pending review')]
     Wait until page contains  The workflow state has been changed
+    Click button  Close
 
-I can retract the content item
+I retract the content item
     Click element    xpath=//fieldset[@id='workflow-menu']
     Click Element    xpath=//fieldset[@id='workflow-menu']//select/option[contains(text(), 'Private')]
     Wait until page contains  The workflow state has been changed
+    Click button  Close
+
+I can edit the document
+    Element should be visible  xpath=//div[@id='document-body']//div[@id='editor-toolbar']
+    Element should be visible  xpath=//div[@id='document-body']//div[@class='meta-bar']//button[@type='submit']
+
+I cannot edit the document
+    Element should not be visible  xpath=//div[@id='document-body']//div[@id='editor-toolbar']
+    Element should not be visible  xpath=//div[@id='document-body']//div[@class='meta-bar']//button[@type='submit']
+

--- a/src/ploneintranet/theme/content/content.py
+++ b/src/ploneintranet/theme/content/content.py
@@ -43,6 +43,11 @@ class ContentView(BrowserView):
                 obj=context,
                 transition=self.request.get('workflow_action')
             )
+            # re-calculate can_edit after the workflow state change
+            self.can_edit = api.user.has_permission(
+                'Modify portal content',
+                obj=context
+            )
             api.portal.show_message(_(
                 "The workflow state has been changed."), request=self.request,
                 type="info")

--- a/src/ploneintranet/theme/content/templates/document_view.pt
+++ b/src/ploneintranet/theme/content/templates/document_view.pt
@@ -60,7 +60,7 @@
                 <textarea tal:condition="not:read_only" name="text" class="pat-raptor" data-pat-raptor="toolbar-type: standard; toolbar-external: #editor-toolbar .loader; buttons: tagMenu, alignCenter, alignLeft, historyRedo, historyUndo, hrCreate, linkCreate, linkRemove, listOrdered, listUnordered, textBlockQuote, textBold, textItalic, textStrike, tableCreate, tableDeleteColumn, tableDeleteRow, tableInsertColumn, tableInsertRow" tal:content="python: context.text.raw if context.text else ''">
                     Content of the textarea
                 </textarea>
-                <span tal:condition="read_only" tal:replace="structure context/text/output" />
+                <span tal:condition="python:read_only and context.text" tal:replace="structure context/text/output" />
               </article>
 
               <article class="document preview" tal:condition="number_of_file_previews" tal:define="number_of_file_previews view/number_of_file_previews">

--- a/src/ploneintranet/theme/content/templates/document_view.pt
+++ b/src/ploneintranet/theme/content/templates/document_view.pt
@@ -43,7 +43,7 @@
                     <button type="submit" tal:condition="not:read_only" class="icon-floppy">Save</button>
                 </div><!-- quick-functions -->
               </div> <!-- #meta-bar -->
-              <div id="editor-toolbar" class="bar"><p class="loader">Loading…</p></div>
+              <div tal:condition="python:context.portal_type == 'Document' and not read_only" id="editor-toolbar" class="bar"><p class="loader">Loading…</p></div>
 
               <fieldset class="pat-collapsible closed meta-extra" data-pat-collapsible="trigger: .meta-data-toggle" id="meta-extra">
                 <fieldset class="bar">
@@ -57,9 +57,10 @@
 
             <div id="document-content">
               <article class="document rich" tal:condition="python: context.portal_type == 'Document'">
-                <textarea name="text" class="pat-raptor" data-pat-raptor="toolbar-type: standard; toolbar-external: #editor-toolbar .loader; buttons: tagMenu, alignCenter, alignLeft, historyRedo, historyUndo, hrCreate, linkCreate, linkRemove, listOrdered, listUnordered, textBlockQuote, textBold, textItalic, textStrike, tableCreate, tableDeleteColumn, tableDeleteRow, tableInsertColumn, tableInsertRow" tal:content="python: context.text.raw if context.text else ''">
+                <textarea tal:condition="not:read_only" name="text" class="pat-raptor" data-pat-raptor="toolbar-type: standard; toolbar-external: #editor-toolbar .loader; buttons: tagMenu, alignCenter, alignLeft, historyRedo, historyUndo, hrCreate, linkCreate, linkRemove, listOrdered, listUnordered, textBlockQuote, textBold, textItalic, textStrike, tableCreate, tableDeleteColumn, tableDeleteRow, tableInsertColumn, tableInsertRow" tal:content="python: context.text.raw if context.text else ''">
                     Content of the textarea
                 </textarea>
+                <span tal:condition="read_only" tal:replace="structure context/text/output" />
               </article>
 
               <article class="document preview" tal:condition="number_of_file_previews" tal:define="number_of_file_previews view/number_of_file_previews">

--- a/src/ploneintranet/theme/content/templates/document_view.pt
+++ b/src/ploneintranet/theme/content/templates/document_view.pt
@@ -11,16 +11,15 @@
         tal:define="workspace python:view.workspace;
             here_url context/absolute_url;
             workspace_url python:workspace.absolute_url();
-            workspace_id python:workspace.id;
-            read_only python:not view.can_edit">
+            workspace_id python:workspace.id">
 
     <h1 id="workspace-name">
         <a href="${workspace_url}" tal:content="workspace/Title">Title</a>
     </h1>
-    <div class="${workspace_id} dark-theme" id="application-body">
+    <div class="${workspace_id} dark-theme" id="application-body" tal:define="read_only python:not view.can_edit">
         <div id="document-body">
           <form class="document pat-inject" method="POST" action="${context/absolute_url}/view" enctype="multipart/form-data"
-                data-pat-inject="source:#global-statusmessage; target:#global-statusmessage; hooks: raptor">
+                data-pat-inject="source:#global-statusmessage; target:#global-statusmessage; hooks: raptor && source: #application-body; target: #application-body">
             <div class="metadata pat-bumper" id="meta">
               <div class="meta-bar">
                 <h1 class="doc-title" id="document-title">${context/title}</h1>
@@ -31,7 +30,7 @@
                     <a href="#share-panel" class="icon-export iconified pat-modal">Share</a>
                     <a class="icon-info-circle meta-data-toggle iconified">Toggle extra metadata</a>
                     <fieldset tal:condition="view/has_workflow" id="workflow-menu" class="pat-subform pat-autosubmit pat-inject"
-                            tal:attributes="data-pat-inject string:target: #global-statusmessage;; url: ${here_url}/view;; source: #global-statusmessage && url: ${here_url}/view;; source: #workflow-menu;; target: #workflow-menu">
+                            tal:attributes="data-pat-inject string:target: #global-statusmessage;; url: ${here_url}/view;; source: #global-statusmessage && url: ${here_url}/view;; source: #application-body;; target: #application-body">
                         <label class="pat-select bare workflow" title="Change the workflow state">
                             <select name="workflow_action" id="workflow_action">
                                 <option tal:repeat="state view/get_workflow_transitions"


### PR DESCRIPTION
If after a WF state change the user no longer has the permission to edit the current document, the UI needs to reflect that 
