### PR TITLE
Encode query string into the search results

### DIFF
--- a/src/ploneintranet/search/browser/templates/search_results.pt
+++ b/src/ploneintranet/search/browser/templates/search_results.pt
@@ -95,7 +95,12 @@
 				<a href="@@search?SearchableText=${corrected}" 
 				   tal:content="corrected"></a>?
 			    </p>
-			    <dl class="search-results">
+			    <!-- We encode the search string into the results div
+				 so that we can check when the search results 
+				 have been loaded via ajax
+			      -->
+			    <dl class="search-results"
+				data-search-string="${request/QUERY_STRING|nothing}">
 				<!-- One hard coded example of a post as a search result:
 				<dt class="title user-post">
 				    <a href=""><span class="author">Joan Baker</span> <em class="action">posted</em> <time>9 minutes ago</time></a>

--- a/src/ploneintranet/suite/tests/acceptance/search.robot
+++ b/src/ploneintranet/suite/tests/acceptance/search.robot
@@ -64,11 +64,8 @@ I can follow the search result ${SEARCH_RESULT_TITLE}
 I can exclude content of type ${CONTENT_TYPE}
     Unselect Checkbox  css=input[type="checkbox"][value="${CONTENT_TYPE}"]
     Select From List By Value  css=select[name="created"]  today
-    Wait Until Element is Visible  css=.search-results
+    Wait Until Element is Visible  css=dl.search-results[data-search-string*="created=today"]
 
 I can set the date range to ${DATE_RANGE_VALUE}
     Select From List By Value  css=select[name="created"]  ${DATE_RANGE_VALUE}
-    # We currently do this twice to get around timing issues with
-    # the ajax request that is generated
-    Select From List By Value  css=select[name="created"]  ${DATE_RANGE_VALUE}
-    Wait Until Element is Visible  css=.search-results
+    Wait Until Element is Visible  css=dl.search-results[data-search-string*="created=${DATE_RANGE_VALUE}"]


### PR DESCRIPTION
This allows us to check when AJAX searches have finished loading (primary use case: robot tests)
