### PR TITLE
Plonesocial security 2

### DIFF
--- a/src/ploneintranet/activitystream/browser/configure.zcml
+++ b/src/ploneintranet/activitystream/browser/configure.zcml
@@ -10,6 +10,7 @@
   <include package=".prototype" />
   <include package=".tiles" />
 
+  <!-- FIXME legacy remove -->
   <browser:viewlet
       name="ploneintranet.suite.navigation"
       manager="plone.app.layout.viewlets.interfaces.IPortalHeader"
@@ -34,6 +35,7 @@
       layer=".interfaces.IPloneIntranetActivitystreamLayer"
       />
 
+  <!-- FIXME legacy remove -->
   <browser:page
       name="stream"
       for="ploneintranet.microblog.interfaces.IMicroblogContext"
@@ -42,6 +44,7 @@
       layer=".interfaces.IPloneIntranetActivitystreamLayer"
       />
 
+  <!-- FIXME legacy remove -->
   <browser:resourceDirectory
       name="ploneintranet.activitystream.stylesheets"
       directory="stylesheets"

--- a/src/ploneintranet/activitystream/browser/tiles/stream.py
+++ b/src/ploneintranet/activitystream/browser/tiles/stream.py
@@ -72,7 +72,7 @@ class StreamTile(Tile):
         container = PLONEINTRANET.microblog
 
         if self.microblog_context:
-            # support collective.local integration
+            # support ploneintranet.workspace integration
             statusupdates = container.context_values(
                 self.microblog_context,
                 limit=self.count,
@@ -92,6 +92,9 @@ class StreamTile(Tile):
     def activities(self):
         ''' The list of our activities
         '''
+        # FIXME this try/except loop and the counting it necessitates
+        # is a workaround because the filtering on View is currently inadequate
+
         statusupdates = self.get_statusupdates()
         i = 0
         for su in statusupdates:
@@ -100,6 +103,7 @@ class StreamTile(Tile):
             try:
                 activity = IActivity(su)
             except Unauthorized:
+                logger.error("Unauthorized. FIXME. This should not happen.")
                 continue
             except NotFound:
                 logger.exception("NotFound: %s" % activity.getURL())

--- a/src/ploneintranet/api/tests/test_statusupdate.py
+++ b/src/ploneintranet/api/tests/test_statusupdate.py
@@ -1,3 +1,7 @@
+from AccessControl import Unauthorized
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+
 from ploneintranet.api.testing import IntegrationTestCase
 from ploneintranet import api as pi_api
 from ploneintranet.microblog.statusupdate import StatusUpdate
@@ -5,13 +9,19 @@ from ploneintranet.microblog.statusupdate import StatusUpdate
 
 class TestStatusUpdate(IntegrationTestCase):
 
+    def setUp(self):
+        self.app = self.layer['app']
+        self.portal = self.layer['portal']
+
     def test_create(self):
+        setRoles(self.portal, TEST_USER_ID, ('Member',))
         text = 'Hello this is my update'
         update = pi_api.microblog.statusupdate.create(text)
         self.assertIsInstance(update, StatusUpdate)
         self.assertEqual(update.text, text)
 
     def test_get(self):
+        setRoles(self.portal, TEST_USER_ID, ('Member',))
         update = pi_api.microblog.statusupdate.create('Test')
         update2 = pi_api.microblog.statusupdate.create('Test2')
         self.assertEqual(
@@ -20,6 +30,6 @@ class TestStatusUpdate(IntegrationTestCase):
         self.assertEqual(
             pi_api.microblog.statusupdate.get(update2.id),
             update2)
-        self.assertIsNone(
-            pi_api.microblog.statusupdate.get(999999999)
-        )
+        self.assertRaises(
+            Unauthorized,
+            pi_api.microblog.statusupdate.get, 999999999)

--- a/src/ploneintranet/microblog/statusupdate.py
+++ b/src/ploneintranet/microblog/statusupdate.py
@@ -96,6 +96,11 @@ class StatusUpdate(Persistent):
             return None
         return uuidToObject(self._context_uuid)
 
+# FIXME distinguish between:
+# - context = context object (can be a page)
+# - microblog_context = workspace or None
+# - security_context = workspace or ISiteRoot
+
 #########################################################################
 
     # backward compatibility wrapper

--- a/src/ploneintranet/microblog/tests/test_permissions.py
+++ b/src/ploneintranet/microblog/tests/test_permissions.py
@@ -3,26 +3,36 @@ import time
 
 from zope.component import queryUtility
 from zope.interface import implements
+from zope.interface import directlyProvides
+
+from AccessControl import getSecurityManager
 from AccessControl import Unauthorized
+from Products.CMFCore.utils import getToolByName
+from Products.CMFCore.permissions import View
+
+from plone import api
 
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
+from plone.app.testing import login, logout
 
 from ploneintranet.microblog.testing import\
     PLONEINTRANET_MICROBLOG_INTEGRATION_TESTING
 
+import ploneintranet.microblog.statuscontainer
 from ploneintranet.microblog.interfaces import IMicroblogTool
+from ploneintranet.microblog.interfaces import IMicroblogContext
 from ploneintranet.microblog.interfaces import IStatusUpdate
-from ploneintranet.microblog import statusupdate
+from ploneintranet.microblog.statusupdate import StatusUpdate
 
 
-class StatusUpdate(statusupdate.StatusUpdate):
+class MockStatusUpdate(StatusUpdate):
     """Override actual implementation with unittest features"""
 
     implements(IStatusUpdate)
 
     def __init__(self, text, userid, creator=None):
-        statusupdate.StatusUpdate.__init__(self, text)
+        StatusUpdate.__init__(self, text)
         self.userid = userid
         if creator:
             self.creator = creator
@@ -44,21 +54,22 @@ class TestPermissions(unittest.TestCase):
         self.app = self.layer['app']
         self.portal = self.layer['portal']
         self.mb_tool = queryUtility(IMicroblogTool)
+        ploneintranet.microblog.statuscontainer.MAX_QUEUE_AGE = 0
+
+    def tearDown(self):
+        ploneintranet.microblog.statuscontainer.MAX_QUEUE_AGE = 1000
 
     def test_add_read_member(self):
         setRoles(self.portal, TEST_USER_ID, ('Member',))
-        sa = StatusUpdate('test a', 'arnold')
+        sa = MockStatusUpdate('test a', 'arnold')
         container = self.mb_tool
         container.add(sa)
-        container.flush_queue()
         values = [x for x in container.values()]
         self.assertEqual([sa], values)
-        # dangling queue thread
-        time.sleep(.1)
 
     def test_add_anon(self):
         setRoles(self.portal, TEST_USER_ID, ())
-        sa = StatusUpdate('test a', 'arnold')
+        sa = MockStatusUpdate('test a', 'arnold')
         container = self.mb_tool
         self.assertRaises(Unauthorized, container.add, sa)
 
@@ -69,3 +80,64 @@ class TestPermissions(unittest.TestCase):
         self.assertEqual([x for x in container.values()], [])
         self.assertEqual([x for x in container.items()], [])
         self.assertEqual([x for x in container.keys()], [])
+
+
+class TestMicroblogContextBlacklisting(unittest.TestCase):
+
+    layer = PLONEINTRANET_MICROBLOG_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        setRoles(self.portal, TEST_USER_ID, ['Manager'])
+        workflowTool = getToolByName(self.portal, 'portal_workflow')
+        workflowTool.setDefaultChain('simple_publication_workflow')
+        workflowTool.updateRoleMappings()
+        f1 = api.content.create(self.portal, 'Folder', 'f1', title=u'Folder 1')
+        directlyProvides(f1, IMicroblogContext)
+        f1.reindexObject()
+        f2 = api.content.create(self.portal, 'Folder', 'f2', title=u'Folder 2')
+        directlyProvides(f2, IMicroblogContext)
+        f2.reindexObject()
+
+        api.content.transition(f2, 'publish')
+        self.assertEqual(api.content.get_state(f1), 'private')
+        self.assertEqual(api.content.get_state(f2), 'published')
+
+        tool = queryUtility(IMicroblogTool)
+        self.su1 = su1 = StatusUpdate('test #foo', f1)
+        tool.add(su1)
+        self.su2 = su2 = StatusUpdate('test #foo', f2)
+        tool.add(su2)
+        # the tool is queued
+        tool.flush_queue()
+
+        # set up new user
+        api.user.create('user1@foo.bar', username='user1', password='secret')
+
+    def tearDown(self):
+        time.sleep(1)  # allow for thread cleanup
+
+    def test_allowed_status_user(self):
+        """The base implementation does not test access controls.
+        The tool should provide those.
+        """
+        # verify setup: only f2 is accessible for Member
+        logout()
+        login(self.portal, 'user1')
+        sm = getSecurityManager()
+        user = api.user.get_current()
+        self.assertEqual(user.getId(), 'user1')
+        self.assertFalse(sm.checkPermission(View, self.portal['f1']))
+        self.assertTrue(sm.checkPermission(View, self.portal['f2']))
+
+        # and now finally the actual test
+        tool = queryUtility(IMicroblogTool)
+        self.assertEqual(list(tool.values()), [self.su2])
+
+    def test_allowed_status_manager(self):
+        """The default test user owns both IMicroblogContexts
+        thus has access to both."""
+        tool = queryUtility(IMicroblogTool)
+        self.assertEqual(list(tool.values()), [self.su2, self.su1])
+
+# more security testing in ploneintranet/suite/tests/test_microblog_security.py

--- a/src/ploneintranet/microblog/tests/test_permissions.py
+++ b/src/ploneintranet/microblog/tests/test_permissions.py
@@ -65,7 +65,7 @@ class TestPermissions(unittest.TestCase):
     def test_read_anon(self):
         setRoles(self.portal, TEST_USER_ID, ())
         container = self.mb_tool
-        self.assertRaises(Unauthorized, container.values)
-        self.assertRaises(Unauthorized, container.items)
-        self.assertRaises(Unauthorized, container.keys)
         self.assertRaises(Unauthorized, container.get, 0)
+        self.assertEqual([x for x in container.values()], [])
+        self.assertEqual([x for x in container.items()], [])
+        self.assertEqual([x for x in container.keys()], [])

--- a/src/ploneintranet/microblog/tests/test_statuscontainer_base.py
+++ b/src/ploneintranet/microblog/tests/test_statuscontainer_base.py
@@ -17,6 +17,9 @@ class StatusContainer(statuscontainer.BaseStatusContainer):
     def _check_add_permission(self, statusupdate):
         pass
 
+    def _blacklist_microblogcontext_uuids(self):
+        return []
+
 
 class StatusUpdate(statusupdate.StatusUpdate):
     """Override actual implementation with unittest features"""

--- a/src/ploneintranet/microblog/tests/test_statuscontainer_base.py
+++ b/src/ploneintranet/microblog/tests/test_statuscontainer_base.py
@@ -14,7 +14,7 @@ class StatusContainer(statuscontainer.BaseStatusContainer):
 
     implements(IStatusContainer)
 
-    def _check_permission(self, perm="read"):
+    def _check_add_permission(self, statusupdate):
         pass
 
 

--- a/src/ploneintranet/microblog/tests/test_statuscontainer_context.py
+++ b/src/ploneintranet/microblog/tests/test_statuscontainer_context.py
@@ -21,6 +21,12 @@ class UUIDStatusContainer(statuscontainer.BaseStatusContainer):
     def _check_add_permission(self, statusupdate):
         pass
 
+    def _blacklist_microblogcontext_uuids(self):
+        try:
+            return self.blacklist
+        except AttributeError:
+            return []
+
 
 class StatusContainer(UUIDStatusContainer):
 
@@ -52,6 +58,7 @@ class TestStatusContainer(unittest.TestCase):
 
     def setUp(self):
         self.container = StatusContainer()
+        self.container.blacklist = []
         self.su1 = StatusUpdate('test', tags=['foo'])
         self.su1.userid = 'dude'
         self.mockcontext = MockContext()
@@ -117,15 +124,17 @@ class TestStatusContainer(unittest.TestCase):
                   self.container.allowed_status_keys()]
         self.assertEqual([self.su1, self.su2, self.su3, self.su4], values)
 
-        uid_blacklist = [self.container._context2uuid(self.mockcontext)]
+        self.container.blacklist = [
+            self.container._context2uuid(self.mockcontext)]
         values = [self.container.get(i)
-                  for i in self.container._allowed_status_keys(uid_blacklist)]
+                  for i in self.container.allowed_status_keys()]
         self.assertEqual([self.su1, self.su4], values)
 
