### PR TITLE
Workspace security fixing

### DIFF
--- a/docs/development/testing.rst
+++ b/docs/development/testing.rst
@@ -165,7 +165,7 @@ Workspaces
 
 The top-level workspace container with the id "workspaces" is created on install by the setup-handler of the workspace package.
 
-The setup-handler of the suite creates three workspaces with the following settings:
+The setup-handler of the suite creates four workspaces with the following settings:
 
 * "Open Market Committee"
 
@@ -193,3 +193,10 @@ The setup-handler of the suite creates three workspaces with the following setti
   * **Member**: allan_neece (and others)
   * **Non-Member**: alice_lindstrom
 
+* "Service announcements"
+
+  * **External visibility**: Open
+  * **Participation policy**: Consumers
+  * **Admin**: christian_stoney
+  * **Member**: allan_neece (and others)
+  * **Non-Member**: alice_lindstrom

--- a/docs/development/testing.rst
+++ b/docs/development/testing.rst
@@ -165,7 +165,7 @@ Workspaces
 
 The top-level workspace container with the id "workspaces" is created on install by the setup-handler of the workspace package.
 
-The setup-handler of the suite creates two workspaces with the following settings:
+The setup-handler of the suite creates three workspaces with the following settings:
 
 * "Open Market Committee"
 
@@ -181,6 +181,14 @@ The setup-handler of the suite creates two workspaces with the following setting
 
   * **External visibility**: Private
   * **Participation policy**: Producers
+  * **Admin**: christian_stoney
+  * **Member**: allan_neece (and others)
+  * **Non-Member**: alice_lindstrom
+
+* "Shareholder information"
+
+  * **External visibility**: Private
+  * **Participation policy**: Consumers
   * **Admin**: christian_stoney
   * **Member**: allan_neece (and others)
   * **Non-Member**: alice_lindstrom

--- a/src/ploneintranet/activitystream/browser/prototype/post.html
+++ b/src/ploneintranet/activitystream/browser/prototype/post.html
@@ -70,16 +70,16 @@
     <!--a href="#" class="share pat-modal">Share <sup class="counter">(8)</sup></a-->
     <form tal:replace="structure view/toggle_like" />
   </div>
-  <tal:commentable condition="view/statusupdate_view/commentable">
-      <div class="comments"
-           id="${string:comments-${thread_id}}"
-           talattributes="id string:comments-${thread_id}">
-        <div tal:attributes="id string:comment-trail-${thread_id}">
-          <tal:loop
-              tal:repeat="comment view/statusupdate_view/comment_views"
-              tal:content="structure comment"
-          />
-        </div>
+  <div class="comments"
+       id="${string:comments-${thread_id}}"
+       talattributes="id string:comments-${thread_id}">
+    <div tal:attributes="id string:comment-trail-${thread_id}">
+      <tal:loop
+          tal:repeat="comment view/statusupdate_view/comment_views"
+          tal:content="structure comment"
+      />
+    </div>
+    <tal:commentable condition="view/statusupdate_view/commentable">
         <tal:define define="
           newpostbox_view nocall:view/newpostbox_view;
           form_id string:comment_box_${thread_id};
@@ -91,8 +91,8 @@
         ">
           <metal:block use-macro="here/@@update-social.html/main" />
         </tal:define>
-      </div>
-  </tal:commentable>
+    </tal:commentable>
+  </div>
 
 </div>
 </metal:macro>

--- a/src/ploneintranet/microblog/statuscontainer.py
+++ b/src/ploneintranet/microblog/statuscontainer.py
@@ -214,8 +214,12 @@ class BaseStatusContainer(Persistent, Explicit):
 
     def _check_add_permission(self, status):
         permission = "Plone Social: Add Microblog Status Update"
-        # FIXME use StatusUpdate.security_context
-        check_context = status.context or self  # workspace or tool
+        try:
+            check_context = status.context
+            if check_context is None:
+                check_context = self  # Fall back to tool
+        except AttributeError:
+            raise Unauthorized("You do not have permission <%s>" % permission)
         if not api.user.has_permission(
                 permission,
                 obj=check_context):

