### PR TITLE
Add a diazo rule for 'login_success' page

### DIFF
--- a/src/ploneintranet/theme/static/rules.xml
+++ b/src/ploneintranet/theme/static/rules.xml
@@ -72,7 +72,8 @@
   </rules>
 
   <rules css:if-content="body.template-dashboard-html, 
-                         body.template-workspaces-html">
+                         body.template-workspaces-html,
+                         body.template-login_success">
     <theme href="generated/empty-home.html" />
     <append css:content-children="#portal-column-content" css:theme="div.container" />
   </rules>


### PR DESCRIPTION
Avoids seeing 'missing design' message after login on every robot test.
