### PR TITLE
content_macros/event_fields update css and add a slot for extra fields

### DIFF
--- a/src/ploneintranet/theme/content/templates/event_view.pt
+++ b/src/ploneintranet/theme/content/templates/event_view.pt
@@ -42,7 +42,7 @@
                                 <a href="/feedback/panel-event-attachments.html#content" class="icon-attach iconified pat-tooltip" data-pat-tooltip="source: ajax" title="Attach documents">
                                     Attachments
                                 </a>
-                                <a class="icon-info-circle meta-data-toggle iconified" title="Show extra metadata fields">Toggle extra metadata</a>
+                                <!-- <a class="icon-info-circle meta-data-toggle iconified" title="Show extra metadata fields">Toggle extra metadata</a> -->
                                 <!-- <a href="" class="icon-copy iconified" title="Copy this document">
                                     Copy
                                 </a>
@@ -69,14 +69,10 @@
 
                             </div>
                         </div>
-                        <fieldset class="pat-collapsible open meta-extra" data-pat-collapsible="trigger: .meta-data-toggle" id="meta-extra">
+                        <!-- <fieldset class="pat-collapsible open meta-extra" data-pat-collapsible="trigger: .meta-data-toggle" id="meta-extra"> -->
                             <!-- <fieldset class="bar">
                                 <input type="text" class="pat-autosuggest" placeholder="Tags" />
                             </fieldset> -->
-                            <fieldset class="bar description">
-                                <textarea name="description" tal:attributes="disabled read_only" rows="8" title="Description" placeholder="Description">${context/description}</textarea>
-                             </fieldset>
-
                             <!-- <fieldset class="bar versioning">
                                 <label>
                                     <input type="checkbox" name="cmfeditions_save_new_version" id="cmfeditions_save_new_version" /> Save a new version
@@ -92,7 +88,7 @@
                                     <button type="submit" name="submit" value="submit" class="submit">Save this version</button>
                                 </fieldset>
                             </fieldset> -->
-                        </fieldset>
+                        <!-- </fieldset> -->
                     </div>
                     <div id="document-content">
                         <div class="document event-details">

--- a/src/ploneintranet/workspace/browser/templates/content_macros.pt
+++ b/src/ploneintranet/workspace/browser/templates/content_macros.pt
@@ -54,7 +54,10 @@
 
 
     <metal:event_fields define-macro="event_fields">
-      <fieldset class="vertical"  tal:define="read_only python:False">
+      <fieldset class="vertical fancy"  tal:define="read_only python:False">
+
+        <metal:extra-fields-top define-slot="extra-fields-top"/>
+
                 <label class="location">
                     Location <input name="location" tal:attributes="disabled read_only" type="text" value="" tal:attributes="value context/location | nothing">
                 </label>

--- a/src/ploneintranet/workspace/browser/templates/content_macros.pt
+++ b/src/ploneintranet/workspace/browser/templates/content_macros.pt
@@ -53,8 +53,14 @@
     </metal:task_fields>
 
 
-    <metal:event_fields define-macro="event_fields">
-      <fieldset class="vertical fancy"  tal:define="read_only python:False">
+    <metal:event_fields define-macro="event_fields"
+                        tal:define="read_only python:False">
+      <fieldset class="vertical fancy">
+        <label class="description">
+          Description
+          <textarea name="description" placeholder="Enter a description of the task"
+                    tal:attributes="disabled read_only" rows="6">${context/description}</textarea>
+        </label>
 
         <metal:extra-fields-top define-slot="extra-fields-top"/>
 

--- a/src/ploneintranet/workspace/browser/templates/content_macros.pt
+++ b/src/ploneintranet/workspace/browser/templates/content_macros.pt
@@ -58,7 +58,7 @@
       <fieldset class="vertical fancy">
         <label class="description">
           Description
-          <textarea name="description" placeholder="Enter a description of the task"
+          <textarea name="description" placeholder="Enter a description of the event"
                     tal:attributes="disabled read_only" rows="6">${context/description}</textarea>
         </label>
 


### PR DESCRIPTION
Resync the event view with the prototype. Move the description into the body and add an extra slot into the event_fields macro to allow additional fields to be included when customized (which we need for iKath).