--- a/src/ploneintranet/microblog/statusupdate.py
+++ b/src/ploneintranet/microblog/statusupdate.py
@@ -94,7 +94,12 @@ class StatusUpdate(Persistent):
     def context(self):
         if not self.context_uuid:
             return None
-        return uuidToObject(self._context_uuid)
+        context = uuidToObject(self._context_uuid)
+        if context is None:
+            raise AttributeError(
+                "Microblog context with uuid {0} could not be "
+                "retrieved".format(self.context_uuid))
+        return context
 
 # FIXME distinguish between:
 # - context = context object (can be a page)

--- a/src/ploneintranet/suite/setuphandlers.py
+++ b/src/ploneintranet/suite/setuphandlers.py
@@ -599,6 +599,33 @@ def testing(context):
               'type': 'Document',
               'state': 'published'}]
          },
+        {'title': u'Service announcements',
+         'description': u'Public service announcements can be found here.',
+         'transition': 'make_open',
+         'participant_policy': 'consumers',
+         'members': {'allan_neece': [u'Members'],
+                     'christian_stoney': [u'Admins', u'Members'],
+                     'francois_gast': [u'Members'],
+                     'jaimie_jacko': [u'Members'],
+                     'fernando_poulter': [u'Members'],
+                     'jesse_shaik': [u'Members'],
+                     'jorge_primavera': [u'Members'],
+                     'silvio_depaoli': [u'Members'],
+                     'kurt_weissman': [u'Members'],
+                     'esmeralda_claassen': [u'Members'],
+                     'rosalinda_roache': [u'Members'],
+                     'guy_hackey': [u'Members'],
+                     },
+         'contents':
+            [{'title': 'Terms and conditions',
+              'description': 'A document just for testing',
+              'type': 'Document',
+              'state': 'published'},
+             {'title': 'Customer satisfaction survey',
+              'description': 'A private document',
+              'type': 'Document'},
+             ]
+         },
     ]
     create_workspaces(workspaces)
 

--- a/src/ploneintranet/suite/setuphandlers.py
+++ b/src/ploneintranet/suite/setuphandlers.py
@@ -573,7 +573,32 @@ def testing(context):
             [{'title': 'Test Document',
               'description': 'A document just for testing',
               'type': 'Document'}]
-         }
+         },
+        {'title': u'Shareholder information',
+         'description': u'"Shareholder information" contains all documents, '
+            u'papers and diagrams for keeping shareholders informed about the '
+            u'current state of affairs.',
+         'transition': 'make_private',
+         'participant_policy': 'consumers',
+         'members': {'allan_neece': [u'Members'],
+                     'christian_stoney': [u'Admins', u'Members'],
+                     'francois_gast': [u'Members'],
+                     'jaimie_jacko': [u'Members'],
+                     'fernando_poulter': [u'Members'],
+                     'jesse_shaik': [u'Members'],
+                     'jorge_primavera': [u'Members'],
+                     'silvio_depaoli': [u'Members'],
+                     'kurt_weissman': [u'Members'],
+                     'esmeralda_claassen': [u'Members'],
+                     'rosalinda_roache': [u'Members'],
+                     'guy_hackey': [u'Members'],
+                     },
+         'contents':
+            [{'title': 'Test Document',
+              'description': 'A document just for testing',
+              'type': 'Document',
+              'state': 'published'}]
+         },
     ]
     create_workspaces(workspaces)
 

--- a/src/ploneintranet/suite/tests/acceptance/workspace.robot
+++ b/src/ploneintranet/suite/tests/acceptance/workspace.robot
@@ -139,6 +139,9 @@ Member cannot publish a document in a Producers workspace
      When I submit the content item
      Then I cannot publish the content item
 
