### PR TITLE
Fixes for template errors identified by running i18ndude

### DIFF
--- a/src/ploneintranet/core/browser/panel_users.pt
+++ b/src/ploneintranet/core/browser/panel_users.pt
@@ -28,7 +28,6 @@
         </form>
 
         <form id="postbox-users"
-              tal:attributes="action view/action"
               class="search-result users pat-inject pat-autosubmit"
               tal:attributes="action string:${here/absolute_url}/@@newpostbox.tile;
                               data-pat-inject string:source: #${form_id}-selected-users;; target:#${form_id}-selected-users && source: #selected-users-data;; target: #selected-users-data">

--- a/src/ploneintranet/search/browser/templates/search_template.pt
+++ b/src/ploneintranet/search/browser/templates/search_template.pt
@@ -3,11 +3,8 @@
       xmlns:metal="http://xml.zope.org/namespaces/metal"
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       lang="en"
-      metal:use-macro="context/main_template/macros/master"
       metal:define-macro="search"
       i18n:domain="ploneintranet">
-
-    <metal:content fill-slot="content">
 
     <form action="${view/__name__}" id="global-search" class="pat-autosubmit pat-inject"
           data-pat-inject="source: #results; target: #results; && source: #tabs-nav; target: #tabs-nav; history: record;">
@@ -39,7 +36,5 @@
             <metal:results metal:define-slot="results" />
         </div>
     </form>
-
-    </metal:content>
 
 </html>

--- a/src/ploneintranet/search/browser/templates/search_template.pt
+++ b/src/ploneintranet/search/browser/templates/search_template.pt
@@ -1,10 +1,10 @@
+<metal:macro define-macro="search">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
       xmlns:tal="http://xml.zope.org/namespaces/tal"
       xmlns:metal="http://xml.zope.org/namespaces/metal"
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       lang="en"
       metal:use-macro="context/main_template/macros/master"
-      metal:define-macro="search"
       i18n:domain="ploneintranet">
 
     <metal:content fill-slot="content">
@@ -43,3 +43,4 @@
     </metal:content>
 
 </html>
+</metal:macro>

--- a/src/ploneintranet/search/browser/templates/search_template.pt
+++ b/src/ploneintranet/search/browser/templates/search_template.pt
@@ -3,8 +3,11 @@
       xmlns:metal="http://xml.zope.org/namespaces/metal"
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       lang="en"
+      metal:use-macro="context/main_template/macros/master"
       metal:define-macro="search"
       i18n:domain="ploneintranet">
+
+    <metal:content fill-slot="content">
 
     <form action="${view/__name__}" id="global-search" class="pat-autosubmit pat-inject"
           data-pat-inject="source: #results; target: #results; && source: #tabs-nav; target: #tabs-nav; history: record;">
@@ -36,5 +39,7 @@
             <metal:results metal:define-slot="results" />
         </div>
     </form>
+
+    </metal:content>
 
 </html>

--- a/src/ploneintranet/theme/browser/templates/main_template.pt
+++ b/src/ploneintranet/theme/browser/templates/main_template.pt
@@ -45,8 +45,7 @@
   <body tal:define="isRTL portal_state/is_rtl;
                     body_class python:plone_layout.bodyClass(template, view);"
         tal:attributes="class body_class;
-                        dir python:isRTL and 'rtl' or 'ltr';
-                        python:plone_view.patterns_settings()"
+                        dir python:isRTL and 'rtl' or 'ltr'"
         id="visual-portal-wrapper">
 
     <header id="portal-top" i18n:domain="plone">

--- a/src/ploneintranet/theme/browser/templates/personal_bar.pt
+++ b/src/ploneintranet/theme/browser/templates/personal_bar.pt
@@ -18,7 +18,6 @@
 	  <li tal:repeat="action view/user_actions"
               tal:attributes="id string:personaltools-${action/id}">
               <a href=""
-		 tal:attributes="action"
 		 tal:content="action/title"
 		 i18n:translate="">
 		  action title

--- a/src/ploneintranet/theme/browser/templates/workspace-add.pt
+++ b/src/ploneintranet/theme/browser/templates/workspace-add.pt
@@ -43,7 +43,7 @@
                 </select>
 
                 <fieldset class="group pat-checklist radio" tal:condition="python: len(wfs) <=6">
-                    <label tal:repeat="wf view/workflows"><input type="radio" name="workflow"  checked="checked" tal:content="wf/title" tal:attributes="value wf/id"/></label>
+                    <label tal:repeat="wf view/workflows"><input type="radio" name="workflow"  checked="checked" tal:attributes="value wf/id"/>${wf/title}</label>
                 </fieldset>
               </label>
             </fieldset>

--- a/src/ploneintranet/userprofile/browser/templates/userprofile.pt
+++ b/src/ploneintranet/userprofile/browser/templates/userprofile.pt
@@ -31,7 +31,7 @@
                     </h2>
                     <ul class="menu">
                         <li class="mail">
-                            <a class="icon-mail" i18n:attributes="title" tal:attributes="title string:Mail ${context/fullname} via ${context/email}" tal:attributes="href string:mailto:${context/email}" tal:content="context/email" />
+                            <a class="icon-mail" i18n:attributes="title" tal:attributes="title string:Mail ${context/fullname} via ${context/email}; href string:mailto:${context/email}" tal:content="context/email" />
                         </li>
                         <li class="phone" tal:condition="context/mobile|nothing">
                             <a class="icon-phone" i18n:attributes="title" tal:attributes="title string:Call ${context/fullname} at ${context/mobile}; href string:tel:${context/mobile}"

--- a/src/ploneintranet/workspace/browser/templates/content_macros.pt
+++ b/src/ploneintranet/workspace/browser/templates/content_macros.pt
@@ -27,7 +27,7 @@
         Due date
         <input type="date"
                name="due"
-               tal:attributes="value context/due|nothing"
+               tal:attributes="value context/due | nothing"
                data-pat-autosubmit="delay: defocus"
                data-pat-date-picker="behaviour: polyfill; show: date"
                class="pat-date-picker" placeholder="Set a deadline"/>
@@ -65,16 +65,16 @@
         <metal:extra-fields-top define-slot="extra-fields-top"/>
 
                 <label class="location">
-                    Location <input name="location" tal:attributes="disabled read_only" type="text" value="" tal:attributes="value context/location | nothing">
+                    Location <input name="location" type="text" value="" tal:attributes="disabled read_only; value context/location | nothing">
                 </label>
                 <br>
                 <label class="organiser">
-                    Organiser <input tal:attributes="disabled read_only" class="pat-autosuggest users" data-pat-autosuggest="" type="text" value="" tal:attributes="value context/organiser | nothing">
+                    Organiser <input class="pat-autosuggest users" data-pat-autosuggest="" type="text" value="" tal:attributes="disabled read_only; value context/organiser | nothing">
                 </label>
                 <br>
                 <fieldset class="pat-checklist options">
                     <label>
-                        <input tal:attributes="checked python:context.whole_day" tal:attributes="disabled read_only" type="checkbox"> All day event
+                        <input tal:attributes="disabled read_only; checked python:context.whole_day" type="checkbox"> All day event
                     </label>
                     <br>
                     <label>


### PR DESCRIPTION
This fixes errors identified by running ./synci18n.sh, but it may be that this also breaks things since I don't know what happens when there are duplicate tal:attributes for an element, and similar issues.
