### PR TITLE
Fix document preview page numbers

### DIFF
--- a/src/ploneintranet/theme/content/templates/document_view.pt
+++ b/src/ploneintranet/theme/content/templates/document_view.pt
@@ -64,7 +64,7 @@
               </article>
 
               <article class="document preview" tal:condition="number_of_file_previews" tal:define="number_of_file_previews view/number_of_file_previews">
-                <tal:previews tal:repeat="preview python:range(number_of_file_previews)">
+                <tal:previews tal:repeat="preview python:range(1, number_of_file_previews+1)">
                   <img src="${python:context.absolute_url()}/docconv_image_preview.jpg?page=${preview}" />
                 </tal:previews>
               </article>


### PR DESCRIPTION
The page numbers start at 1. Previously this page would show two copies of the first page and exclude the final page.
