### PR TITLE
Events: use a custom widget for dates

### DIFF
--- a/src/ploneintranet/suite/tests/acceptance/workspace.robot
+++ b/src/ploneintranet/suite/tests/acceptance/workspace.robot
@@ -119,6 +119,11 @@ Member can submit a document
      When I submit the content item
      Then I cannot edit the document
 
+Member can create an event
+    Given I am in a workspace as a workspace member
+     When I can create a new event  Christmas  2014-12-25  2014-12-26
+     Then I can edit an event  Christmas  2120-12-25  2121-12-26
+
 Member can submit and retract a document
     Given I am in a workspace as a workspace member
      When I can create a new document    My substandard document

--- a/src/ploneintranet/suite/tests/lib/keywords.robot
+++ b/src/ploneintranet/suite/tests/lib/keywords.robot
@@ -308,6 +308,27 @@ I can create a structure
     Click element  xpath=//a/strong[contains(text(), 'Another Folder')]
     Wait Until Page Contains Element  xpath=//a[@class='pat-inject follow'][contains(@href, '/document-in-subfolder')]
 
+I can create a new event
+    [arguments]  ${title}  ${start}  ${end}
+    Click link  Events
+    Click Link  Create event
+    Wait Until Page Contains Element  css=.panel-content form .panel-body
+    Input Text  css=.panel-content input[name=title]  text=${title}
+    Input Text  css=.panel-content input[name=start]  text=${start}
+    Input Text  css=.panel-content input[name=end]  text=${end}
+    Click Button  css=#form-buttons-create
+
+I can edit an event
+    [arguments]  ${title}  ${start}  ${end}
+    Reload Page
+    Click link  Events
+    Click Element  xpath=//h3[text()='Older events']
+    Click link  ${title}
+    Wait Until Page Contains Element  css=div.event-details
+    Input Text  css=div.event-details input[name=start]  text=${start}
+    Input Text  css=div.event-details input[name=end]  text=${end}
+    Click Button  Save
+
 The file appears in the sidebar
     Wait until Page contains Element  xpath=//input[@name='bartige_flosser.odt']  timeout=20 s
 

--- a/src/ploneintranet/workspace/basecontent/configure.zcml
+++ b/src/ploneintranet/workspace/basecontent/configure.zcml
@@ -69,4 +69,8 @@
     permission="zope2.View"
     />
 
+  <adapter factory=".widgets.PatDatePickerConverter" />
+  <adapter factory=".widgets.StartPatDatePickerFieldWidget" />
+  <adapter factory=".widgets.EndPatDatePickerFieldWidget" />
+
 </configure>

--- a/src/ploneintranet/workspace/basecontent/templates/event_view.pt
+++ b/src/ploneintranet/workspace/basecontent/templates/event_view.pt
@@ -42,14 +42,14 @@
                                 <a href="/feedback/panel-event-attachments.html#content" class="icon-attach iconified pat-tooltip" data-pat-tooltip="source: ajax" title="Attach documents" i18n:attributes="title" i18n:translate="">
                                     Attachments
                                 </a>
-                                <!-- <a class="icon-info-circle meta-data-toggle iconified" title="Show extra metadata fields">Toggle extra metadata</a> -->
-                                <!-- <a href="" class="icon-copy iconified" title="Copy this document" i18n:attributes="title" i18n:translate="">
+                                <a class="icon-info-circle meta-data-toggle iconified" title="Show extra metadata fields" i18n:attributes="title" i18n:translate="">Toggle extra metadata</a>
+                                <!-- <a href="" class="icon-copy iconified" title="Copy this document">
                                     Copy
                                 </a>
                                 <a href="#share-panel" class="icon-export iconified pat-modal" title="Share this document" i18n:attributes="title" i18n:translate="">
                                     Share
                                 </a>
-                                <a class="icon-info-circle meta-data-toggle iconified" title="Show extra metadata fields" i18n:attributes="title" i18n:translate="">Toggle extra metadata</a>
+                                 <a class="icon-info-circle meta-data-toggle iconified" title="Show extra metadata fields">Toggle extra metadata</a>
                                 <fieldset class="pat-subform pat-autosubmit pat-inject" data-pat-inject="target: #document-content::before; url: /feedback/banner-notifications.html; source: #workflow-state-changed::element;">
                                     <label class="pat-select bare" title="Change the workflow state">
                                         <select>
@@ -69,10 +69,14 @@
 
                             </div>
                         </div>
-                        <!-- <fieldset class="pat-collapsible open meta-extra" data-pat-collapsible="trigger: .meta-data-toggle" id="meta-extra"> -->
+                        <fieldset class="pat-collapsible closed meta-extra" data-pat-collapsible="trigger: .meta-data-toggle" id="meta-extra">
                             <!-- <fieldset class="bar">
                                 <input type="text" class="pat-autosuggest" placeholder="Tags" />
                             </fieldset> -->
