### PR TITLE
Adding events

### DIFF
--- a/src/ploneintranet/suite/tests/acceptance/workspace.robot
+++ b/src/ploneintranet/suite/tests/acceptance/workspace.robot
@@ -399,6 +399,7 @@ I can publish the content item
     Click element    xpath=//fieldset[@id='workflow-menu']
     Click Element    xpath=//fieldset[@id='workflow-menu']//select/option[contains(text(), 'Published')]
     Wait until page contains  The workflow state has been changed
+    Wait until page contains  Close
     Click button  Close
 
 I cannot publish the content item

--- a/src/ploneintranet/theme/content/templates/event_view.pt
+++ b/src/ploneintranet/theme/content/templates/event_view.pt
@@ -26,7 +26,7 @@
             <form class="document pat-inject" method="POST" action="${context/absolute_url}/view#meta">
     <div class="metadata pat-bumper" id="meta">
         <div class="meta-bar">
-            <h1 class="doc-title" id="document-title">
+            <h1 class="doc-title" id="document-title" tal:content="context/title">
                 Traces through Time data workshop
             </h1>
             <!-- Next link should be populated with the link back to the parent. Used for small screen and accessibilty -->
@@ -93,68 +93,9 @@
     </div>
     <div id="document-content">
         <div class="document event-details">
-            <fieldset class="vertical">
-                <label class="location">
-                    Location <input name="location" tal:attributes="disabled read_only" type="text" value="${context/location}">
-                </label>
-                <br>
-                <label class="organiser">
-                    Organiser <input tal:attributes="disabled read_only" class="pat-autosuggest users" data-pat-autosuggest="words: Bi Angli &lt;bi.angli@shenzenair.com&gt;, Edmund Hall &lt;edmund.hall@aircanada.com&gt;, Hanns-Martin Schulte &lt;hanns.martin.schulte@lufthansa.de&gt;, Helge Nørdal &lt;hnoerdal@sas.dk&gt;, John Doe &lt;john.doe@aircanada.com&gt;, Liz Baker &lt;liz.baker@united.com&gt;, Peter Meier &lt;peter.meier@swiss.com&gt;, Ratana Preecha &lt;ratana.preecha@thaiair.com&gt;" type="text" value="Janet Northcote &lt;janet.northcote@staralliance.com&gt;">
-                </label>
-                <br>
-                <fieldset class="pat-checklist options">
-                    <label>
-                        <input tal:attributes="checked python:context.whole_day" tal:attributes="disabled read_only" type="checkbox"> All day event
-                    </label>
-                    <br>
-                    <label>
-                        <input type="checkbox" tal:attributes="disabled read_only" > Visible on other calendars
-                    </label>
-                </fieldset>
-                <br>
-                <fieldset class="date-time">
-                    <fieldset class="row">
-                            <fieldset class="group six columns">
-                                <legend>From</legend>
-                                <input type="date" tal:attributes="disabled read_only" size="10" class="date" name="start-day" placeholder="Date" value="${context/start/date}" />
-                                <input type="time" tal:attributes="disabled read_only" size="10" class="date" name="start-time" placeholder="Time" value="${context/start/time}" />
-                            </fieldset>
 
-                            <fieldset class="group six columns">
-                                <legend>To</legend>
-                                <input type="date" tal:attributes="disabled read_only" size="10" class="date" name="end_date-day" placeholder="Date" value="${context/end/date}"/>
-                                <input type="time" tal:attributes="disabled read_only" size="10" class="date" name="end_date-time" placeholder="Time" value="${context/end/time}"/>
-                            </fieldset>
-                    </fieldset>
+            <metal:task_fields use-macro="context/content_macros/event_fields"/>
 
