### PR TITLE
fullname is calculated now, don't attempt to update it on subsequent run

### DIFF
--- a/src/ploneintranet/suite/setuphandlers.py
+++ b/src/ploneintranet/suite/setuphandlers.py
@@ -72,7 +72,8 @@ def create_users(context, users, avatars_dir):
             # Already exists - update
             profile = pi_api.userprofile.get(userid)
             for key, value in properties.items():
-                setattr(profile, key, value)
+                if key != 'fullname':  # now this field is calculated
+                    setattr(profile, key, value)
             logger.info('Updated user {}'.format(userid))
 
         portrait_path = os.path.join(avatars_dir, portrait_filename)


### PR DESCRIPTION
With the new user pofiles, the fullname is now calculated and can't be set anymore. Our setuphandlers code tries to set all profile attributes once again, if run a second time. By now, the new user profiles are applied and fullname can't be set anymore. Therefore we shouldn't attempt to.