+                            <fieldset class="bar description">
+                                <textarea name="description" tal:attributes="disabled read_only" rows="8" title="Description" placeholder="Description">${context/description}</textarea>
+                             </fieldset>
+
                             <!-- <fieldset class="bar versioning">
                                 <label>
                                     <input type="checkbox" name="cmfeditions_save_new_version" id="cmfeditions_save_new_version" /> Save a new version
@@ -88,14 +92,14 @@
                                     <button type="submit" name="submit" value="submit" class="submit">Save this version</button>
                                 </fieldset>
                             </fieldset> -->
-                        <!-- </fieldset> -->
+                        </fieldset>
                     </div>
                     <div id="document-content">
-                        <div class="document event-details">
-
-                            <metal:task_fields use-macro="context/content_macros/event_fields"/>
-
-                        </div>
+                      <div class="document event-details">
+                        <fieldset class="vertical fancy">
+                          <metal:task_fields use-macro="context/content_macros/event_fields" />
+                        </fieldset>
+                      </div>
                     </div>
                 </form>
             </div>

--- a/src/ploneintranet/workspace/basecontent/widgets.py
+++ b/src/ploneintranet/workspace/basecontent/widgets.py
@@ -1,0 +1,68 @@
+from datetime import datetime
+from plone.app.event.base import default_timezone
+from plone.app.event.dx.behaviors import IEventBasic
+from ploneintranet.workspace.interfaces import IWorkspaceAppFormLayer
+from z3c.form.converter import BaseDataConverter
+from z3c.form.interfaces import IFieldWidget
+from z3c.form.interfaces import IWidget
+from z3c.form.interfaces import NO_VALUE
+from z3c.form.util import getSpecification
+from z3c.form.widget import FieldWidget
+from z3c.form.widget import Widget
+from zope.component import adapter
+from zope.component import adapts
+from zope.interface import implementer
+from zope.interface import implementer_only
+from zope.schema.interfaces import IDatetime
+
+
+class IPatDatePickerWidget(IWidget):
+    """ Marker interface """
+
+
+@implementer_only(IPatDatePickerWidget)
+class PatDatePickerWidget(Widget):
+    """pat-date-picker gives us a list of strings with the date first and the
+    time second. To extract the value we need to convert that to a datetime
+    object.
+
+    :rtype datetime:
+    """
+    def extract(self, default=NO_VALUE):
+        value = self.request.get(self.name, default)
+        if value == default:
+            return default
+        if isinstance(value, str):
+            # Date only
+            date = datetime(value, '%Y-%m-%d')
+        if value[0] == u'':
+            return None
+        else:
+            if value[1] == u'':
+                value[1] = u'0:00'
+            time_str = "{0} {1}".format(*value)
+            date = datetime.strptime(time_str, '%Y-%m-%d %H:%M')
+        date = date.replace(
+            tzinfo=default_timezone(self.context, as_tzinfo=True))
+        return date
+
+
+class PatDatePickerConverter(BaseDataConverter):
+    """toFieldValue just needs to return the datetime object
+    """
+    adapts(IDatetime, IPatDatePickerWidget)
+
+    def toFieldValue(self, value):
+        return value
+
+
+@adapter(getSpecification(IEventBasic['start']), IWorkspaceAppFormLayer)
+@implementer(IFieldWidget)
+def StartPatDatePickerFieldWidget(field, request):
+    return FieldWidget(field, PatDatePickerWidget(request))
+
+
+@adapter(getSpecification(IEventBasic['end']), IWorkspaceAppFormLayer)
+@implementer(IFieldWidget)
+def EndPatDatePickerFieldWidget(field, request):
+    return FieldWidget(field, PatDatePickerWidget(request))

--- a/src/ploneintranet/workspace/browser/templates/add_event.pt
+++ b/src/ploneintranet/workspace/browser/templates/add_event.pt
@@ -5,21 +5,20 @@
   <form method="POST" action="#" tal:attributes="action request/URL" class="wizard-box pat-inject" data-pat-inject="source: #document-body; target: #document-body && source: #workspace-documents; target: #workspace-documents">
     <div class="panel-body">
 
-      <fieldset class="icon-tabs">
-        <label class="icon-ok-circle">
-          <input checked="checked" name="portal_type" value="Event" type="radio" /> <span tal:omit-tag="" i18n:translate="">Event</span>
-        </label>
-      </fieldset>
       <fieldset class="vertical">
         <input type="text" name="title" placeholder="Event title" autofocus />
