### PR TITLE
promote API docs

### DIFF
--- a/docs/development/api.rst
+++ b/docs/development/api.rst
@@ -1,8 +1,8 @@
-=================
-ploneintranet.api
-=================
+==================
+Plone Intranet API
+==================
 
-This package provides a simple developer API to the most commonly used features of ploneintranet.
+The ``ploneintranet.api`` package provides a simple developer API to the most commonly used features of ploneintranet.
 
 Microblogging API
 -----------------

--- a/docs/development/components/index.rst
+++ b/docs/development/components/index.rst
@@ -5,7 +5,6 @@ Component Packages
 .. toctree::
     :maxdepth: 2
 
-    ploneintranet-api
     userprofiles
     microblogstream
     notifications

--- a/docs/development/components/microblogstream.rst
+++ b/docs/development/components/microblogstream.rst
@@ -263,3 +263,12 @@ For every activity reply provider on a post, the macro "comment.html" is called.
 * Section "comment-content" with the actual content; the ``getText`` method of the activity provider assembles text, mentions and tags
 * Section "preview", for attachment previews
 
+
+Microblogging API
+=================
+
+.. automodule:: ploneintranet.api.microblog.statusupdate
+    :members:
+    :undoc-members:
+    :show-inheritance:
+

--- a/docs/development/components/userprofiles.rst
+++ b/docs/development/components/userprofiles.rst
@@ -19,3 +19,11 @@ Username as Userid
 ------------------
 
 The default membrane implementation uses UUIDs as the unique id that Plone uses to grant roles and permissions (userid). We use the username instead, to ensure compatibility with external authentication sources such as LDAP which have no knowledge of Plone's UUIDs.
+
+User Profile API
+----------------
+
+.. automodule:: ploneintranet.api.userprofile
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -8,6 +8,7 @@ Developer documentation
     contributing
     frontend/index
     forms
+    api
     components/index
     testing
     debugging


### PR DESCRIPTION
API deserves a higher-level documentation entry.
Also adds API ref to specific component docs.