-        uid_blacklist = [self.container._context2uuid(self.mockcontext),
-                         self.container._context2uuid(self.mockcontext2)]
+        self.container.blacklist = [
+            self.container._context2uuid(self.mockcontext),
+            self.container._context2uuid(self.mockcontext2)]
         values = [self.container.get(i)
-                  for i in self.container._allowed_status_keys(uid_blacklist)]
+                  for i in self.container.allowed_status_keys()]
         self.assertEqual([self.su1], values)
 
 

--- a/src/ploneintranet/microblog/tests/test_statuscontainer_context.py
+++ b/src/ploneintranet/microblog/tests/test_statuscontainer_context.py
@@ -18,7 +18,7 @@ class UUIDStatusContainer(statuscontainer.BaseStatusContainer):
 
     implements(IStatusContainer)
 
-    def _check_permission(self, perm="read"):
+    def _check_add_permission(self, statusupdate):
         pass
 
 

--- a/src/ploneintranet/microblog/tests/test_statuscontainer_mentions.py
+++ b/src/ploneintranet/microblog/tests/test_statuscontainer_mentions.py
@@ -19,6 +19,9 @@ class StatusContainer(statuscontainer.BaseStatusContainer):
     def _check_add_permission(self, statusupdate):
         pass
 
+    def _blacklist_microblogcontext_uuids(self):
+        return []
+
 
 class StatusUpdate(statusupdate.StatusUpdate):
     """Override actual implementation with unittest features"""

