### PR TITLE
Use zest.releaser entry point to include more files in release.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -128,5 +128,8 @@ setup(name='ploneintranet',
       # -*- Entry points: -*-
       [z3c.autoinclude.plugin]
       target = plone
+
+      [zest.releaser.releaser.after_checkout]
+      add_files_to_release = ploneintranet.core.release:add_files_to_release
       """,
       )

--- a/src/ploneintranet/core/release.py
+++ b/src/ploneintranet/core/release.py
@@ -6,6 +6,10 @@ logger = logging.getLogger('ploneintranet.core.release')
 
 def add_files_to_release(data):
     """zest.releaser entry point for adding files to the release."""
+    if data.get('name') != 'ploneintranet':
+        # This entry point should only do something when releasing the
+        # ploneintranet package.
+        return
     # cd to the directory that has the fresh tag checkout and use the
     # Makefile to fetch the release bundles.
     logger.info('Making fetchrelease call in tag checkout.')

--- a/src/ploneintranet/core/release.py
+++ b/src/ploneintranet/core/release.py
@@ -1,0 +1,14 @@
+import logging
+from zest.releaser.utils import execute_command
+
+logger = logging.getLogger('ploneintranet.core.release')
+
+
+def add_files_to_release(data):
+    """zest.releaser entry point for adding files to the release."""
+    # cd to the directory that has the fresh tag checkout and use the
+    # Makefile to fetch the release bundles.
+    logger.info('Making fetchrelease call in tag checkout.')
+    res = execute_command('cd {0} && make fetchrelease'.format(data['tagdir']))
+    print(res)
+    logger.info('fetchrelease done.')


### PR DESCRIPTION
In the 0.1 release, ploneintranet/theme/static/generated directory has no bundles directory.
See https://groups.io/org/groupsio/ploneintranet-dev/message/45
This fixes it. After merging this, you need to run bin/buildout so the new entry point gets picked up.