+Member cannot create content in a Consumers workspace
+    Given I am in a Consumers workspace as a workspace member
+     Then I cannot create a new document
 
 Site Administrator can add example user as member of workspace
     Given I'm logged in as a 'Site Administrator'
@@ -331,6 +334,13 @@ I can create a new document
     Input Text  css=.panel-content input[name=title]  text=${title}
     Click Button  css=#form-buttons-create
     Wait Until Page Contains Element  css=#content input[value="${title}"]
+
+I cannot create a new document
+    Click link  Documents
+    Wait until page contains  Test Document
+    Page Should Not Contain   Create document
+    Click link  Functions
+    Page Should Not Contain   Create document
 
 I can create a new folder
     Click link  Documents

--- a/src/ploneintranet/suite/tests/acceptance/workspace.robot
+++ b/src/ploneintranet/suite/tests/acceptance/workspace.robot
@@ -143,6 +143,11 @@ Member cannot create content in a Consumers workspace
     Given I am in a Consumers workspace as a workspace member
      Then I cannot create a new document
 
+Non-Member can view published content in an open workspace
+    Given I am in an open workspace as a non-member
+     Then I can see the document  Terms and conditions
+      And I cannot see the document  Customer satisfaction survey
+
 Site Administrator can add example user as member of workspace
     Given I'm logged in as a 'Site Administrator'
      Add workspace  Example Workspace
@@ -431,3 +436,12 @@ I cannot edit the document
     Element should not be visible  xpath=//div[@id='document-body']//div[@id='editor-toolbar']
     Element should not be visible  xpath=//div[@id='document-body']//div[@class='meta-bar']//button[@type='submit']
 
+I can see the document
+    [arguments]  ${title}
+    Click link  Documents
+    Page should contain  ${title}
+
+I cannot see the document
+    [arguments]  ${title}
+    Click link  Documents
+    Page should not contain  ${title}

--- a/src/ploneintranet/suite/tests/lib/keywords.robot
+++ b/src/ploneintranet/suite/tests/lib/keywords.robot
@@ -58,6 +58,10 @@ I am in a Producers workspace as a workspace member
     I am logged in as the user allan_neece
     I go to the Open Parliamentary Papers Guidance Workspace
 
+I am in a Consumers workspace as a workspace member
+    I am logged in as the user allan_neece
+    I go to the Shareholder Information Workspace
+
 I am in a workspace as a workspace admin
     I am logged in as the user christian_stoney
     I go to the Open Market Committee Workspace
@@ -72,6 +76,10 @@ I go to the Open Parliamentary Papers Guidance Workspace
     Wait Until Element Is Visible  css=h1#workspace-name
     Wait Until Page Contains  Parliamentary papers guidance
 
+I go to the Shareholder Information Workspace
+    Go To  ${PLONE_URL}/workspaces/shareholder-information
+    Wait Until Element Is Visible  css=h1#workspace-name
+    Wait Until Page Contains  Shareholder information
 
 I try go to the Open Market Committee Workspace
     Go To  ${PLONE_URL}/workspaces/open-market-committee

--- a/src/ploneintranet/suite/tests/lib/keywords.robot
+++ b/src/ploneintranet/suite/tests/lib/keywords.robot
@@ -66,6 +66,14 @@ I am in a workspace as a workspace admin
     I am logged in as the user christian_stoney
     I go to the Open Market Committee Workspace
 
+I am in an open workspace as a workspace member
+    I am logged in as the user allan_neece
+    I go to the Service Announcements Workspace
+
+I am in an open workspace as a non-member
+    I am logged in as the user alice_lindstrom
+    I go to the Service Announcements Workspace
+
 I go to the Open Market Committee Workspace
     Go To  ${PLONE_URL}/workspaces/open-market-committee
     Wait Until Element Is Visible  css=h1#workspace-name
@@ -80,6 +88,11 @@ I go to the Shareholder Information Workspace
     Go To  ${PLONE_URL}/workspaces/shareholder-information
     Wait Until Element Is Visible  css=h1#workspace-name
     Wait Until Page Contains  Shareholder information