--- a/src/ploneintranet/microblog/tests/test_statuscontainer_mentions.py
+++ b/src/ploneintranet/microblog/tests/test_statuscontainer_mentions.py
@@ -16,7 +16,7 @@ class StatusContainer(statuscontainer.BaseStatusContainer):
 
     implements(IStatusContainer)
 
-    def _check_permission(self, perm="read"):
+    def _check_add_permission(self, statusupdate):
         pass
 
 

--- a/src/ploneintranet/microblog/tests/test_statuscontainer_queued.py
+++ b/src/ploneintranet/microblog/tests/test_statuscontainer_queued.py
@@ -10,7 +10,6 @@ from ploneintranet.microblog import statusupdate
 
 from ploneintranet.microblog.statuscontainer import STATUSQUEUE
 import ploneintranet.microblog.statuscontainer
-ploneintranet.microblog.statuscontainer.MAX_QUEUE_AGE = 50
 from ploneintranet.microblog.testing import tearDownContainer
 
 
@@ -21,6 +20,9 @@ class StatusContainer(statuscontainer.QueuedStatusContainer):
 
     def _check_add_permission(self, statusupdate):
         pass
+
+    def _blacklist_microblogcontext_uuids(self):
+        return []
 
 
 class StatusUpdate(statusupdate.StatusUpdate):
@@ -50,9 +52,11 @@ class TestQueueStatusContainer(unittest.TestCase):
         self.container = StatusContainer()
         # make sure also first item will be queued
         self.container._mtime = int(time.time() * 1000)
+        ploneintranet.microblog.statuscontainer.MAX_QUEUE_AGE = 50
 
     def tearDown(self):
         tearDownContainer(self.container)
+        ploneintranet.microblog.statuscontainer.MAX_QUEUE_AGE = 1000
 
     def test_verify_interface(self):
         self.assertTrue(verifyClass(IStatusContainer, StatusContainer))

--- a/src/ploneintranet/microblog/tests/test_statuscontainer_queued.py
+++ b/src/ploneintranet/microblog/tests/test_statuscontainer_queued.py
@@ -19,7 +19,7 @@ class StatusContainer(statuscontainer.QueuedStatusContainer):
 
     implements(IStatusContainer)
 
-    def _check_permission(self, perm="read"):
+    def _check_add_permission(self, statusupdate):
         pass
 
 

--- a/src/ploneintranet/microblog/tests/test_statuscontainer_tags.py
+++ b/src/ploneintranet/microblog/tests/test_statuscontainer_tags.py
@@ -11,7 +11,7 @@ class StatusContainer(statuscontainer.BaseStatusContainer):
 
     implements(IStatusContainer)
 
-    def _check_permission(self, perm="read"):
+    def _check_add_permission(self, statusupdate):
         pass
 
 

--- a/src/ploneintranet/microblog/tests/test_statuscontainer_tags.py
+++ b/src/ploneintranet/microblog/tests/test_statuscontainer_tags.py
@@ -14,6 +14,9 @@ class StatusContainer(statuscontainer.BaseStatusContainer):
     def _check_add_permission(self, statusupdate):
         pass
 
