### PR TITLE
Don't over-cache the workspace lookup

### DIFF
--- a/src/ploneintranet/workspace/browser/workspace.py
+++ b/src/ploneintranet/workspace/browser/workspace.py
@@ -1,6 +1,6 @@
 from Products.Five import BrowserView
 from plone import api
-from plone.memoize.forever import memoize
+from plone.memoize.view import memoize
 from zope.interface import implements
 from plone.app.blocks.interfaces import IBlocksTransformEnabled
 from ploneintranet.workspace.interfaces import IWorkspaceState


### PR DESCRIPTION
This is an attempt to fix sporadic test failures where the workspace would be 'None' during tests, despite being inside a workspace.