-                    <label class="timezone">Timezone
-                        <select class="timezone" tal:attributes="disabled read_only" >
-                            <option data-timezone-id="80" gmt-adjustment="GMT+12:00" data-use-daylight-time="1" value="12">(GMT+12:00) Auckland, Wellington</option>
-                            <option data-timezone-id="81" gmt-adjustment="GMT+12:00" data-use-daylight-time="0" value="12">(GMT+12:00) Fiji, Kamchatka, Marshall Is.</option>
-                            <option data-timezone-id="82" gmt-adjustment="GMT+13:00" data-use-daylight-time="0" value="13">(GMT+13:00) Nuku'alofa</option>
-                        </select>
-                    </label>
-
-                </fieldset>
-                    <label class="invitees">Invitees
-                        <input class="pat-autosuggest users" tal:attributes="disabled read_only" data-pat-autosuggest="words:EPP LDAP Administrator &lt;admin@staralliance.com&gt;,Plone LDAP Administrator &lt;admin@staralliance.com&gt;,Administrator StarDesk &lt;webworkadmin@staralliance.com&gt;,"
-                            data-pat-autosuggest-classes='{"Brett Anderson &lt;brett.anderson@united.com&gt;": ["undecided"], "Steffen Harbarth &lt;steffen.harbarth@dlh.de&gt;": ["confirmed"], "Julie Pepiot &lt;julie.pepiot@swiss.com&gt;": ["tentative"], "Lillian Lautzenheiser-Page &lt;lillian.lautz-page@ual.com&gt;": ["declined"], "G7 &lt;g7@world.com&gt;": ["group"]}'>
-
-
-                        <span class="legend">
-                            <dfn class="undecided">Undecided</dfn>
-                            <dfn class="confirmed">Confirmed</dfn>
-                            <dfn class="tentative">Tentative</dfn>
-                            <dfn class="declined">Declined</dfn>
-                        </span>
-
-                    </label>
-
-                <label class="attachments">Attached documents from this workspace
-                    <input tal:attributes="disabled read_only" class="pat-autosuggest documents" data-pat-autosuggest="words:2013 Outline,Bag tag regulations,Baggage rules,First delivery presentation,IATA standards 2012,Initial competitive analysis,Market segmentation,Minutes kick-off meeting,Out of the box,Priority bag process,Priority bag tag specification,Waste not want not" type="text" value="Boardbook, Waste not want not">
-                </label>
-
-            </fieldset>
         </div>
     </div>
 </form>

--- a/src/ploneintranet/theme/content/templates/event_view.pt
+++ b/src/ploneintranet/theme/content/templates/event_view.pt
@@ -15,100 +15,100 @@
                     workspace_id python:workspace.id;
                     read_only python:not view.can_edit">
 
-    <h1 id="workspace-name">
-        <!-- Next link is to lead to landing state of current workspace -->
-        <a href="${workspace_url}" tal:content="workspace/Title">Title</a>
-    </h1>
+        <h1 id="workspace-name">
+            <!-- Next link is to lead to landing state of current workspace -->
+            <a href="${workspace_url}" tal:content="workspace/Title">Title</a>
+        </h1>
 
-    <div class="${workspace_id} dark-theme" id="application-body">
+        <div class="${workspace_id} dark-theme" id="application-body">
 