-        <br/>
-        <textarea name="description" placeholder="Enter a description of the event" rows="6"></textarea>
       </fieldset>
 
       <fieldset class="vertical"
                 tal:define="workspace context/acquire_workspace;
-                            workspace_url context/absolute_url;">
-        <metal:task_fields use-macro="context/content_macros/event_fields"/>
+                            workspace_url context/absolute_url">
+        <label class="description">
+          <tal:desc i18n:domain="plone" i18n:translate="">Description</tal:desc>
+          <textarea name="description" placeholder="Enter a description of the event" rows="6"/>
+        </label>
+        <fieldset class="vertical">
+          <metal:task_fields use-macro="context/content_macros/event_fields"/>
+        </fieldset>
       </fieldset>
 
     </div>
@@ -32,5 +31,6 @@
         Cancel
       </button>
     </div>
+    <input type="hidden" name="portal_type" value="Event"/>
   </form>
 </div>

--- a/src/ploneintranet/workspace/browser/templates/content_macros.pt
+++ b/src/ploneintranet/workspace/browser/templates/content_macros.pt
@@ -52,79 +52,91 @@
       </tal:case_todo>
     </metal:task_fields>
 
-
     <metal:event_fields define-macro="event_fields"
                         tal:define="read_only python:False">
-      <fieldset class="vertical fancy">
-        <label class="description">
-          <span tal:omit-tag="" i18n:translate="">Description</span>
-          <textarea name="description" placeholder="Enter a description of the event"
-                    tal:attributes="disabled read_only" rows="6">${context/description}</textarea>
+
+      <metal:extra-fields-top define-slot="extra-fields-top"/>
+
+      <label class="location">
+        <span tal:omit-tag="" i18n:translate="">Location</span> <input name="location" type="text" value="" tal:attributes="disabled read_only; value context/location | nothing" />
+      </label>
+      <br/>
+      <label class="organiser">
+        <span tal:omit-tag="" i18n:translate="">Organiser</span> <input class="pat-autosuggest users" data-pat-autosuggest="" type="text" value="" tal:attributes="disabled read_only; value context/organiser | nothing"/>
+      </label>
+      <br/>
+      <fieldset class="pat-checklist options">
+        <label>
+          <input tal:attributes="disabled read_only; checked python:context.get('whole_day')" type="checkbox"/> <span tal:omit-tag="" i18n:translate="">All day event</span>
+        </label>
+        <br/>
+        <label>
+          <input type="checkbox" tal:attributes="disabled read_only"/> <span tal:omit-tag="" i18n:translate="">Visible on other calendars</span>
+        </label>
+      </fieldset>
+      <br/>
+      <fieldset class="group date-time">
+        <fieldset class="row group">
+          <fieldset class="group six columns">
+            <legend i18n:translate="">From</legend>
+
+            <div class="row"
+                 tal:define="start context/start | nothing">
+              <label class="six columns">
+
+                <input type="date" tal:attributes="disabled read_only" size="10" class="pat-date-picker" name="start" placeholder="Date" data-pat-date-picker="behaviour: polyfill; show: date" value="${start}"/>
+              </label>
+              <label class="six columns">
+                <input type="time" size="10" class="date" name="start" placeholder="Time"
+                       tal:attributes="disabled read_only;
+                                       value python:start and start.strftime('%H:%M')"/>
+              </label>
+            </div>
+          </fieldset>
+
+          <fieldset class="group six columns">
+            <legend i18n:translate="">To</legend>
+            <div class="row"
+                 tal:define="end context/end | nothing">
+              <label class="six columns">
+                <input type="date" tal:attributes="disabled read_only" size="10" class="pat-date-picker" name="end" placeholder="Date" value="${end}"/>
+              </label>
+              <label class="six columns">
+                <input type="time" size="10" class="date" name="end" placeholder="Time" value=""
+                       tal:attributes="disabled read_only;
+                                       value python:end and end.strftime('%H:%M')"/>
+              </label>
+            </div>
+          </fieldset>
+        </fieldset>
+
+        <label class="timezone"><span tal:omit-tag="" i18n:translate="">Timezone</span>
+        <select class="timezone"  tal:attributes="disabled read_only" >
+          <option data-timezone-id="80" gmt-adjustment="GMT+12:00" data-use-daylight-time="1" value="12">(GMT+12:00) Auckland, Wellington</option>
+          <option data-timezone-id="81" gmt-adjustment="GMT+12:00" data-use-daylight-time="0" value="12">(GMT+12:00) Fiji, Kamchatka, Marshall Is.</option>
+          <option data-timezone-id="82" gmt-adjustment="GMT+13:00" data-use-daylight-time="0" value="13">(GMT+13:00) Nuku'alofa</option>
+        </select>
         </label>
 
