### PR TITLE
Update documentation on testing setup

### DIFF
--- a/docs/development/components/microblogstream.rst
+++ b/docs/development/components/microblogstream.rst
@@ -14,7 +14,7 @@ Microblog and Activity Stream
 Introduction
 ------------
 
-This stack of functionality used to be split into various packages (plonesocial.*). After the unification, the packages are nowpart of ploneintranet, but still under their original folder names (e.g. `ploneintranet.microblog <https://github.com/ploneintranet/ploneintranet/tree/master/src/ploneintranet/microblog>`_, which used to be plonesocial.microblog).
+This stack of functionality used to be split into various packages (plonesocial.*). After the unification, the packages are now part of ploneintranet, but still under their original folder names (e.g. `ploneintranet.microblog <https://github.com/ploneintranet/ploneintranet/tree/master/src/ploneintranet/microblog>`_, which used to be plonesocial.microblog).
 
 Packages
 ========

--- a/docs/development/components/workspace.rst
+++ b/docs/development/components/workspace.rst
@@ -123,6 +123,10 @@ What can members of the workspace do?
   - Members can create, edit and publish their own content
     *and* content created by others.
 
+.. note::
+
+  Unless the policy is set to *Moderators*, Members will only see the content created by others if it has been published.
+
 Policy Scenarios
 ----------------
 

--- a/docs/development/testing.rst
+++ b/docs/development/testing.rst
@@ -163,7 +163,9 @@ Testing scenarios
 Workspaces
 ----------
 
-The `setuphandlers.py` of the workspaces package creates two workspaces with the following settings:
+The top-level workspace container with the id "workspaces" is created on install by the setup-handler of the workspace package.
+
+The setup-handler of the suite creates two workspaces with the following settings:
 
 * "Open Market Committee"
 

--- a/docs/development/testing.rst
+++ b/docs/development/testing.rst
@@ -152,8 +152,34 @@ Run the test you want to trace::
 That should open up the Jenkins firefox on your local machine and play the session.
 
 If you want to dig deeper, add the statement ``Debug`` into the offending robot test.
-In that case the pybot process above will drop you into a debug session, where you 
+In that case the pybot process above will drop you into a debug session, where you
 can continue the test manually by inserting commands like ``click link  link=Rain``
 which then should step by step update your local firefox display with the test run on Jenkins.
 
+
+Testing scenarios
+=================
+
+Workspaces
+----------
+
+The `setuphandlers.py` of the workspaces package creates two workspaces with the following settings:
+
+* "Open Market Committee"
+
+  * **External visibility**: Private
+  * **Participation policy**: Publishers
+  * **Admin**: christian_stoney
+  * **Member**: allan_neece (and others)
+  * **Non-Member**: alice_lindstrom
+
+  A document, a file and an image are created in sub-folder "Manage Information" with allan_neece as the owner, so that he will be abler to manipulate them in robot tests.
+
+* "Parliamentary papers guidance"
+
+  * **External visibility**: Private
+  * **Participation policy**: Producers
+  * **Admin**: christian_stoney
+  * **Member**: allan_neece (and others)
+  * **Non-Member**: alice_lindstrom
 

--- a/src/ploneintranet/suite/tests/acceptance/workspace.robot
+++ b/src/ploneintranet/suite/tests/acceptance/workspace.robot
@@ -128,6 +128,18 @@ Member can submit and retract a document
      When I retract the content item
      Then I can edit the document
 
+Member can publish a document in a Publishers workspace
+    Given I am in a workspace as a workspace member
+     When I can create a new document    My publishing document
+     When I submit the content item
+     Then I can publish the content item
+
+Member cannot publish a document in a Producers workspace
+    Given I am in a Producers workspace as a workspace member
+     When I can create a new document    My non-publishing document
+     When I submit the content item
+     Then I cannot publish the content item
+
 
 # XXX: The following tests derive from ploneintranet.workspace and still
 # need to be adapted to our current state of layout integration
@@ -317,8 +329,6 @@ I can create a new document
     Click Button  css=#form-buttons-create
     Wait Until Page Contains Element  css=#content input[value="${title}"]
 
-
-
 I can create a new folder
     Click link  Documents
     Click link  Create folder
@@ -384,6 +394,17 @@ I retract the content item
     Click Element    xpath=//fieldset[@id='workflow-menu']//select/option[contains(text(), 'Draft')]
     Wait until page contains  The workflow state has been changed
     Click button  Close
+
+I can publish the content item
+    Click element    xpath=//fieldset[@id='workflow-menu']
+    Click Element    xpath=//fieldset[@id='workflow-menu']//select/option[contains(text(), 'Published')]
+    Wait until page contains  The workflow state has been changed
+    Click button  Close
+
+I cannot publish the content item
+    Click element    xpath=//fieldset[@id='workflow-menu']
+    Element should be visible   xpath=//fieldset[@id='workflow-menu']//select/option[contains(text(), 'Draft')]
+    Element should not be visible   xpath=//fieldset[@id='workflow-menu']//select/option[contains(text(), 'Published')]
 
 I can edit the document
     Element should be visible  xpath=//div[@id='document-body']//div[@id='editor-toolbar']

--- a/src/ploneintranet/suite/tests/lib/keywords.robot
+++ b/src/ploneintranet/suite/tests/lib/keywords.robot
@@ -54,6 +54,10 @@ I am in a workspace as a workspace member
     I am logged in as the user allan_neece
     I go to the Open Market Committee Workspace
 
+I am in a Producers workspace as a workspace member
+    I am logged in as the user allan_neece
+    I go to the Open Parliamentary Papers Guidance Workspace
+
 I am in a workspace as a workspace admin
     I am logged in as the user christian_stoney
     I go to the Open Market Committee Workspace
@@ -62,6 +66,12 @@ I go to the Open Market Committee Workspace
     Go To  ${PLONE_URL}/workspaces/open-market-committee
     Wait Until Element Is Visible  css=h1#workspace-name
     Wait Until Page Contains  Open Market Committee
+
+I go to the Open Parliamentary Papers Guidance Workspace
+    Go To  ${PLONE_URL}/workspaces/parliamentary-papers-guidance
+    Wait Until Element Is Visible  css=h1#workspace-name
+    Wait Until Page Contains  Parliamentary papers guidance
+
 
 I try go to the Open Market Committee Workspace
     Go To  ${PLONE_URL}/workspaces/open-market-committee


### PR DESCRIPTION
@gyst here are some notes in the documentation about the testing setup for workspaces.
To illustrate the difference between the policies "Producers" and "Publishers" I added 2 simple robot tests.
