### PR TITLE
improve profile sorting

### DIFF
--- a/src/ploneintranet/activitystream/configure.zcml
+++ b/src/ploneintranet/activitystream/configure.zcml
@@ -18,7 +18,7 @@
 
   <genericsetup:registerProfile
       name="default"
-      title="Plone Intranet: -- (Activitystream)"
+      title="Plone Intranet: -- [Activitystream]"
       directory="profiles/default"
       description="Installs the ploneintranet.activitystream package"
       provides="Products.GenericSetup.interfaces.EXTENSION"
@@ -27,7 +27,7 @@
 
   <genericsetup:registerProfile
       name="uninstall"
-      title="Plone Intranet: -- (Activitystream uninstall)"
+      title="Plone Intranet: -- [Activitystream uninstall]"
       directory="profiles/uninstall"
       description="Uninstalls the ploneintranet.activitystream package"
       provides="Products.GenericSetup.interfaces.EXTENSION"

--- a/src/ploneintranet/attachments/configure.zcml
+++ b/src/ploneintranet/attachments/configure.zcml
@@ -19,7 +19,7 @@
     <!-- Register the installation GenericSetup extension profile -->
     <genericsetup:registerProfile
         name="default"
-        title="Plone Intranet: -- (Attachments)"
+        title="Plone Intranet: -- [Attachments]"
         directory="profiles/default"
         description="Extension profile for ploneintranet.attachments."
         provides="Products.GenericSetup.interfaces.EXTENSION"
@@ -27,7 +27,7 @@
 
     <genericsetup:registerProfile
         name="uninstall"
-        title="Plone Intranet: -- (Attachments uninstall)"
+        title="Plone Intranet: -- [Attachments uninstall]"
         directory="profiles/uninstall"
         description="Uninstalls the ploneintranet.attachments package."
         provides="Products.GenericSetup.interfaces.EXTENSION"

--- a/src/ploneintranet/core/profiles.zcml
+++ b/src/ploneintranet/core/profiles.zcml
@@ -7,7 +7,7 @@
 
   <genericsetup:registerProfile
       name="default"
-      title="Plone Intranet: -- (deprecated: Social Core: default)"
+      title="Plone Intranet: -- [deprecated: Social Core: default]"
       directory="profiles/default"
       description="Installs shared utilities for PloneIntranet"
       provides="Products.GenericSetup.interfaces.EXTENSION"
@@ -16,7 +16,7 @@
 
   <genericsetup:registerProfile
       name="minimal"
-      title="Plone Intranet: -- (deprecated: Social Core: minimal)"
+      title="Plone Intranet: -- [deprecated: Social Core: minimal]"
       directory="profiles/minimal"
       description="Installs only required utilities, NOT patternslib resources"
       provides="Products.GenericSetup.interfaces.EXTENSION"
@@ -25,7 +25,7 @@
 
   <genericsetup:registerProfile
       name="uninstall"
-      title="Plone Intranet: -- (deprecated: Social Core uninstall)"
+      title="Plone Intranet: -- [deprecated: Social Core uninstall]"
       directory="profiles/uninstall"
       description="Uninstalls shared utilities for PloneIntranet"
       provides="Products.GenericSetup.interfaces.EXTENSION"

--- a/src/ploneintranet/docconv/client/configure.zcml
+++ b/src/ploneintranet/docconv/client/configure.zcml
@@ -27,7 +27,7 @@
     <!-- Register the installation GenericSetup extension profile -->
     <genericsetup:registerProfile
         name="default"
-        title="Plone Intranet: -- (Docconv Client)"
+        title="Plone Intranet: -- [Docconv Client]"
         directory="profiles/default"
         description="Extension profile for ploneintranet.docconv.client."
         provides="Products.GenericSetup.interfaces.EXTENSION"
@@ -35,7 +35,7 @@
 
     <genericsetup:registerProfile
         name="uninstall"
-        title="Plone Intranet: -- (Docconv Client uninstall)"
+        title="Plone Intranet: -- [Docconv Client uninstall]"
         directory="profiles/uninstall"
         description="Uninstalls ploneintranet.docconv.client."
         provides="Products.GenericSetup.interfaces.EXTENSION"

--- a/src/ploneintranet/invitations/configure.zcml
+++ b/src/ploneintranet/invitations/configure.zcml
@@ -16,7 +16,7 @@
 
   <genericsetup:registerProfile
      name="default"