-        <div id="document-body">
-            <form class="document pat-inject" method="POST" action="${context/absolute_url}/view#meta">
-    <div class="metadata pat-bumper" id="meta">
-        <div class="meta-bar">
-            <h1 class="doc-title" id="document-title" tal:content="context/title">
-                Traces through Time data workshop
-            </h1>
-            <!-- Next link should be populated with the link back to the parent. Used for small screen and accessibilty -->
-            <button class="pat-switch back-to-parent icon-left-open" data-pat-switch="body focus-* focus-sidebar">${python:context.__parent__.title}</button>
-            <input type="text" tal:attributes="disabled read_only" placeholder="Document title" class="doc-title pat-content-mirror" data-pat-content-mirror="target: #document-title" value="${context/title}" />
-            <div class="quick-functions">
-                <a href="#confirm-delete" class="icon-trash iconified" title="Delete this event">
-                    Delete
-                </a>
-                <a href="/feedback/panel-event-attachments.html#content" class="icon-attach iconified pat-tooltip" data-pat-tooltip="source: ajax" title="Attach documents">
-                    Attachments
-                </a>
-                <a class="icon-info-circle meta-data-toggle iconified" title="Show extra metadata fields">Toggle extra metadata</a>
-                <!-- <a href="" class="icon-copy iconified" title="Copy this document">
-                    Copy
-                </a>
-                <a href="#share-panel" class="icon-export iconified pat-modal" title="Share this document">
-                    Share
-                </a>
-                <a class="icon-info-circle meta-data-toggle iconified" title="Show extra metadata fields">Toggle extra metadata</a>
-                <fieldset class="pat-subform pat-autosubmit pat-inject" data-pat-inject="target: #document-content::before; url: /feedback/banner-notifications.html; source: #workflow-state-changed::element;">
-                    <label class="pat-select bare" title="Change the workflow state">
-                        <select>
-                            <option>Private</option>
-                            <option>Public</option>
-                            <option>Members</option>
-                            <option>Pending</option>
-                            <option>Logged in</option>
-                            <option>Internal</option>
-                            <option>External</option>
-                        </select>
-                    </label>
-                </fieldset -->
-                <!--
- -->
-                <button type="submit" tal:condition="not:read_only" class="icon-floppy" title="Save this document">Save</button>
+            <div id="document-body">
+                <form class="document pat-inject" method="POST" action="${context/absolute_url}/view#document-body">
+                    <div class="metadata pat-bumper" id="meta">
+                        <div class="meta-bar">
+                            <h1 class="doc-title" id="document-title" tal:content="context/title">
+                                Traces through Time data workshop
+                            </h1>
+                            <!-- Next link should be populated with the link back to the parent. Used for small screen and accessibilty -->
+                            <button class="pat-switch back-to-parent icon-left-open" data-pat-switch="body focus-* focus-sidebar">${python:context.__parent__.title}</button>
+                            <input type="text" name="title" tal:attributes="disabled read_only" placeholder="Document title" class="doc-title pat-content-mirror" data-pat-content-mirror="target: #document-title" value="${context/title}" />
+                            <div class="quick-functions">
+                                <a href="#confirm-delete" class="icon-trash iconified" title="Delete this event">
+                                    Delete
+                                </a>
+                                <a href="/feedback/panel-event-attachments.html#content" class="icon-attach iconified pat-tooltip" data-pat-tooltip="source: ajax" title="Attach documents">
+                                    Attachments
+                                </a>
+                                <a class="icon-info-circle meta-data-toggle iconified" title="Show extra metadata fields">Toggle extra metadata</a>
+                                <!-- <a href="" class="icon-copy iconified" title="Copy this document">
+                                    Copy
+                                </a>
+                                <a href="#share-panel" class="icon-export iconified pat-modal" title="Share this document">
+                                    Share
+                                </a>
+                                <a class="icon-info-circle meta-data-toggle iconified" title="Show extra metadata fields">Toggle extra metadata</a>
+                                <fieldset class="pat-subform pat-autosubmit pat-inject" data-pat-inject="target: #document-content::before; url: /feedback/banner-notifications.html; source: #workflow-state-changed::element;">
+                                    <label class="pat-select bare" title="Change the workflow state">
+                                        <select>
+                                            <option>Private</option>
+                                            <option>Public</option>
+                                            <option>Members</option>
+                                            <option>Pending</option>
+                                            <option>Logged in</option>
+                                            <option>Internal</option>
+                                            <option>External</option>
+                                        </select>
+                                    </label>
+                                </fieldset -->
+                                <!--
+                 -->
+                                <button type="submit" tal:condition="not:read_only" class="icon-floppy" title="Save this document">Save</button>
 
