### PR TITLE
plone.belowcontent: don't register PI.simplesharing.share

### DIFF
--- a/src/ploneintranet/simplesharing/configure.zcml
+++ b/src/ploneintranet/simplesharing/configure.zcml
@@ -23,15 +23,6 @@
       class=".forms.SimpleSharing"
       />
 
-  <browser:viewlet
-      name="ploneintranet.simplesharing.share"
-      for="Products.CMFCore.interfaces.IContentish"
-      manager="plone.app.layout.viewlets.interfaces.IBelowContent"
-      class=".viewlets.SimpleSharingViewlet"
-      permission="cmf.ModifyPortalContent"
-      view="plone.app.layout.globals.interfaces.IViewView"
-      />
-
   <browser:resourceDirectory
       name="ploneintranet.simplesharing.js"
       directory="js"


### PR DESCRIPTION
A Share link is rendered in plone.belowcontent via the main_template,
this appears on /workspaces/ although it doesn't make much sense to
share such a listing page and it's not in proto. There is a placeholder
for sharing documents in the metadata bar so I doubt we ever want to
include a share button in the page footer.
