### PR TITLE
Add ploneintranet.api docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ docs:
 
 # Re-generate
 api-docs:
-	@cd docs && make api-stubs
+	@bin/sphinx-apidoc -o docs/api src/ploneintranet
 
 docs-clean:
 	rm -rf docs/html

--- a/docs/api/ploneintranet.api.microblog.rst
+++ b/docs/api/ploneintranet.api.microblog.rst
@@ -1,0 +1,22 @@
+ploneintranet.api.microblog package
+===================================
+
+Submodules
+----------
+
+ploneintranet.api.microblog.statusupdate module
+-----------------------------------------------
+
+.. automodule:: ploneintranet.api.microblog.statusupdate
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: ploneintranet.api.microblog
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/ploneintranet.api.rst
+++ b/docs/api/ploneintranet.api.rst
@@ -6,18 +6,11 @@ Subpackages
 
 .. toctree::
 
+    ploneintranet.api.microblog
     ploneintranet.api.tests
 
 Submodules
 ----------
-
-ploneintranet.api.microblog module
-----------------------------------
-
-.. automodule:: ploneintranet.api.microblog
-    :members:
-    :undoc-members:
-    :show-inheritance:
 
 ploneintranet.api.testing module
 --------------------------------

--- a/docs/api/ploneintranet.api.tests.rst
+++ b/docs/api/ploneintranet.api.tests.rst
@@ -4,10 +4,10 @@ ploneintranet.api.tests package
 Submodules
 ----------
 
-ploneintranet.api.tests.test_microblog module
----------------------------------------------
+ploneintranet.api.tests.test_statusupdate module
+------------------------------------------------
 
-.. automodule:: ploneintranet.api.tests.test_microblog
+.. automodule:: ploneintranet.api.tests.test_statusupdate
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/development/components/index.rst
+++ b/docs/development/components/index.rst
@@ -5,6 +5,7 @@ Component Packages
 .. toctree::
     :maxdepth: 2
 
+    ploneintranet-api
     microblogstream
     workspace
     invitations

--- a/docs/development/components/ploneintranet-api.rst
+++ b/docs/development/components/ploneintranet-api.rst
@@ -1,0 +1,16 @@
+=================
+ploneintranet.api
+=================
+
+.. admonition:: Description
+
+    This package provides a simple developer API to the most commonly used features of ploneintranet.
+
+ploneintranet.api.microblog module
+----------------------------------
+
+.. automodule:: ploneintranet.api.microblog
+    :members:
+    :undoc-members:
+    :show-inheritance:
+

--- a/docs/development/components/ploneintranet-api.rst
+++ b/docs/development/components/ploneintranet-api.rst
@@ -9,7 +9,7 @@ ploneintranet.api
 ploneintranet.api.microblog module
 ----------------------------------
 
-.. automodule:: ploneintranet.api.microblog
+.. automodule:: ploneintranet.api.microblog.statusupdate
     :members:
     :undoc-members:
     :show-inheritance:


### PR DESCRIPTION
This adds the api docs for ploneintranet.api into the main developer documentation.