+                            </div>
+                        </div>
+                        <fieldset class="pat-collapsible open meta-extra" data-pat-collapsible="trigger: .meta-data-toggle" id="meta-extra">
+                            <!-- <fieldset class="bar">
+                                <input type="text" class="pat-autosuggest" placeholder="Tags" />
+                            </fieldset> -->
+                            <fieldset class="bar description">
+                                <textarea name="description" tal:attributes="disabled read_only" rows="8" title="Description" placeholder="Description">${context/description}</textarea>
+                             </fieldset>
+
+                            <!-- <fieldset class="bar versioning">
+                                <label>
+                                    <input type="checkbox" name="cmfeditions_save_new_version" id="cmfeditions_save_new_version" /> Save a new version
+                                </label>
+                                <fieldset class="condensed pat-depend new-version-details" data-pat-depend="cmfeditions_save_new_version">
+                                    <label>Upload a new file
+                                        <input type="file" name="file_file">
+                                    </label>
+                                    <label>
+                                        <textarea placeholder="Change notes" name="cmfeditions_version_comment" id="cmfeditions_version_comment" cols="80" rows="4"></textarea>
+                                    </label>
+
+                                    <button type="submit" name="submit" value="submit" class="submit">Save this version</button>
+                                </fieldset>
+                            </fieldset> -->
+                        </fieldset>
+                    </div>
+                    <div id="document-content">
+                        <div class="document event-details">
+
+                            <metal:task_fields use-macro="context/content_macros/event_fields"/>
+
+                        </div>
+                    </div>
+                </form>
             </div>
-        </div>
-        <fieldset class="pat-collapsible open meta-extra" data-pat-collapsible="trigger: .meta-data-toggle" id="meta-extra">
-            <!-- <fieldset class="bar">
-                <input type="text" class="pat-autosuggest" placeholder="Tags" />
-            </fieldset> -->
-            <fieldset class="bar description">
-                <textarea name="description" tal:attributes="disabled read_only" rows="8" title="Description" placeholder="Description">${context/description}</textarea>
-             </fieldset>
 
-            <!-- <fieldset class="bar versioning">
-                <label>
-                    <input type="checkbox" name="cmfeditions_save_new_version" id="cmfeditions_save_new_version" /> Save a new version
-                </label>
-                <fieldset class="condensed pat-depend new-version-details" data-pat-depend="cmfeditions_save_new_version">
-                    <label>Upload a new file
-                        <input type="file" name="file_file">
-                    </label>
-                    <label>
-                        <textarea placeholder="Change notes" name="cmfeditions_version_comment" id="cmfeditions_version_comment" cols="80" rows="4"></textarea>
-                    </label>
-
-                    <button type="submit" name="submit" value="submit" class="submit">Save this version</button>
-                </fieldset>
-            </fieldset> -->
-        </fieldset>
-    </div>
-    <div id="document-content">
-        <div class="document event-details">
-
-            <metal:task_fields use-macro="context/content_macros/event_fields"/>
+            <aside class="sidebar left tagging-off" id="sidebar" data-tile="plone/new-workspace/@@sidebar.default" tal:define="container context/@@plone_context_state/folder" tal:attributes="data-tile string:${container/absolute_url}/@@sidebar.default">
+            </aside>
 
         </div>
-    </div>
-</form>
-        </div>
 
-<aside class="sidebar left tagging-off" id="sidebar" data-tile="plone/new-workspace/@@sidebar.default" tal:define="container context/@@plone_context_state/folder" tal:attributes="data-tile string:${container/absolute_url}/@@sidebar.default">
-</aside>
-
-    </div>
-
-<nav class="navigation workspace-tabs" id="workspace-tabs" data-tile="./@@workspace.tabs.tile" tal:attributes="data-tile string:${workspace_url}/@@workspace.tabs.tile" />
+        <nav class="navigation workspace-tabs" id="workspace-tabs" data-tile="./@@workspace.tabs.tile" tal:attributes="data-tile string:${workspace_url}/@@workspace.tabs.tile" />
 
 
-        </metal:content>
-    </body>
+    </metal:content>
+</body>
 </html>

--- a/src/ploneintranet/workspace/browser/add_content.py
+++ b/src/ploneintranet/workspace/browser/add_content.py
@@ -4,6 +4,7 @@ from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from plone import api
 from ploneintranet.theme import _
 from ploneintranet.theme.utils import dexterity_update
+from ploneintranet.workspace.utils import parent_workspace
 from zope.event import notify
 from zope.lifecycleevent import ObjectModifiedEvent
 
@@ -62,3 +63,13 @@ class AddContent(BrowserView):
 class AddFolder(AddContent):
 
     template = ViewPageTemplateFile('templates/add_folder.pt')
