### PR TITLE
Solr tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,14 @@ bin/buildout: bin/python2.7
 bin/python2.7:
 	@virtualenv --clear -p python2.7 .
 
+####################################################################
+# Solr
+
+solr: bin/buildout
+	@bin/buildout -c solr.cfg
+
+solr-clean:
+	rm -rf parts/solr parts/solr-test
 
 ####################################################################
 # Testing
@@ -168,4 +176,5 @@ api-docs:
 docs-clean:
 	rm -rf docs/html
 
-.PHONY: all docs api-docs docs-clean clean check-clean
+.PHONY: all docs api-docs docs-clean clean check-clean solr-clean
+

--- a/solr.cfg
+++ b/solr.cfg
@@ -60,7 +60,7 @@ additional-solrconfig =
     </requestHandler>
 
 filter =
-    text solr.EdgeNGramFilterFactory minGramSize="2" maxGramSize="15"
+    text solr.EdgeNGramFilterFactory minGramSize="4" maxGramSize="15"
     text solr.ICUFoldingFilterFactory
     text solr.WordDelimiterFilterFactory splitOnCaseChange="0" splitOnNumerics="0" stemEnglishPossessive="0" preserveOriginal="1"
     text solr.TrimFilterFactory

--- a/solr.cfg
+++ b/solr.cfg
@@ -62,11 +62,13 @@ additional-solrconfig =
     </requestHandler>
 
 filter =
-    text solr.EdgeNGramFilterFactory minGramSize="4" maxGramSize="15"
     text solr.ICUFoldingFilterFactory
     text solr.WordDelimiterFilterFactory splitOnCaseChange="0" splitOnNumerics="0" stemEnglishPossessive="0" preserveOriginal="1"
     text solr.TrimFilterFactory
     text solr.StopFilterFactory ignoreCase="true" words="stopwords.txt"
+
+filter-index =
+    text solr.EdgeNGramFilterFactory minGramSize="2" maxGramSize="15"
 
 [instance]
 zcml-additional =

--- a/solr.cfg
+++ b/solr.cfg
@@ -33,12 +33,13 @@ java-opts =
 [core1]
 max-num-results = 500
 unique-key = UID
+spellcheckField = spelling
 index =
     name:Creator                type:string stored:true
-    name:Description            type:text copyfield:default stored:true
-    name:SearchableText         type:text copyfield:default stored:false
+    name:Description            type:text copyfield:default copyfield:spelling stored:true
+    name:SearchableText         type:text copyfield:default copyfield:spelling stored:false
     name:tags                   type:string copyfield:default stored:true multivalued:true
-    name:Title                  type:text copyfield:default stored:true
+    name:Title                  type:text copyfield:default copyfield:spelling stored:true
     name:UID                    type:string stored:true required:true
     name:allowedRolesAndUsers   type:string stored:false multivalued:true
     name:created                type:date stored:true
@@ -52,6 +53,7 @@ index =
     name:path_string            type:string indexed:false stored:true
     name:portal_type            type:string stored:true
     name:review_state           type:string stored:true
+    name:spelling               type:text_general indexed:true stored:false multivalued:true
 additional-solrconfig =
     <requestHandler name="/select" class="solr.SearchHandler">
         <arr name="last-components">

--- a/solr.cfg
+++ b/solr.cfg
@@ -8,14 +8,13 @@ parts +=
 test-eggs =
     ${:package-name} [solr,test]
 
-[solr-settings]
+[solr]
+recipe = collective.recipe.solrinstance:mc
 host = 0.0.0.0
 port = 8983
 min-ram = 128M
 max-ram = 256M
 basepath = /solr
-vardir = ${buildout:directory}/var/${:_buildout_section_name_}
-pidpath = ${:vardir}
 solr-version = 5
 default-search-field = default
 section-name = SOLR
@@ -23,25 +22,13 @@ directoryFactory = solr.NRTCachingDirectoryFactory
 cores = core1
 java-opts =
   -Dcom.sun.management.jmxremote
-  -Djava.rmi.server.hostname=${solr-settings:host}
+  -Djava.rmi.server.hostname=${solr:host}
   -Dcom.sun.management.jmxremote.port=8094
   -Dcom.sun.management.jmxremote.ssl=false
    -Dcom.sun.management.jmxremote.authenticate=false
   -server
-  -Xms${solr-settings:min-ram}
-  -Xmx${solr-settings:max-ram}
-
-[solr]
-<= solr-settings
-recipe = collective.recipe.solrinstance:mc
-port = 8983
-script = solr
-
-[solr-test]
-<= solr-settings
-recipe = collective.recipe.solrinstance:mc
-port = 8984
-script = solr-test
+  -Xms${solr:min-ram}
+  -Xmx${solr:max-ram}
 
 [core1]
 max-num-results = 500