+
+I go to the Service Announcements Workspace
+    Go To  ${PLONE_URL}/workspaces/service-announcements
+    Wait Until Element Is Visible  css=h1#workspace-name
+    Wait Until Page Contains  Service announcements
 
 I try go to the Open Market Committee Workspace
     Go To  ${PLONE_URL}/workspaces/open-market-committee

--- a/src/ploneintranet/workspace/browser/templates/workspace.pt
+++ b/src/ploneintranet/workspace/browser/templates/workspace.pt
@@ -7,7 +7,7 @@
             i18n:domain="ploneintranet">
 
     <body class="view-secure">
-        <metal:content fill-slot="content" 
+        <metal:content fill-slot="content"
                         tal:define="workspace view/workspace; workspace_url python:workspace.absolute_url()">
             <h1 id="workspace-name">
                 <!-- Next link is to lead to landing state of current workspace -->
@@ -18,7 +18,7 @@
 
                 <div id="document-body">
                     <!-- Careful. I integrate the newpostbox tile from dashboard here, but the markup is different from the one on a workspace, so this still needs to get fixed -->
-                    <form id="new-post-box" data-tile="./@@newpostbox.tile" tal:attributes="data-tile string:${workspace_url}/@@newpostbox.tile"></form>
+                    <form tal:condition="view/can_add_status_updates" id="new-post-box" data-tile="./@@newpostbox.tile" tal:attributes="data-tile string:${workspace_url}/@@newpostbox.tile"></form>
                     <div id="activity-stream" data-tile="./@@activitystream.tile" tal:attributes="data-tile string:${workspace_url}/@@activitystream.tile" ></div>
                 </div>
 

--- a/src/ploneintranet/workspace/browser/tiles/sidebar.py
+++ b/src/ploneintranet/workspace/browser/tiles/sidebar.py
@@ -69,6 +69,15 @@ class BaseTile(BrowserView):
             obj=self,
         )
 
+    def can_add(self):
+        """
+        Is this user allowed to add content?
+        """
+        return api.user.has_permission(
+            "Add portal content",
+            obj=self,
+        )
+
 
 class SidebarSettingsMembers(BaseTile):
     """

--- a/src/ploneintranet/workspace/browser/tiles/sidebar.py
+++ b/src/ploneintranet/workspace/browser/tiles/sidebar.py
@@ -66,7 +66,7 @@ class BaseTile(BrowserView):
         """
         return api.user.has_permission(
             "ploneintranet.workspace: Manage workspace",
-            obj=self,
+            obj=self.context,
         )
 
     def can_add(self):