+
+
+class AddEvent(AddContent):
+
+    template = ViewPageTemplateFile('templates/add_event.pt')
+
+    def redirect(self, url):
+        workspace = parent_workspace(self.context)
+        return self.request.response.redirect(workspace.absolute_url() +
+                                              '#workspace-events')

--- a/src/ploneintranet/workspace/browser/configure.zcml
+++ b/src/ploneintranet/workspace/browser/configure.zcml
@@ -19,6 +19,13 @@
       />
 
   <browser:page
+      name="content_macros"
+      for="*"
+      permission="zope2.View"
+      template="templates/content_macros.pt"
+      />
+
+  <browser:page
       name="transfer"
       for="ploneintranet.workspace.workspacefolder.IWorkspaceFolder"
       class=".forms.TransferMembershipForm"
@@ -60,6 +67,13 @@
       for="Products.CMFCore.interfaces.IFolderish"
       class=".add_content.AddFolder"
       template="templates/add_folder.pt"
+      permission="cmf.AddPortalContent"
+      />
+
+  <browser:page
+      name="add_event"
+      for="Products.CMFCore.interfaces.IFolderish"
+      class=".add_content.AddEvent"
       permission="cmf.AddPortalContent"
       />
 

--- a/src/ploneintranet/workspace/browser/templates/add_event.pt
+++ b/src/ploneintranet/workspace/browser/templates/add_event.pt
@@ -1,0 +1,36 @@
+<div id="content">
+  <h1>
+    Create event
+  </h1>
+  <form method="POST" action="#" tal:attributes="action request/URL" class="wizard-box pat-inject" data-pat-inject="source: #document-body; target: #document-body && source: #workspace-documents; target: #workspace-documents">
+    <div class="panel-body">
+
+      <fieldset class="icon-tabs">
+        <label class="icon-ok-circle">
+          <input checked="checked" name="portal_type" value="Event" type="radio" /> Event
+        </label>
+      </fieldset>
+      <fieldset class="vertical">
+        <input type="text" name="title" placeholder="Event title" autofocus />
+        <br/>
+        <textarea name="description" placeholder="Enter a description of the event" rows="6"></textarea>
+      </fieldset>
+
+      <fieldset class="vertical"
+                tal:define="workspace context/acquire_workspace;
+                            workspace_url context/absolute_url;">
+        <metal:task_fields use-macro="context/content_macros/event_fields"/>
+      </fieldset>
+
+    </div>
+    <div class="buttons panel-footer">
+      <span tal:replace="structure context/@@authenticator/authenticator"/>
+      <button id="form-buttons-create" name="form.buttons.create" type="submit" value="Create" class="icon-ok-circle close-panel focus">
+        Create
+      </button>
+      <button id="form-buttons-cancel" name="form.buttons.cancel" type="button" value="Cancel" class="icon-cancel-circle close-panel">
+        Cancel
+      </button>
+    </div>
+  </form>
+</div>