@@ -79,16 +66,15 @@ filter =
     text solr.TrimFilterFactory
     text solr.StopFilterFactory ignoreCase="true" words="stopwords.txt"
 
-
 [instance]
 zcml-additional =
     <configure xmlns="http://namespaces.zope.org/zope"
            xmlns:solr="http://namespaces.ploneintranet.org/search/solr">
 	<include package="ploneintranet.search.solr" />
         <solr:connection
-            host="${solr-settings:host}"
-            port="${solr-settings:port}"
-            basepath="${solr-settings:basepath}"
+            host="${solr:host}"
+            port="${solr:port}"
+            basepath="${solr:basepath}"
             core="core1"
          />
     </configure>
@@ -96,3 +82,11 @@ zcml-additional =
 [scripts]
 eggs = ${buildout:package-name} [test,develop,release,solr]
 
+# Separate solr instance reserved for tests
+# (Not required for production use)
+[solr-test]
+<= solr
+port = 8984
+script = solr-test
+vardir = ${buildout:directory}/var/solr-test
+pidpath = ${:vardir}

--- a/src/ploneintranet/search/base.py
+++ b/src/ploneintranet/search/base.py
@@ -5,6 +5,7 @@ import collections
 import logging
 
 from plone import api
+from plone.api.validation import required_parameters
 from zope import globalrequest
 
 from .interfaces import ISearchResult
@@ -286,6 +287,7 @@ class SiteSearch(object):
                 raise LookupError(msg)
         return self._apply_filters(query, filters)
 
+    @required_parameters('phrase', )
     def query(self,
               phrase,
               filters=None,

--- a/src/ploneintranet/search/tests/base.py
+++ b/src/ploneintranet/search/tests/base.py
@@ -53,7 +53,7 @@ class SiteSearchContentsTestMixin(SiteSearchTestBaseMixin):
         self.doc2 = self.create_doc(
             title=u'Test Doc 2',
             description=(u'This is another test document. '
-                         u'Please let some stuff be indexed.'),
+                         u'Please let some stuff be indexed. '),
             subject=(u'test', u'my-other-tag'),
         )
         self.doc2.creation_date = datetime.datetime(2002, 9, 11, 0, 10, 1)
@@ -130,13 +130,20 @@ class SiteSearchTestsMixin(SiteSearchContentsTestMixin):
     def test_query_phrase_only(self):
         util = self._make_utility()
         response = self._query(util, 'hopefully')
+        self.assertEqual(response.total_results, 1)
         result = next(iter(response), None)
         self.assertIsNotNone(result)
         self.assertEqual(result.title, self.doc1.Title())
         self.assertEqual(result.url, self.doc1.absolute_url())
-        self.assertEqual(response.total_results, 1)
         self.assertEqual(set(response.facets['friendly_type_name']), {'Page'})
         self.assertEqual(set(response.facets['tags']), {u'test', u'my-tag'})
+
+    def test_query_partial_match(self):
+        util = self._make_utility()
+        response = self._query(util, 'hope')
+        self.assertEqual(response.total_results, 1)
+        response = self._query(util, 'doc')
+        self.assertEqual(response.total_results, 3)
 
     def test_query_with_empty_filters(self):
         util = self._make_utility()

--- a/src/ploneintranet/search/tests/base.py
+++ b/src/ploneintranet/search/tests/base.py
@@ -241,7 +241,6 @@ class SiteSearchTestsMixin(SiteSearchContentsTestMixin):
         self.assertEqual(response.spell_corrected_search, expect_suggestion)
 
     def test_spell_corrected_search(self):
-        self._check_spellcheck_response(None, None)
         self._check_spellcheck_response('', None)
         self._check_spellcheck_response(u'', None)
         self._check_spellcheck_response(u'*:*', None)

--- a/src/ploneintranet/search/zcatalog.py
+++ b/src/ploneintranet/search/zcatalog.py
@@ -18,6 +18,10 @@ class SiteSearch(base.SiteSearch):
     _apply_security = base.NoOpQueryMethod()
 
     def _create_query_object(self, phrase):
+        # Poor man's partial word matching
+        phrase = phrase.strip()
+        if not phrase.endswith('*'):
+            phrase = phrase + '*'
         return dict(SearchableText=phrase)
 
     def _apply_debug(self, query):


### PR DESCRIPTION
This PR includes a few solr-related improvements
- Cleans up the solr buildout inheritance setup to make it easier to re-use in deployments
- Enables connection pooling
- Ups the ngram size to 4 (an ngram size of 2 produces some pretty odd results such as a search for 'document' giving you results that contain the word 'do')
- Sets up a separate field for spellchecking. This improves the speed and accuracy of spelling suggestions, and stops you getting unhelpful stemmed spelling suggestions.