@@ -75,7 +75,7 @@ class BaseTile(BrowserView):
         """
         return api.user.has_permission(
             "Add portal content",
-            obj=self,
+            obj=self.context,
         )
 
 

--- a/src/ploneintranet/workspace/browser/tiles/templates/sidebar.pt
+++ b/src/ploneintranet/workspace/browser/tiles/templates/sidebar.pt
@@ -4,7 +4,7 @@
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       lang="en"
       i18n:domain="ploneintranet">
-  <body>
+  <body tal:define="can_add view/can_add">
     <aside class="sidebar left tagging-off" id="sidebar" >
 
       <div hidden="hidden" id="more-menu">
@@ -48,7 +48,7 @@
 
               <div class="quick-functions">
                 <a class="selector-toggle-select more-menu-trigger">Functions</a>
-                <a title="Create document" href="/panel-create-document.html#document-content" class="create-document pat-modal icon-doc-text" data-pat-modal="class: large"
+                <a tal:condition="can_add" title="Create document" href="/panel-create-document.html#document-content" class="create-document pat-modal icon-doc-text" data-pat-modal="class: large"
                    tal:attributes="href string:${context/absolute_url}/add_content"
                    i18n:attributes="title" i18n:translate="">Create document</a>
                 <!-- XXX: This is not yet completed -->
@@ -166,7 +166,7 @@ Supported types include (class names):
 - type-pdf
 
                 -->
-                
+
                 <!-- Each group has a class 'group'. The following class — which is prefixed by 'type-' is dynamic. If the grouping of the items selector is on date for instance, the class becomes 'type-date'. If the grouping is by user, then it's 'type-user' and the user avatar is there as an image. In case the grouping is by document type, then each group gets the icon of the document type it represents. For intance the group with PowerPoint files gets 'type-powerpoint' and a rich document gets 'type-rich'. The same type-* class names are supported as for a document.
                 -->
                 <!-- Notice that there is a dynamic class 'has-description/has no description which depends on whether a description of the object is available' -->
@@ -190,38 +190,43 @@ Supported types include (class names):
               </fieldset>
             </form>
 
-            <div class="button-bar create-buttons">
-              <a href="@@add_content" tal:attributes="href string:${context/absolute_url}/add_content" class="button create-document pat-modal icon-doc-text" data-pat-modal="class: large"
-                 i18n:translate="">Create document</a>
-              <a href="@@add_folder" tal:attributes="href string:${context/absolute_url}/add_folder" class="button create-folder pat-modal icon-folder" data-pat-modal="class: large"
-                 i18n:translate="">Create folder</a>
-            </div>
-            <form action="workspaceFileUpload" method="POST" class="pat-inject" data-pat-inject="#workspace-documents && #activity-stream" enctype="multipart/form-data" tal:attributes="action string:${context/absolute_url}/workspaceFileUpload">
-              <fieldset class="pat-upload" data-pat-upload="label: ${view/drop_files_label}; trigger: auto;" tal:attributes="data-pat-upload string:label: ${view/drop_files_label};; trigger: auto;">
-                <label class="accessibility-options">
-                  <input type="file" name="file" multiple="multiple"/> Upload files
-                </label>
-              </fieldset>
-              <button type="submit" hidden="hidden">Upload</button>
-            </form>
+            <tal:can_add condition="can_add">
+              <div class="button-bar create-buttons">
+                <a href="@@add_content" tal:attributes="href string:${context/absolute_url}/add_content" class="button create-document pat-modal icon-doc-text" data-pat-modal="class: large"
+                   i18n:translate="">Create document</a>
+                <a href="@@add_folder" tal:attributes="href string:${context/absolute_url}/add_folder" class="button create-folder pat-modal icon-folder" data-pat-modal="class: large"
+                   i18n:translate="">Create folder</a>
+              </div>
+              <form action="workspaceFileUpload" method="POST" class="pat-inject" data-pat-inject="#workspace-documents && #activity-stream" enctype="multipart/form-data" tal:attributes="action string:${context/absolute_url}/workspaceFileUpload">
+                <fieldset class="pat-upload" data-pat-upload="label: ${view/drop_files_label}; trigger: auto;" tal:attributes="data-pat-upload string:label: ${view/drop_files_label};; trigger: auto;">
+                  <label class="accessibility-options">
+                    <input type="file" name="file" multiple="multiple"/> Upload files
+                  </label>
+                </fieldset>
+                <button type="submit" hidden="hidden">Upload</button>
+              </form>
+            </tal:can_add>
 
             <div class="pat-collapsible more-menu closed" data-pat-collapsible="trigger: .selector-toggle-select" id="selector-more-menu">
               <ul class="menu">
-                <li>
-                  <a href="@@add_content" tal:attributes="href string:${context/absolute_url}/add_content" class="icon-doc-text create-document pat-modal" data-pat-modal="class: large" i18n:translate="">Create document</a>
-                </li>
-                <li>
-                  <a href="@@add_folder" tal:attributes="href string:${context/absolute_url}/add_folder" class="icon-folder create-folder pat-modal" data-pat-modal="class: large" i18n:translate="">Create folder</a>
-                </li>
-                <li>
-                  <label class=" icon-upload-cloud"><input multiple="multiple" type="file"/> <span tal:omit-tag="" i18n:translate="">Upload file(s)</span></label>
-                </li>
+                <tal:can_add condition="can_add">
+                  <li>
+                    <a href="@@add_content" tal:attributes="href string:${context/absolute_url}/add_content" class="icon-doc-text create-document pat-modal" data-pat-modal="class: large" i18n:translate="">Create document</a>
+                  </li>
+                  <li>
+                    <a href="@@add_folder" tal:attributes="href string:${context/absolute_url}/add_folder" class="icon-folder create-folder pat-modal" data-pat-modal="class: large" i18n:translate="">Create folder</a>
+                  </li>
+                  <li>
+                    <label class=" icon-upload-cloud"><input multiple="multiple" type="file"/> <span tal:omit-tag="" i18n:translate="">Upload file(s)</span></label>
+                  </li>
+                </tal:can_add>
                 <!-- This is commented until the functionality will be completed -->
                 <!--li>
                     <a class="pat-toggle icon-ok selector-toggle-select" data-pat-toggle="selector: #selector; value: mode-select mode-follow">Select</a>
                     </li-->
               </ul>
             </div>
+
 
             <div hidden="hidden" id="selector-create-menu">
               <ul class="menu">
@@ -288,7 +293,7 @@ Supported types include (class names):
         <div id="workspace-events" tal:define="events view/events; ws view/workspace">
           <div class="button-bar functions" id="-functions">
             <div class="quick-functions">
-              <a title="Create new event" href="/panel-create-event.html#document-content" class="create-document pat-modal icon-doc-text" data-pat-modal="class: large" data-pat-inject="source:#content" tal:attributes="href string:${ws/absolute_url}/add_event">Create event</a>
+              <a tal:condition="can_add" title="Create new event" href="/panel-create-event.html#document-content" class="create-document pat-modal icon-doc-text" data-pat-modal="class: large" data-pat-inject="source:#content" tal:attributes="href string:${ws/absolute_url}/add_event">Create event</a>
             </div>
           </div>
           <div class="content">

--- a/src/ploneintranet/workspace/browser/tiles/workspaces.py
+++ b/src/ploneintranet/workspace/browser/tiles/workspaces.py
@@ -6,7 +6,6 @@ from plone import api
 from ploneintranet.microblog.interfaces import IMicroblogTool
 from ploneintranet.core import ploneintranetCoreMessageFactory as _
 from zope.component import queryUtility
-from zExceptions import Unauthorized
 
 
 class WorkspacesTile(Tile):
@@ -38,19 +37,15 @@ def my_workspaces(context):
     )
     workspaces = []
     for brain in brains:
-        try:
-            workspaces.append({
-                'id': brain.getId,
-                'title': brain.Title,
-                'description': brain.Description,
-                'url': brain.getURL(),
-                'activities': get_workspace_activities(brain),
-                'class': escape_id_to_class(brain.getId),
-            })
-        except Unauthorized:
-            # the query above should actually filter on *my* workspaces
-            # i.e. workspaces I'm am allowed to view. This is just a stopgap
-            pass
+        workspaces.append({
+            'id': brain.getId,
+            'title': brain.Title,
+            'description': brain.Description,
+            'url': brain.getURL(),
+            'activities': get_workspace_activities(brain),
+            'class': escape_id_to_class(brain.getId),
+        })
+
     return workspaces
 
 

--- a/src/ploneintranet/workspace/browser/tiles/workspaces.py
+++ b/src/ploneintranet/workspace/browser/tiles/workspaces.py
@@ -49,7 +49,7 @@ def my_workspaces(context):
             })
         except Unauthorized:
             # the query above should actually filter on *my* workspaces
-            # i.e. workspaces I'm a member of. This is just a stopgap
+            # i.e. workspaces I'm am allowed to view. This is just a stopgap
             pass
     return workspaces
 

--- a/src/ploneintranet/workspace/browser/workspace.py
+++ b/src/ploneintranet/workspace/browser/workspace.py
@@ -23,7 +23,7 @@ class BaseWorkspaceView(BrowserView):
         """
         return api.user.has_permission(
             "ploneintranet.workspace: Manage workspace",
-            obj=self,
+            obj=self.context,
         )
 
     def can_add_status_updates(self):