--- a/src/ploneintranet/workspace/browser/templates/content_macros.pt
+++ b/src/ploneintranet/workspace/browser/templates/content_macros.pt
@@ -1,0 +1,77 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      i18n:domain="plone">
+  <body>
+
+    <metal:task_fields define-macro="task_fields">
+    </metal:task_fields>
+
+    <metal:task_fields define-macro="event_fields">
+      <fieldset class="vertical" tal:define="read_only python:False">
+                <label class="location">
+                    Location <input name="location" tal:attributes="disabled read_only" type="text" value="" tal:attributes="value context/location | nothing">
+                </label>
+                <br>
+                <label class="organiser">
+                    Organiser <input tal:attributes="disabled read_only" class="pat-autosuggest users" data-pat-autosuggest="" type="text" value="" tal:attributes="value context/organiser | nothing">
+                </label>
+                <br>
+                <fieldset class="pat-checklist options">
+                    <label>
+                        <input tal:attributes="checked python:context.whole_day" tal:attributes="disabled read_only" type="checkbox"> All day event
+                    </label>
+                    <br>
+                    <label>
+                        <input type="checkbox" tal:attributes="disabled read_only" > Visible on other calendars
+                    </label>
+                </fieldset>
+                <br>
+                <fieldset class="date-time">
+                    <fieldset class="row">
+                            <fieldset class="group six columns">
+                                <legend>From</legend>
+                                <input type="date" tal:attributes="disabled read_only" size="10" class="date" name="start-day" placeholder="Date" value="" />
+                                <input type="time" tal:attributes="disabled read_only" size="10" class="date" name="start-time" placeholder="Time" value="" />
+                            </fieldset>
+
+                            <fieldset class="group six columns">
+                                <legend>To</legend>
+                                <input type="date" tal:attributes="disabled read_only" size="10" class="date" name="end_date-day" placeholder="Date" value=""/>
+                                <input type="time" tal:attributes="disabled read_only" size="10" class="date" name="end_date-time" placeholder="Time" value=""/>
+                            </fieldset>
+                    </fieldset>
+
+                    <label class="timezone">Timezone
+                        <select class="timezone" tal:attributes="disabled read_only" >
+                            <option data-timezone-id="80" gmt-adjustment="GMT+12:00" data-use-daylight-time="1" value="12">(GMT+12:00) Auckland, Wellington</option>
+                            <option data-timezone-id="81" gmt-adjustment="GMT+12:00" data-use-daylight-time="0" value="12">(GMT+12:00) Fiji, Kamchatka, Marshall Is.</option>
+                            <option data-timezone-id="82" gmt-adjustment="GMT+13:00" data-use-daylight-time="0" value="13">(GMT+13:00) Nuku'alofa</option>
+                        </select>
+                    </label>
+
+                </fieldset>
+                    <label class="invitees">Invitees
+                        <input class="pat-autosuggest users" tal:attributes="disabled read_only" data-pat-autosuggest=""
+                            data-pat-autosuggest-classes=''>
+
+
+                        <span class="legend">
+                            <dfn class="undecided">Undecided</dfn>
+                            <dfn class="confirmed">Confirmed</dfn>
+                            <dfn class="tentative">Tentative</dfn>
+                            <dfn class="declined">Declined</dfn>
+                        </span>
+
+                    </label>
+
+                <label class="attachments">Attached documents from this workspace
+                    <input tal:attributes="disabled read_only" class="pat-autosuggest documents" data-pat-autosuggest="" type="text" value="">
+                </label>
+
+            </fieldset>
+    </metal:task_fields>
+
+  </body>
+</html>

--- a/src/ploneintranet/workspace/browser/tiles/templates/sidebar.pt
+++ b/src/ploneintranet/workspace/browser/tiles/templates/sidebar.pt
@@ -259,7 +259,7 @@
         </tal:no-tasks>
         <tal:tasks condition="tasks">
           <form action="#"
-            tal:define="ws view/my_workspace"
+            tal:define="ws view/workspace"
             tal:attributes="action string:${ws/absolute_url}/@@sidebar.default"
             method="post" class="pat-autosubmit pat-inject" data-pat-inject="target: #workspace-settings > .tabs-content; source: #workspace-settings > .tabs-content && target: #document-content::before; source: .sidebar-status-message">
             <fieldset class="object-list tasks pat-checklist">
@@ -285,7 +285,12 @@
         </tal:tasks>
     </div>
 
-    <div id="workspace-events" tal:define="events view/events">
+    <div id="workspace-events" tal:define="events view/events; ws view/workspace">
+      <div class="button-bar functions" id="-functions">
+        <div class="quick-functions">
+            <a title="Create new event" href="/panel-create-event.html#document-content" class="create-document pat-modal icon-doc-text" data-pat-modal="class: large" data-pat-inject="source:#content" tal:attributes="href string:${ws/absolute_url}/add_event">Create event</a>
+        </div>
+      </div>
       <div class="content">
 
         <div class="pat-collapsible" data-pat-collapsible="store: local" id="upcoming-events">


### PR DESCRIPTION
This is a cleanup of the stub to handle events. The markup is now in sync with the prototype and adding events is hooked up. This is a necessary prerequisite to start working on making the autocompleter and date picker work on the event form.
