### PR TITLE
Show relative dates/times: 'last month', 'just now'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(name='ploneintranet',
       install_requires=[
           'setuptools',
           # -*- Extra requirements: -*-
+          'arrow',
           'requests',
           'loremipsum',
           'slc.docconv',

--- a/soft-versions.cfg
+++ b/soft-versions.cfg
@@ -4,6 +4,7 @@
 # too much fallout.
 # Hard version pins are controlled by versions.cfg
 [versions]
+arrow = 0.5.4
 MarkupSafe = 0.23
 PyYAML = 3.11
 Twisted = 15.2.1

--- a/src/ploneintranet/activitystream/browser/activity.py
+++ b/src/ploneintranet/activitystream/browser/activity.py
@@ -6,6 +6,8 @@ from plone import api
 from plone.memoize.view import memoize
 from ploneintranet.core import ploneintranetCoreMessageFactory as _
 
+import arrow
+
 
 class ActivityView(BrowserView):
     ''' This view renders an activity
@@ -91,21 +93,11 @@ class ActivityView(BrowserView):
     @property
     @memoize
     def date(self):
-        ''' The date of our context object
+        ''' The relative date of our context object e.g. '2 minutes ago',
+        'last year'
         '''
-        # We have to transform Python datetime into Zope DateTime
-        # before we can call toLocalizedTime.
-        time = self.context.raw_date
-        if hasattr(time, 'isoformat'):
-            time = DateTime(self.context.raw_date.isoformat())
+        lang = self.request.get('LANGUAGE', 'en')
+        arrow_date = arrow.get(self.context.raw_date)
+        relative_date = arrow_date.humanize(locale=lang)
+        return relative_date
 
-        if DateTime().Date() == time.Date():
-            time_only = True
-        else:
-            # time_only=False still returns time only
-            time_only = None
-        return self.toLocalizedTime(
-            time,
-            long_format=True,
-            time_only=time_only
-        )

--- a/src/ploneintranet/workspace/browser/tiles/templates/workspaces.pt
+++ b/src/ploneintranet/workspace/browser/tiles/templates/workspaces.pt
@@ -20,7 +20,7 @@
                                 </strong>
                                 <span class="verb">${activity/verb}</span>
                                 <strong class="object" tal:content="structure activity/object">Object</strong>
-                                <time class="datestamp" tal:content="activity/time/title">2 Hours ago</time>
+                                <time class="datestamp" tal:content="python:view.relative_date(activity['date'])">2 Hours ago</time>
                             </p>
                         </tal:activities>
                     </a>

--- a/src/ploneintranet/workspace/browser/tiles/workspaces.py
+++ b/src/ploneintranet/workspace/browser/tiles/workspaces.py
@@ -8,6 +8,8 @@ from ploneintranet.core import ploneintranetCoreMessageFactory as _
 from zope.component import queryUtility
 from zExceptions import Unauthorized
 
+import arrow
+
 
 class WorkspacesTile(Tile):
 
@@ -24,6 +26,12 @@ class WorkspacesTile(Tile):
         """ The list of my workspaces
         """
         return my_workspaces(self.context)
+
+    def relative_date(self, date):
+        lang = self.request.get('LANGUAGE', 'en')
+        arrow_date = arrow.get(date)
+        relative_date = arrow_date.humanize(locale=lang)
+        return relative_date
 
 
 def my_workspaces(context):
@@ -74,9 +82,7 @@ def get_workspace_activities(brain, limit=1):
             subject=creator,
             verb=_(u'posted'),
             object=item.text,
-            time={
-                'datetime': item.date.strftime('%Y-%m-%d'),
-                'title': item.date.strftime('%d %B %Y, %H:%M')}
+            date=item.date,
         ))
     return results
 

--- a/src/ploneintranet/workspace/tests/test_tiles.py
+++ b/src/ploneintranet/workspace/tests/test_tiles.py
@@ -40,10 +40,7 @@ class TestTiles(BaseViewTest):
             {
                 'object': 'Proposal draft V1.0 # This is a mock!!!',
                 'subject': 'charlotte_holzer',
-                'time': {
-                    'datetime': '2008-02-14',
-                    'title': '14 February 2008, 18:43'
-                },
+                'date': DateTime('2008/02/14 18:43:00 UTC'),
                 'verb': 'posted'
             }
         )


### PR DESCRIPTION
This adds a dependency on the arrow library [1] which supports "humanized" relative dates in many languages.
1. https://arrow.readthedocs.org 