@@ -31,7 +31,8 @@ class BaseWorkspaceView(BrowserView):
         Does this user have the permission to add status updates
         """
         return api.user.has_permission(
-            "Plone Social: Add Microblog Status Update", obj=self)
+            "Plone Social: Add Microblog Status Update",
+            obj=self.context)
 
 
 class WorkspaceView(BaseWorkspaceView):

--- a/src/ploneintranet/workspace/browser/workspace.py
+++ b/src/ploneintranet/workspace/browser/workspace.py
@@ -26,6 +26,13 @@ class BaseWorkspaceView(BrowserView):
             obj=self,
         )
 
+    def can_add_status_updates(self):
+        """
+        Does this user have the permission to add status updates
+        """
+        return api.user.has_permission(
+            "Plone Social: Add Microblog Status Update", obj=self)
+
 
 class WorkspaceView(BaseWorkspaceView):
     """

--- a/src/ploneintranet/workspace/profiles/default/workflows/ploneintranet_workspace_workflow/definition.xml
+++ b/src/ploneintranet/workspace/profiles/default/workflows/ploneintranet_workspace_workflow/definition.xml
@@ -31,7 +31,6 @@
       <permission-role>Manager</permission-role>
       <permission-role>Site Administrator</permission-role>
       <permission-role>TeamManager</permission-role>