-     title="Plone Intranet: -- (Invitations)"
+     title="Plone Intranet: -- [Invitations]"
      directory="profiles/default"
      description="Invite users to a plone site using a unique URL"
      provides="Products.GenericSetup.interfaces.EXTENSION"
@@ -24,7 +24,7 @@
 
   <genericsetup:registerProfile
      name="uninstall"
-     title="Plone Intranet: -- (Invitations uninstall)"
+     title="Plone Intranet: -- [Invitations uninstall]"
      directory="profiles/uninstall"
      description="Uninstall the ploneintranet.invitations package"
      provides="Products.GenericSetup.interfaces.EXTENSION"

--- a/src/ploneintranet/messaging/configure.zcml
+++ b/src/ploneintranet/messaging/configure.zcml
@@ -11,7 +11,7 @@
 
   <genericsetup:registerProfile
       name="default"
-      title="Plone Intranet: -- (Messaging)"
+      title="Plone Intranet: -- [Messaging]"
       directory="profiles/default"
       description="Installs the ploneintranet.messaging package"
       provides="Products.GenericSetup.interfaces.EXTENSION"
@@ -19,7 +19,7 @@
 
   <genericsetup:registerProfile
       name="uninstall"
-      title="Plone Intranet: -- (Messaging)"
+      title="Plone Intranet: -- [Messaging]"
       directory="profiles/uninstall"
       description="Uninstalls the ploneintranet.messaging package"
       provides="Products.GenericSetup.interfaces.EXTENSION"

--- a/src/ploneintranet/microblog/configure.zcml
+++ b/src/ploneintranet/microblog/configure.zcml
@@ -17,7 +17,7 @@
 
   <genericsetup:registerProfile
       name="default"
-      title="Plone Intranet: -- (Microblog)"
+      title="Plone Intranet: -- [Microblog]"
       directory="profiles/default"
       description="Installs the ploneintranet.microblog package"
       provides="Products.GenericSetup.interfaces.EXTENSION"
@@ -26,7 +26,7 @@
 
   <genericsetup:registerProfile
       name="uninstall"
-      title="Plone Intranet: -- (Microblog uninstall)"
+      title="Plone Intranet: -- [Microblog uninstall]"
       directory="profiles/uninstall"
       description="Uninstalls the ploneintranet.microblog package"
       provides="Products.GenericSetup.interfaces.EXTENSION"

--- a/src/ploneintranet/network/configure.zcml
+++ b/src/ploneintranet/network/configure.zcml
@@ -17,7 +17,7 @@
 
   <genericsetup:registerProfile
       name="default"
-      title="Plone Intranet: -- (Social Network)"
+      title="Plone Intranet: -- [Social Network]"
       directory="profiles/default"
       description="Installs the ploneintranet.network package"
       provides="Products.GenericSetup.interfaces.EXTENSION"
@@ -26,7 +26,7 @@
 
   <genericsetup:registerProfile
       name="uninstall"
-      title="Plone Intranet: -- (Social Network: Uninstall)"
+      title="Plone Intranet: -- [Social Network: Uninstall]"
       directory="profiles/uninstall"
       description="Uninstalls the ploneintranet.network package"
       provides="Products.GenericSetup.interfaces.EXTENSION"

--- a/src/ploneintranet/notifications/configure.zcml
+++ b/src/ploneintranet/notifications/configure.zcml
@@ -21,7 +21,7 @@
 
   <genericsetup:registerProfile
       name="default"
-      title="Plone Intranet: -- (Notifications)"
+      title="Plone Intranet: -- [Notifications]"
       directory="profiles/default"
       description="Installs the ploneintranet.notifications package"
       provides="Products.GenericSetup.interfaces.EXTENSION"
@@ -29,7 +29,7 @@
 
   <genericsetup:registerProfile
       name="uninstall"
-      title="Plone Intranet: -- (Notifications: Uninstall)"
+      title="Plone Intranet: -- [Notifications: Uninstall]"
       directory="profiles/uninstall"
       description="Uninstalls the ploneintranet.notifications package"
       provides="Products.GenericSetup.interfaces.EXTENSION"

--- a/src/ploneintranet/pagerank/configure.zcml
+++ b/src/ploneintranet/pagerank/configure.zcml
@@ -14,7 +14,7 @@
 
   <genericsetup:registerProfile
       name="default"