+    def _blacklist_microblogcontext_uuids(self):
+        return []
+
 
 class StatusUpdate(statusupdate.StatusUpdate):
     """Override actual implementation with unittest features"""

--- a/src/ploneintranet/microblog/tests/test_statuscontainer_threaded.py
+++ b/src/ploneintranet/microblog/tests/test_statuscontainer_threaded.py
@@ -12,7 +12,7 @@ class StatusContainer(statuscontainer.BaseStatusContainer):
 
     implements(IStatusContainer)
 
-    def _check_permission(self, perm="read"):
+    def _check_add_permission(self, statusupdate):
         pass
 
 

--- a/src/ploneintranet/microblog/tests/test_statuscontainer_threaded.py
+++ b/src/ploneintranet/microblog/tests/test_statuscontainer_threaded.py
@@ -15,6 +15,9 @@ class StatusContainer(statuscontainer.BaseStatusContainer):
     def _check_add_permission(self, statusupdate):
         pass
 
+    def _blacklist_microblogcontext_uuids(self):
+        return []
+
 
 class StatusUpdate(statusupdate.StatusUpdate):
     """Override actual implementation with unittest features"""

--- a/src/ploneintranet/microblog/tests/test_statuscontainer_user.py
+++ b/src/ploneintranet/microblog/tests/test_statuscontainer_user.py
@@ -13,7 +13,7 @@ class StatusContainer(statuscontainer.BaseStatusContainer):
 
     implements(IStatusContainer)
 
-    def _check_permission(self, perm="read"):
+    def _check_add_permission(self, statusupdate):
         pass
 
 

--- a/src/ploneintranet/microblog/tests/test_statuscontainer_user.py
+++ b/src/ploneintranet/microblog/tests/test_statuscontainer_user.py
@@ -16,6 +16,9 @@ class StatusContainer(statuscontainer.BaseStatusContainer):
     def _check_add_permission(self, statusupdate):
         pass
 
+    def _blacklist_microblogcontext_uuids(self):
+        return []
+
 
 class StatusUpdate(statusupdate.StatusUpdate):
     """Override actual implementation with unittest features"""