-      <permission-role>Editor</permission-role>
     </permission-map>
     <permission-map name="Add portal content" acquired="False">
       <permission-role>Manager</permission-role>
@@ -75,7 +74,6 @@
       <permission-role>Manager</permission-role>
       <permission-role>Site Administrator</permission-role>
       <permission-role>TeamManager</permission-role>
-      <permission-role>Editor</permission-role>
     </permission-map>
     <permission-map name="Add portal content" acquired="False">
       <permission-role>Manager</permission-role>
@@ -119,7 +117,6 @@
       <permission-role>Manager</permission-role>
       <permission-role>Site Administrator</permission-role>
       <permission-role>TeamManager</permission-role>
-      <permission-role>Editor</permission-role>
     </permission-map>
     <permission-map name="Add portal content" acquired="False">
       <permission-role>Manager</permission-role>

--- a/src/ploneintranet/workspace/profiles/default/workflows/ploneintranet_workspace_workflow/definition.xml
+++ b/src/ploneintranet/workspace/profiles/default/workflows/ploneintranet_workspace_workflow/definition.xml
@@ -62,7 +62,6 @@
       <permission-role>Site Administrator</permission-role>
       <permission-role>TeamMember</permission-role>
       <permission-role>TeamManager</permission-role>
-      <permission-role>Authenticated</permission-role>
     </permission-map>
     <permission-map name="Modify portal content" acquired="False">
       <permission-role>Manager</permission-role>

--- a/src/ploneintranet/workspace/profiles/default/workflows/ploneintranet_workspace_workflow/definition.xml
+++ b/src/ploneintranet/workspace/profiles/default/workflows/ploneintranet_workspace_workflow/definition.xml
@@ -7,6 +7,7 @@
   <permission>Access contents information</permission>
   <permission>View</permission>
   <permission>Modify portal content</permission>
+  <permission>Add portal content</permission>
   <permission>Plone Social: Add Microblog Status Update</permission>
   <permission>Plone Social: View Microblog Status Update</permission>
 
@@ -30,6 +31,13 @@
       <permission-role>Manager</permission-role>
       <permission-role>Site Administrator</permission-role>
       <permission-role>TeamManager</permission-role>