-      title="Plone Intranet: -- (Pagerank)"
+      title="Plone Intranet: -- [Pagerank]"
       directory="profiles/default"
       description="Installs the ploneintranet.pagerank package"
       provides="Products.GenericSetup.interfaces.EXTENSION"
@@ -22,7 +22,7 @@
 
   <genericsetup:registerProfile
       name="testing"
-      title="Plone Intranet: -- (Pagerank: Testing)"
+      title="Plone Intranet: -- [Pagerank: Testing]"
       directory="profiles/testing"
       description="Integration testing setup for ploneintranet.pagerank"
       provides="Products.GenericSetup.interfaces.EXTENSION"

--- a/src/ploneintranet/search/configure.zcml
+++ b/src/ploneintranet/search/configure.zcml
@@ -16,7 +16,7 @@
 
   <genericsetup:registerProfile
       name="default"
-      title="Plone Intranet: -- (Search)"
+      title="Plone Intranet: -- [Search]"
       directory="profiles/default"
       description="Search for PloneIntranet"
       provides="Products.GenericSetup.interfaces.EXTENSION"
@@ -24,7 +24,7 @@
 
   <genericsetup:registerProfile
       name="uninstall"
-      title="Plone Intranet: -- (Search uninstall)"
+      title="Plone Intranet: -- [Search uninstall]"
       directory="profiles/uninstall"
       description="Uninstall Search for PloneIntranet"
       provides="Products.GenericSetup.interfaces.EXTENSION"

--- a/src/ploneintranet/socialsuite/profiles.zcml
+++ b/src/ploneintranet/socialsuite/profiles.zcml
@@ -7,7 +7,7 @@
 
   <genericsetup:registerProfile
       name="default"
-      title="Plone Intranet: -- (deprecated: Social Suite)"
+      title="Plone Intranet: -- [deprecated: Social Suite]"
       directory="profiles/default"
       description="Installs the suite of all ploneintranet packages"
       provides="Products.GenericSetup.interfaces.EXTENSION"
@@ -16,16 +16,16 @@
 
   <genericsetup:registerProfile
       name="uninstall"
-      title="Plone Intranet: -- (deprecated: Social Suite: Uninstall)"
+      title="Plone Intranet: -- [deprecated: Social Suite: Uninstall]"
       directory="profiles/uninstall"
-      description="Uninstalls ploneintranet.socialsuite (but not the other ploneintranet.* packages)"
+      description="Uninstalls ploneintranet.socialsuite [but not the other ploneintranet.* packages]"
       provides="Products.GenericSetup.interfaces.EXTENSION"
       i18n:attributes="title; description"
       />
 
   <genericsetup:registerProfile
       name="demo"
-      title="Plone Intranet: -- (deprecated: Social Suite: Demo)"
+      title="Plone Intranet: -- [deprecated: Social Suite: Demo]"
       directory="profiles/demo"
       description="WARNING: CANNOT BE UNINSTALLED! Do not run in a production environment. Creates fake user profiles and microblog posts."
       provides="Products.GenericSetup.interfaces.EXTENSION"
@@ -34,7 +34,7 @@
 
   <genericsetup:importStep
       name="ploneintranet.demo"
-      title="Plone Intranet Social Suite (Set up demo data)"
+      title="Plone Intranet Social Suite [Set up demo data]"
       description=""
       handler="ploneintranet.socialsuite.setuphandlers.demo" />
 

--- a/src/ploneintranet/socialtheme/configure.zcml
+++ b/src/ploneintranet/socialtheme/configure.zcml
@@ -11,7 +11,7 @@
 
   <genericsetup:registerProfile
       name="default"
-      title="Plone Intranet: -- (deprecated: Social Theme)"
+      title="Plone Intranet: -- [deprecated: Social Theme]"
       directory="profiles/default"
       description='Skin overrides for ploneintranet.socialtheme'
       provides="Products.GenericSetup.interfaces.EXTENSION"

--- a/src/ploneintranet/theme/configure.zcml
+++ b/src/ploneintranet/theme/configure.zcml
@@ -27,7 +27,7 @@
     <!-- Register the installation GenericSetup extension profile -->
     <genericsetup:registerProfile
         name="default"
