### PR TITLE
Implement the new extended sidebar

### DIFF
--- a/src/ploneintranet/workspace/browser/tiles/sidebar.py
+++ b/src/ploneintranet/workspace/browser/tiles/sidebar.py
@@ -378,7 +378,10 @@ class Sidebar(BaseTile):
                 structural_type=structural_type,
                 content_type=content_type,
                 dpi=dpi,
-                url=url
+                url=url,
+                creator=api.user.get(username=r['Creator']),
+                modified=r['modified'],
+                subject=r['Subject']
             ))
         return results
 

--- a/src/ploneintranet/workspace/browser/tiles/templates/sidebar-settings-members.pt
+++ b/src/ploneintranet/workspace/browser/tiles/templates/sidebar-settings-members.pt
@@ -19,6 +19,7 @@
               </h3>
               <div class="quick-functions">
                 
+                <a class="toggle-sidebar-size pat-toggle" data-pat-toggle="selector: body; value: sidebar-normal sidebar-large" title="expand/reduce sidebar">Expand sidebar</a>
                 <a title="Show functions" class="member-list-toggle-select more-menu-trigger">Functions</a>
                 
                 <a class="toggle-select-mode pat-toggle member-list-toggle-select" data-pat-toggle="selector: #member-list; value: mode-select mode-follow">Select</a>

--- a/src/ploneintranet/workspace/browser/tiles/templates/sidebar.pt
+++ b/src/ploneintranet/workspace/browser/tiles/templates/sidebar.pt
@@ -47,6 +47,7 @@
               </div>
 
               <div class="quick-functions">
+                <a class="toggle-sidebar-size pat-toggle" data-pat-toggle="selector: body; value: sidebar-normal sidebar-large" title="expand/reduce sidebar">Expand sidebar</a>
                 <a class="selector-toggle-select more-menu-trigger">Functions</a>
                 <a tal:condition="can_add" title="Create document" href="/panel-create-document.html#document-content" class="create-document pat-modal icon-doc-text" data-pat-modal="class: large"
                    tal:attributes="href string:${context/absolute_url}/add_content"
@@ -183,6 +184,18 @@ Supported types include (class names):
 
                       <dfn class="byline" tal:content="item/description" tal:condition="item/description">An interactive workshop to test new and innovative tools to trace people through time.</dfn>
                     </a>
+                    <div class="additional-meta-data">
+                        <a href="/guido-stevens/" class="author meta-column" title="Author of this document" i18n:attributes="title" tal:define="creator item/creator" tal:content="python:creator.getProperty('fullname')" tal:attributes="href string:${here/portal_url}/author/${creator/getId}">
+                            Creator
+                        </a>
+                        <time class="modification-date meta-column" title="Date and time of the latest modification" i18n:attributes="title" tal:content="python:item['modified'].strftime('%d %B %Y, %H:%M')">
+                            {{ doc.date }}
+                        </time>
+                        <nav class="tag-cloud tags meta-column">
+                            <a tal:repeat="subject item/subject" href="#" class="tag" tal:content="subject">Finanzplanung</a>
+                        </nav>
+                    </div>
+
                   </label>
                 </tal:block>
 
@@ -261,6 +274,7 @@ Supported types include (class names):
           <div class="button-bar functions" id="tasks-functions">
 
             <div class="quick-functions">
+              <a class="toggle-sidebar-size pat-toggle" data-pat-toggle="selector: body; value: sidebar-normal sidebar-large" title="expand/reduce sidebar">Expand sidebar</a>
               <a title="Create new task"
                  class="create-document pat-modal icon-doc-text" data-pat-modal="class: large" data-pat-inject="source:#content"
                  tal:attributes="href string:${ws/absolute_url}/add_task"
@@ -353,6 +367,7 @@ Supported types include (class names):
         <div id="workspace-events" tal:define="events view/events; ws view/workspace">
           <div class="button-bar functions" id="-functions">
             <div class="quick-functions">
+              <a class="toggle-sidebar-size pat-toggle" data-pat-toggle="selector: body; value: sidebar-normal sidebar-large" title="expand/reduce sidebar">Expand sidebar</a>
               <a tal:condition="can_add" title="Create new event" href="/panel-create-event.html#document-content" class="create-document pat-modal icon-doc-text" data-pat-modal="class: large" data-pat-inject="source:#content" tal:attributes="href string:${ws/absolute_url}/add_event">Create event</a>
             </div>
           </div>


### PR DESCRIPTION
Cornelis has done a sidebar extender button. This is specially interesting for the file sidebar where we now can show additional metadata like tags, modification date and author. It currently shows on the sidebars for docs, events and tasks plus on the members settings tab.