+      <permission-role>Editor</permission-role>
+    </permission-map>
+    <permission-map name="Add portal content" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Site Administrator</permission-role>
+      <permission-role>TeamManager</permission-role>
+      <permission-role>Contributor</permission-role>
     </permission-map>
     <permission-map name="Plone Social: Add Microblog Status Update" acquired="False">
       <permission-role>Manager</permission-role>
@@ -67,6 +75,13 @@
       <permission-role>Manager</permission-role>
       <permission-role>Site Administrator</permission-role>
       <permission-role>TeamManager</permission-role>
+      <permission-role>Editor</permission-role>
+    </permission-map>
+    <permission-map name="Add portal content" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Site Administrator</permission-role>
+      <permission-role>TeamManager</permission-role>
+      <permission-role>Contributor</permission-role>
     </permission-map>
     <permission-map name="Plone Social: Add Microblog Status Update" acquired="False">
       <permission-role>Manager</permission-role>
@@ -104,6 +119,13 @@
       <permission-role>Manager</permission-role>
       <permission-role>Site Administrator</permission-role>
       <permission-role>TeamManager</permission-role>
+      <permission-role>Editor</permission-role>
+    </permission-map>
+    <permission-map name="Add portal content" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Site Administrator</permission-role>
+      <permission-role>TeamManager</permission-role>
+      <permission-role>Contributor</permission-role>
     </permission-map>
     <permission-map name="Plone Social: Add Microblog Status Update" acquired="False">
       <permission-role>Manager</permission-role>

--- a/src/ploneintranet/workspace/tests/test_workspace_workflow.py
+++ b/src/ploneintranet/workspace/tests/test_workspace_workflow.py
@@ -31,8 +31,11 @@ class TestWorkSpaceWorkflow(BaseTestCase):
 
     def test_private_workspace(self):
         """
-        Private workspaces should be visible to all,
-        but only accessible to members
+        Private workspaces should be visible and accessible
+        only to members.
+        NOTE: Non-members should be able to request access. Therefore they need
+        limited access to some attributes of the workspace like Title.
+        This scenario is NOT tested here yet.
         """
         api.content.transition(self.workspace_folder,
                                'make_private')
@@ -67,8 +70,8 @@ class TestWorkSpaceWorkflow(BaseTestCase):
             username='nonmember',
             obj=self.workspace_folder,
         )
-        self.assertTrue(nonmember_permissions[VIEW],
-                        'Non-member cannot view private workspace')
+        self.assertFalse(nonmember_permissions[VIEW],
+                         'Non-member cannot view private workspace')
         self.assertFalse(nonmember_permissions[ACCESS],
                          'Non-member can access private workspace')
         self.assertFalse(nonmember_permissions[ADD_STATUS],

--- a/src/ploneintranet/workspace/tests/test_workspace_workflow.py
+++ b/src/ploneintranet/workspace/tests/test_workspace_workflow.py
@@ -71,7 +71,7 @@ class TestWorkSpaceWorkflow(BaseTestCase):
             obj=self.workspace_folder,
         )
         self.assertFalse(nonmember_permissions[VIEW],
-                         'Non-member cannot view private workspace')
+                         'Non-member can view private workspace')
         self.assertFalse(nonmember_permissions[ACCESS],
                          'Non-member can access private workspace')
         self.assertFalse(nonmember_permissions[ADD_STATUS],


### PR DESCRIPTION
- Take away the View permission from Authenticated in "private" workspaces.
  This currently violates "Workspace is visible to non-members", but since we have no story to request access, we leave it like this
- Do not show buttons / links for creating content to users who do not have the permission to use them
- In the social activity stream, make sure comments are shown to all with viewer permissions, but only the commenting form is hidden 
- Add permission "Add portal content" to the workflow of workspaces to turn off inheritance
  This permission is given, in all states of the workflow, to role Contributor
- Tighten security in microblog: If the context of a StatusUpdate is a workspace, and that workspace cannot be resolved because the user does not have the permission to view it, don't silently ignore but raise an error.