-        title="Plone Intranet: -- (Theme)"
+        title="Plone Intranet: -- [Theme]"
         directory="profiles/default"
         description="Extension profile for ploneintranet.theme."
         provides="Products.GenericSetup.interfaces.EXTENSION"
@@ -35,7 +35,7 @@
 
     <genericsetup:registerProfile
         name="uninstall"
-        title="Plone Intranet: -- (Theme uninstall)"
+        title="Plone Intranet: -- [Theme uninstall]"
         directory="profiles/uninstall"
         description="Extension profile for ploneintranet.theme."
         provides="Products.GenericSetup.interfaces.EXTENSION"

--- a/src/ploneintranet/themeswitcher/configure.zcml
+++ b/src/ploneintranet/themeswitcher/configure.zcml
@@ -22,7 +22,7 @@
 
    <genericsetup:registerProfile
         name="default"
-        title="Plone Intranet: -- (Themeswitcher)"
+        title="Plone Intranet: -- [Themeswitcher]"
         description="Enables on-the-fly theme switching"
         directory="profiles/default"
         for="Products.CMFPlone.interfaces.IPloneSiteRoot"
@@ -31,7 +31,7 @@
 
    <genericsetup:registerProfile
         name="testing"
-        title="Plone Intranet: -- (Themeswitcher: Testing)"
+        title="Plone Intranet: -- [Themeswitcher: Testing]"
         description="Installs testthemeA for test purposes"
         directory="profiles/testing"
         for="Products.CMFPlone.interfaces.IPloneSiteRoot"

--- a/src/ploneintranet/todo/configure.zcml
+++ b/src/ploneintranet/todo/configure.zcml
@@ -15,7 +15,7 @@
     <!-- Register the installation GenericSetup extension profile -->
     <genericsetup:registerProfile
         name="default"
-        title="Plone Intranet: -- (Todo)"
+        title="Plone Intranet: -- [Todo]"
         directory="profiles/default"
         description="Extension profile for ploneintranet.todo."
         provides="Products.GenericSetup.interfaces.EXTENSION"
@@ -23,7 +23,7 @@
 
     <genericsetup:registerProfile
         name="uninstall"
-        title="Plone Intranet: -- (Todo uninstall)"
+        title="Plone Intranet: -- [Todo uninstall]"
         directory="profiles/uninstall"
         description="Extension profile for ploneintranet.todo."
         provides="Products.GenericSetup.interfaces.EXTENSION"

--- a/src/ploneintranet/userprofile/configure.zcml
+++ b/src/ploneintranet/userprofile/configure.zcml
@@ -19,7 +19,7 @@
 
   <genericsetup:registerProfile
       name="default"
-      title="Plone Intranet: -- (User Profiles)"
+      title="Plone Intranet: -- [User Profiles]"
       directory="profiles/default"
       description="Installs the ploneintranet.userprofile package"
       provides="Products.GenericSetup.interfaces.EXTENSION"
@@ -28,7 +28,7 @@
 
   <genericsetup:registerProfile
       name="uninstall"
-      title="Plone Intranet: -- (User Profiles uninstall)"
+      title="Plone Intranet: -- [User Profiles uninstall]"
       directory="profiles/uninstall"
       description="Installs the ploneintranet.userprofile package"
       provides="Products.GenericSetup.interfaces.EXTENSION"

--- a/src/ploneintranet/workspace/configure.zcml
+++ b/src/ploneintranet/workspace/configure.zcml
@@ -137,7 +137,7 @@
 
   <genericsetup:registerProfile
       name="default"
-      title="Plone Intranet: -- (Workspace)"
+      title="Plone Intranet: -- [Workspace]"
       directory="profiles/default"
       description="Workspace for PloneIntranet"
       provides="Products.GenericSetup.interfaces.EXTENSION"
@@ -154,7 +154,7 @@
 
   <genericsetup:registerProfile
       name="uninstall"
-      title="Plone Intranet: -- (Workspace uninstall)"
+      title="Plone Intranet: -- [Workspace uninstall]"
       directory="profiles/uninstall"
       description="Workspace for PloneIntranet"
       provides="Products.GenericSetup.interfaces.EXTENSION"


### PR DESCRIPTION
Python sorts as: [' ', '#', '(', '*', '+', '-', ':', '=', 'A', 'Z', '[', 'a', 'z']
Changing to square brackets makes it easier to insert 'Optional' add-ons above the '[Required]' ones