-        <metal:extra-fields-top define-slot="extra-fields-top"/>
-
-                <label class="location">
-                    <span tal:omit-tag="" i18n:translate="">Location</span> <input name="location" type="text" value="" tal:attributes="disabled read_only; value context/location | nothing" />
-                </label>
-                <br>
-                <label class="organiser">
-                    <span tal:omit-tag="" i18n:translate="">Organiser</span> <input class="pat-autosuggest users" data-pat-autosuggest="" type="text" value="" tal:attributes="disabled read_only; value context/organiser | nothing">
-                </label>
-                <br>
-                <fieldset class="pat-checklist options">
-                    <label>
-                        <input tal:attributes="disabled read_only; checked python:context.whole_day" type="checkbox"> <span tal:omit-tag="" i18n:translate="">All day event</span>
-                    </label>
-                    <br>
-                    <label>
-                        <input type="checkbox" tal:attributes="disabled read_only"> <span tal:omit-tag="" i18n:translate="">Visible on other calendars</span>
-                    </label>
-                </fieldset>
-                <br>
-                <fieldset class="date-time">
-                    <fieldset class="row">
-                            <fieldset class="group six columns">
-                                <legend i18n:translate="">From</legend>
-                                <input type="date" tal:attributes="disabled read_only" size="10" class="date" name="start-day" placeholder="Date" value="" />
-                                <input type="time" tal:attributes="disabled read_only" size="10" class="date" name="start-time" placeholder="Time" value="" />
-                            </fieldset>
-
-                            <fieldset class="group six columns">
-                                <legend i18n:translate="">To</legend>
-                                <input type="date" tal:attributes="disabled read_only" size="10" class="date" name="end_date-day" placeholder="Date" value=""/>
-                                <input type="time" tal:attributes="disabled read_only" size="10" class="date" name="end_date-time" placeholder="Time" value=""/>
-                            </fieldset>
-                    </fieldset>
-
-                    <label class="timezone"><span tal:omit-tag="" i18n:translate="">Timezone</span>
-                        <select class="timezone"  tal:attributes="disabled read_only" >
-                            <option data-timezone-id="80" gmt-adjustment="GMT+12:00" data-use-daylight-time="1" value="12">(GMT+12:00) Auckland, Wellington</option>
-                            <option data-timezone-id="81" gmt-adjustment="GMT+12:00" data-use-daylight-time="0" value="12">(GMT+12:00) Fiji, Kamchatka, Marshall Is.</option>
-                            <option data-timezone-id="82" gmt-adjustment="GMT+13:00" data-use-daylight-time="0" value="13">(GMT+13:00) Nuku'alofa</option>
-                        </select>
-                    </label>
-
-                </fieldset>
-                    <label class="invitees"><span tal:omit-tag="" i18n:translate="">Invitees</span>
-                        <input class="pat-autosuggest users" tal:attributes="disabled read_only" data-pat-autosuggest=""
-                            data-pat-autosuggest-classes=''>
+      </fieldset>
+      <label class="invitees"><span tal:omit-tag="" i18n:translate="">Invitees</span>
+      <input class="pat-autosuggest users" tal:attributes="disabled read_only" data-pat-autosuggest=""
+             data-pat-autosuggest-classes=''/>
 
 
-                        <span class="legend">
-                            <dfn class="undecided" i18n:translate="">Undecided</dfn>
-                            <dfn class="confirmed" i18n:translate="">Confirmed</dfn>
-                            <dfn class="tentative" i18n:translate="">Tentative</dfn>
-                            <dfn class="declined" i18n:translate="">Declined</dfn>
-                        </span>
+      <span class="legend">
+        <dfn class="undecided" i18n:translate="">Undecided</dfn>
+        <dfn class="confirmed" i18n:translate="">Confirmed</dfn>
+        <dfn class="tentative" i18n:translate="">Tentative</dfn>
+        <dfn class="declined" i18n:translate="">Declined</dfn>
+      </span>
 
-                    </label>
+      </label>
 
-                <label class="attachments"  tal:define="read_only python:False"><span tal:omit-tag="" i18n:translate="">Attached documents from this workspace</span>
-                    <input tal:attributes="disabled read_only" class="pat-autosuggest documents" data-pat-autosuggest="" type="text" value="">
-                </label>
+      <label class="attachments"  tal:define="read_only python:False"><span tal:omit-tag="" i18n:translate="">Attached documents from this workspace</span>
+      <input tal:attributes="disabled read_only" class="pat-autosuggest documents" data-pat-autosuggest="" type="text" value=""/>
+      </label>
 
-            </fieldset>
     </metal:event_fields>
 
   </body>


### PR DESCRIPTION
We need a custom z3c.form widget to save dates and times on events so that we can use the dexterity_update mechanism. Timezones are not yet supported.