--- a/src/ploneintranet/microblog/tests/test_tiles.py
+++ b/src/ploneintranet/microblog/tests/test_tiles.py
@@ -5,6 +5,7 @@ from ploneintranet.microblog.browser.interfaces import (
 from ploneintranet.activitystream.browser.interfaces import (
     IPloneIntranetActivitystreamLayer
 )
+import ploneintranet.microblog.statuscontainer
 from ploneintranet.microblog.tool import MicroblogTool
 from ploneintranet.microblog.testing import (
     PLONEINTRANET_MICROBLOG_INTEGRATION_TESTING
@@ -23,6 +24,10 @@ class TestSetup(unittest.TestCase):
         self.request = self.layer['request']
         alsoProvides(self.request, IPloneIntranetActivitystreamLayer)
         alsoProvides(self.request, IPloneIntranetMicroblogLayer)
+        ploneintranet.microblog.statuscontainer.MAX_QUEUE_AGE = 0
+
+    def tearDown(self):
+        ploneintranet.microblog.statuscontainer.MAX_QUEUE_AGE = 1000
 
     def test_newpostbox_tile_on_portal(self):
         ''' This will test the existence of the newpostbox.tile
@@ -73,6 +78,6 @@ class TestSetup(unittest.TestCase):
         self.assertEqual(tile.is_posting, True)
         self.assertEqual(tile.post_text, u'Testing post')
         # self.assertEqual(tile.post_attachment, u'No attachments')
-        # calling update does not create a post
+        # calling update creates a post
         tile.update()
         self.assertIsInstance(tile.post, StatusUpdate)

--- a/src/ploneintranet/microblog/tests/test_tool.py
+++ b/src/ploneintranet/microblog/tests/test_tool.py
@@ -1,23 +1,13 @@
-import time
 import unittest2 as unittest
-from zope.interface import directlyProvides
 from zope.component import queryUtility
 
-from AccessControl import getSecurityManager
-from Products.CMFCore.permissions import View
-from Products.CMFCore.utils import getToolByName
-
 from plone import api
-from plone.app.testing import TEST_USER_ID, setRoles
-from plone.app.testing import login, logout
 
 from ploneintranet.microblog.testing import \
     PLONEINTRANET_MICROBLOG_INTEGRATION_TESTING
 
 from ploneintranet.microblog.interfaces import IStatusContainer
 from ploneintranet.microblog.interfaces import IMicroblogTool
-from ploneintranet.microblog.interfaces import IMicroblogContext
-from ploneintranet.microblog.statusupdate import StatusUpdate
 
 
 class TestMicroblogTool(unittest.TestCase):
@@ -38,62 +28,3 @@ class TestMicroblogTool(unittest.TestCase):
         self.assertNotIn('ploneintranet_microblog', self.portal)
         tool = queryUtility(IMicroblogTool, None)
         self.assertIsNone(tool)
-
-
-class TestMicroblogToolContextBlacklisting(unittest.TestCase):
-
-    layer = PLONEINTRANET_MICROBLOG_INTEGRATION_TESTING
-
-    def setUp(self):
-        self.portal = self.layer['portal']
-        setRoles(self.portal, TEST_USER_ID, ['Manager'])
-        workflowTool = getToolByName(self.portal, 'portal_workflow')
-        workflowTool.setDefaultChain('simple_publication_workflow')
-        workflowTool.updateRoleMappings()
-        f1 = api.content.create(self.portal, 'Folder', 'f1', title=u'Folder 1')
-        directlyProvides(f1, IMicroblogContext)
-        f1.reindexObject()
-        f2 = api.content.create(self.portal, 'Folder', 'f2', title=u'Folder 2')
-        directlyProvides(f2, IMicroblogContext)
-        f2.reindexObject()
-
-        api.content.transition(f2, 'publish')
-        self.assertEqual(api.content.get_state(f1), 'private')
-        self.assertEqual(api.content.get_state(f2), 'published')
-
-        tool = queryUtility(IMicroblogTool)
-        self.su1 = su1 = StatusUpdate('test #foo', f1)
-        tool.add(su1)
-        self.su2 = su2 = StatusUpdate('test #foo', f2)
-        tool.add(su2)
-        # the tool is queued
-        tool.flush_queue()
-
-        # set up new user
-        api.user.create('user1@foo.bar', username='user1', password='secret')
-
-    def tearDown(self):
-        time.sleep(1)  # allow for thread cleanup
-
-    def test_allowed_status_user(self):
-        """The base implementation does not test access controls.
-        The tool should provide those.
-        """
-        # verify setup: only f2 is accessible for Member
-        logout()
-        login(self.portal, 'user1')
-        sm = getSecurityManager()
-        user = api.user.get_current()
-        self.assertEqual(user.getId(), 'user1')
-        self.assertFalse(sm.checkPermission(View, self.portal['f1']))
-        self.assertTrue(sm.checkPermission(View, self.portal['f2']))
-
-        # and now finally the actual test
-        tool = queryUtility(IMicroblogTool)
-        self.assertEqual(list(tool.values()), [self.su2])
-
-    def test_allowed_status_manager(self):
-        """The default test user owns both IMicroblogContexts
-        thus has access to both."""
-        tool = queryUtility(IMicroblogTool)
-        self.assertEqual(list(tool.values()), [self.su2, self.su1])

--- a/src/ploneintranet/microblog/tests/test_uuid_integration.py
+++ b/src/ploneintranet/microblog/tests/test_uuid_integration.py
@@ -14,7 +14,10 @@ class StatusContainer(BaseStatusContainer):
     """we don't care about permission checks for the uuid integration"""
 
     def _check_add_permission(self, statusupdate):
-        return True
+        pass
+
+    def _blacklist_microblogcontext_uuids(self):
+        return []
 
 
 class StatusUpdate(statusupdate.StatusUpdate):

--- a/src/ploneintranet/microblog/tests/test_uuid_integration.py
+++ b/src/ploneintranet/microblog/tests/test_uuid_integration.py
@@ -13,7 +13,7 @@ from ploneintranet.microblog import statusupdate
 class StatusContainer(BaseStatusContainer):
     """we don't care about permission checks for the uuid integration"""
 
-    def _check_permission(self, perm="read"):
+    def _check_add_permission(self, statusupdate):
         return True
 
 

--- a/src/ploneintranet/microblog/tool.py
+++ b/src/ploneintranet/microblog/tool.py
@@ -1,10 +1,8 @@
 from zope.interface import implements
 from Products.CMFCore.utils import UniqueObject
-from Products.CMFCore.utils import getToolByName
 from OFS.SimpleItem import SimpleItem
 
 from interfaces import IMicroblogTool
-from interfaces import IMicroblogContext
 from statuscontainer import QueuedStatusContainer
 
 
@@ -15,47 +13,3 @@ class MicroblogTool(UniqueObject, SimpleItem, QueuedStatusContainer):
 
     meta_type = 'ploneintranet.microblog tool'
     id = 'ploneintranet_microblog'
-
-    # FIXME this method is called a lot - view.memoize or performance optimize
-    def allowed_status_keys(self):
-        """Return the subset of IStatusUpdate keys
-        that are related to UUIDs of accessible contexts.
-        I.e. blacklist all IStatusUpdate that has a context
-        which we don't have permission to access.
-
-        This method is implemented on the tool,
-        overriding a noop implementation on BaseStatusContainer.
-
-        This implementation depends on two critical assumptions:
-
-        1) The set of available IMicroblogContext objects can be
-        adequately queried from the catalog. This implies a reliance
-        on the "View" permission - any workspace that should not be
-        accessible should not have View.
-
-        This assumption is currently violated by workspace. FIXME.
-
-        2) The global security manager is valid.
-        This is currently OK but would be violated if we were to
-        introduce nested workspaces.
-        Even though non-nested workspaces already introduce a local
-        security manager, this only applies to content *within* the
-        workspace. The security of the workspace itself is adequately
-        reflected in the global security manager.
-        """
-        catalog = getToolByName(self, 'portal_catalog')
-        marker = IMicroblogContext.__identifier__
-
-        # microblog backend access control completely relies on this:
-        # catalog implicitly filters on current_user View permission
-        results = catalog.searchResults(object_provides=marker)
-
-        # SiteRoot context is NOT whitelisted
-        whitelist = [x.UID for x in results]
-        # SiteRoot context is not UUID indexed, so not blacklisted
-        blacklist = [x for x in self._uuid_mapping.keys()
-                     if x not in whitelist]
-
-        # return all statuses with no IMicroblogContext (= SiteRoot)
-        # or with a IMicroblogContext that is accessible (= not blacklisted)
-        return self._allowed_status_keys(blacklist)

--- a/src/ploneintranet/microblog/tool.py
+++ b/src/ploneintranet/microblog/tool.py
@@ -16,6 +16,7 @@ class MicroblogTool(UniqueObject, SimpleItem, QueuedStatusContainer):
     meta_type = 'ploneintranet.microblog tool'
     id = 'ploneintranet_microblog'
 
+    # FIXME this method is called a lot - view.memoize or performance optimize
     def allowed_status_keys(self):
         """Return the subset of IStatusUpdate keys
         that are related to UUIDs of accessible contexts.
@@ -24,15 +25,37 @@ class MicroblogTool(UniqueObject, SimpleItem, QueuedStatusContainer):
 
         This method is implemented on the tool,
         overriding a noop implementation on BaseStatusContainer.
+
+        This implementation depends on two critical assumptions:
+
+        1) The set of available IMicroblogContext objects can be
+        adequately queried from the catalog. This implies a reliance
+        on the "View" permission - any workspace that should not be
+        accessible should not have View.
+
+        This assumption is currently violated by workspace. FIXME.
+
+        2) The global security manager is valid.
+        This is currently OK but would be violated if we were to
+        introduce nested workspaces.
+        Even though non-nested workspaces already introduce a local
+        security manager, this only applies to content *within* the
+        workspace. The security of the workspace itself is adequately
+        reflected in the global security manager.
         """
         catalog = getToolByName(self, 'portal_catalog')
         marker = IMicroblogContext.__identifier__
+
+        # microblog backend access control completely relies on this:
+        # catalog implicitly filters on current_user View permission
         results = catalog.searchResults(object_provides=marker)
+
         # SiteRoot context is NOT whitelisted
         whitelist = [x.UID for x in results]
         # SiteRoot context is not UUID indexed, so not blacklisted
         blacklist = [x for x in self._uuid_mapping.keys()
                      if x not in whitelist]
+
         # return all statuses with no IMicroblogContext (= SiteRoot)
         # or with a IMicroblogContext that is accessible (= not blacklisted)
         return self._allowed_status_keys(blacklist)

--- a/src/ploneintranet/suite/tests/test_microblog_security.py
+++ b/src/ploneintranet/suite/tests/test_microblog_security.py
@@ -1,0 +1,64 @@
+import unittest2 as unittest
+from AccessControl import Unauthorized
+from plone.app.testing import login, logout
+from zope.component import queryUtility
+
+
+from ploneintranet.suite.testing import\
+    PLONEINTRANET_SUITE_FUNCTIONAL
+
+from ploneintranet.microblog.interfaces import IMicroblogTool
+# from ploneintranet.microblog.interfaces import IMicroblogContext
+from ploneintranet.microblog.statusupdate import StatusUpdate
+
+
+class TestMicroblogSecurity(unittest.TestCase):
+    """
+    This test expans on microblog/tests/test_tool.py
+    It needs complex test fixures which are not available in microblog.
+    Instead we use the existing suite test fixture.
+    """
+
+    layer = PLONEINTRANET_SUITE_FUNCTIONAL
+
+    def setUp(self):
+        self.app = self.layer['app']
+        self.portal = self.layer['portal']
+        self.tool = queryUtility(IMicroblogTool)
+        self.workspace = self.portal.workspaces['open-market-committee']
+
+    def test_member_allowed_write(self):
+        login(self.portal, 'allan_neece')
+        su1 = StatusUpdate('test #foo')
+        su2 = StatusUpdate('test #foo', self.workspace)
+        self.tool.add(su1)
+        # should NOT raise Unauthorized
+        self.tool.add(su2)
+
+    def test_nonmember_unauthorized_write(self):
+        login(self.portal, 'alice_lindstrom')
+        su1 = StatusUpdate('test #foo')
+        su2 = StatusUpdate('test #foo', self.workspace)
+        self.tool.add(su1)
+        # should raise, since Alice is not a member of the workspace
+        self.assertRaises(Unauthorized, self.tool.add, su2)
+
+    @unittest.skip("FIXME: Remove VIEW from workspace for non-member")
+    def test_nonmember_unauthorized_get(self):
+        login(self.portal, 'allan_neece')
+        su = StatusUpdate('test #foo', self.workspace)
+        self.tool.add(su)
+        logout()
+        login(self.portal, 'alice_lindstrom')
+        # should raise, since Alice is not a member of the workspace
+        self.assertRaises(Unauthorized, self.tool.get, su.id)
+
+    @unittest.skip("FIXME: Remove VIEW from workspace for non-member")
+    def test_nonmember_secured_read(self):
+        login(self.portal, 'allan_neece')
+        su = StatusUpdate('test #foo', self.workspace)
+        self.tool.add(su)
+        logout()
+        login(self.portal, 'alice_lindstrom')
+        # silently filters all you're not allowed to see
+        self.assertEqual([x for x in self.tool.keys()], [])

--- a/src/ploneintranet/suite/tests/test_microblog_security.py
+++ b/src/ploneintranet/suite/tests/test_microblog_security.py
@@ -43,7 +43,6 @@ class TestMicroblogSecurity(unittest.TestCase):
         # should raise, since Alice is not a member of the workspace
         self.assertRaises(Unauthorized, self.tool.add, su2)
 
-    @unittest.skip("FIXME: Remove VIEW from workspace for non-member")
     def test_nonmember_unauthorized_get(self):
         login(self.portal, 'allan_neece')
         su = StatusUpdate('test #foo', self.workspace)
@@ -53,7 +52,6 @@ class TestMicroblogSecurity(unittest.TestCase):
         # should raise, since Alice is not a member of the workspace
         self.assertRaises(Unauthorized, self.tool.get, su.id)
 
-    @unittest.skip("FIXME: Remove VIEW from workspace for non-member")
     def test_nonmember_secured_read(self):
         login(self.portal, 'allan_neece')
         su = StatusUpdate('test #foo', self.workspace)
@@ -61,4 +59,4 @@ class TestMicroblogSecurity(unittest.TestCase):
         logout()
         login(self.portal, 'alice_lindstrom')
         # silently filters all you're not allowed to see
-        self.assertEqual([x for x in self.tool.keys()], [])
+        self.assertFalse(su.id in self.tool.keys())


### PR DESCRIPTION
This is a full security audit of the microblog stack.
- protect write access with AddStatusUpdate
- protect all read accessors with ViewStatusUpdate
- is aware of local security context in workspaces (via api.user.has_permission)
- caches expensive security check in ramcache

Also reorganizes implementation and tests for readability, which creates noise in the diff but clarity in the actual code.
