### PR TITLE
Library Security

### DIFF
--- a/src/ploneintranet/library/browser/baseviews.zcml
+++ b/src/ploneintranet/library/browser/baseviews.zcml
@@ -7,17 +7,13 @@
     xmlns:plone="http://namespaces.plone.org/plone"
     i18n_domain="ploneintranet">
 
-  <!-- the content permissions below
-       need to become zope2.View with proper workflow applied -->
-  <include package="ploneintranet.layout" file="permissions.zcml" />
-
   <browser:page
     name="document_view"
     for="plone.app.contenttypes.interfaces.IDocument"
     layer="ploneintranet.library.interfaces.ILibraryContentLayer"
     template="templates/page.pt"
     class=".baseviews.ContentView"
-    permission="ploneintranet.viewsite"
+    permission="zope2.View"
     />
 
   <browser:page
@@ -26,7 +22,7 @@
     layer="ploneintranet.library.interfaces.ILibraryContentLayer"
     template="templates/page.pt"
     class=".baseviews.ContentView"
-    permission="ploneintranet.viewsite"
+    permission="zope2.View"
     />
 
 </configure>

--- a/src/ploneintranet/library/browser/configure.zcml
+++ b/src/ploneintranet/library/browser/configure.zcml
@@ -17,15 +17,13 @@
      permission="ploneintranet.viewsite"
      />
 
-  <!-- the content permissions below and in baseviews
-       need to become zope2.View with proper workflow applied -->
   <browser:page
      name="view"
      for="ploneintranet.library.content.ILibraryApp"
      class=".views.LibraryAppView"
      template="templates/library.html"
      layer="ploneintranet.library.interfaces.IPloneintranetLibraryLayer"
-     permission="ploneintranet.viewsite"
+     permission="zope2.View"
      />
 
   <browser:page
@@ -34,7 +32,7 @@
      class=".views.LibrarySectionView"
      template="templates/library.html"
      layer="ploneintranet.library.interfaces.IPloneintranetLibraryLayer"
-     permission="ploneintranet.viewsite"
+     permission="zope2.View"
      />
 
   <browser:page
@@ -43,7 +41,7 @@
      class=".views.LibraryFolderView"
      template="templates/library.html"
      layer="ploneintranet.library.interfaces.IPloneintranetLibraryLayer"
-     permission="ploneintranet.viewsite"
+     permission="zope2.View"
      />
 
 </configure>

--- a/src/ploneintranet/library/browser/utils.py
+++ b/src/ploneintranet/library/browser/utils.py
@@ -7,24 +7,29 @@ folderish = ('ploneintranet.library.section',
              'ploneintranet.library.folder')
 pageish = ('Document', 'News Item', 'Link', 'File')
 hidden = ('Image')
+types_to_show = list(folderish) + list(pageish)
 
 
-def sections_of(context):
+def sections_of(context, **kwargs):
+    if 'portal_type' not in kwargs:
+        kwargs.update(portal_type=types_to_show)
+    results = context.restrictedTraverse('@@folderListing')(**kwargs)
     struct = []
-    for child in context.objectValues():
-        if child.portal_type in hidden:
+    for item in results:
+        if item.portal_type in hidden:
             continue
-        elif child.portal_type in folderish:
+        elif item.portal_type in folderish:
             type_ = 'container'
-        elif child.portal_type in pageish:
+        elif item.portal_type in pageish:
             type_ = 'document'
         else:
             # to add: collection, newsitem, event, link, file
             type_ = 'unsupported'
-            log.error("Unsupported type %s", child.portal_type)
-        section = dict(title=child.Title(),
-                       description=child.Description(),
-                       absolute_url=child.absolute_url(),
+            log.error("Unsupported type %s", item.portal_type)
+        child = item.getObject()
+        section = dict(title=item.title,
+                       description=item.description,
+                       absolute_url=item.getURL(),
                        type=type_,
                        context=child)
         section['content'] = children_of(child)
@@ -32,22 +37,25 @@ def sections_of(context):
     return struct
 
 
-def children_of(context):
+def children_of(context, **kwargs):
+    if 'portal_type' not in kwargs:
+        kwargs.update(portal_type=types_to_show)
+    results = context.restrictedTraverse('@@folderListing')(**kwargs)
     content = []
-    for child in context.objectValues():
-        if child.portal_type in hidden:
+    for item in results:
+        if item.portal_type in hidden:
             continue
-        elif child.portal_type in folderish:
+        elif item.portal_type in folderish:
             (follow, icon) = ("follow-section", "icon-squares")
-        elif child.portal_type in pageish:
+        elif item.portal_type in pageish:
             (follow, icon) = ("follow-page", "icon-page")
         else:
             # to add: collection, newsitem, event, link, file
-            log.error("Unsupported type %s", child.portal_type)
+            log.error("Unsupported type %s", item.portal_type)
             (follow, icon) = ("follow-x", "icon-x")
         content.append(dict(
-            title=child.Title(),
-            absolute_url=child.absolute_url(),
+            title=item.title,
+            absolute_url=item.getURL(),
             follow=follow,
             icon=icon))
     return content

--- a/src/ploneintranet/library/setuphandlers.py
+++ b/src/ploneintranet/library/setuphandlers.py
@@ -17,11 +17,10 @@ def setupVarious(context):
     portal = context.getSite()
     catalog = api.portal.get_tool('portal_catalog')
     if len(catalog(portal_type='ploneintranet.library.app')) == 0:
-        library = api.content.create(
+        api.content.create(
             type='ploneintranet.library.app',
             title='Library',
             container=portal)
-        api.content.transition(library, "publish")
 
     # profiles/default/registry.xml has no effect
     registry = getUtility(IRegistry)

--- a/src/ploneintranet/suite/profiles/default/workflows.xml
+++ b/src/ploneintranet/suite/profiles/default/workflows.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<object name="portal_workflow" meta_type="Plone Workflow Tool">
+ <property
+    name="title">Contains workflow definitions for your portal</property>
+ <object name="simple_intranet_workflow" meta_type="Workflow"/>
+ <bindings>
+  <default>
+   <bound-workflow workflow_id="simple_intranet_workflow"/>
+  </default>
+  <type type_id="File">
+   <bound-workflow workflow_id="(Default)"/>
+  </type>
+ </bindings>
+</object>

--- a/src/ploneintranet/suite/profiles/default/workflows/simple_intranet_workflow/definition.xml
+++ b/src/ploneintranet/suite/profiles/default/workflows/simple_intranet_workflow/definition.xml
@@ -1,0 +1,191 @@
+<?xml version="1.0"?>
+<dc-workflow workflow_id="simple_intranet_workflow" title="Simple Publication Workflow" description=" - Simple workflow that is useful for basic intranets. Based on simple_publication_workflow but does not allow access to Anonymous at all: replaces Anonymous with Authenticated. - Things start out as private, and can either be submitted for review, or published directly. - The creator of a content item can edit the item even after it is published." state_variable="review_state"         initial_state="private" manager_bypass="False" >
+ <permission>Access contents information</permission>
+ <permission>Change portal events</permission>
+ <permission>Modify portal content</permission>
+ <permission>View</permission>
+ <state state_id="pending" title="Pending review" >
+  <description>Waiting to be reviewed, not editable by the owner.</description>
+  <exit-transition transition_id="publish" />
+  <exit-transition transition_id="reject" />
+  <exit-transition transition_id="retract" />
+  <permission-map name="Access contents information" acquired="False">
+   <permission-role>Manager</permission-role>
+   <permission-role>Owner</permission-role>
+   <permission-role>Editor</permission-role>
+   <permission-role>Reader</permission-role>
+   <permission-role>Contributor</permission-role>
+   <permission-role>Reviewer</permission-role>
+   <permission-role>Site Administrator</permission-role>
+  </permission-map>
+  <permission-map name="Change portal events" acquired="False">
+   <permission-role>Manager</permission-role>
+   <permission-role>Reviewer</permission-role>
+   <permission-role>Site Administrator</permission-role>
+  </permission-map>
+  <permission-map name="Modify portal content" acquired="False">
+   <permission-role>Manager</permission-role>
+   <permission-role>Reviewer</permission-role>
+   <permission-role>Site Administrator</permission-role>
+  </permission-map>
+  <permission-map name="View" acquired="False">
+   <permission-role>Manager</permission-role>
+   <permission-role>Owner</permission-role>
+   <permission-role>Editor</permission-role>
+   <permission-role>Reader</permission-role>
+   <permission-role>Contributor</permission-role>
+   <permission-role>Reviewer</permission-role>
+   <permission-role>Site Administrator</permission-role>
+  </permission-map>
+  
+  
+ </state>
+ <state state_id="private" title="Private" >
+  <description>Can only be seen and edited by the owner.</description>
+  <exit-transition transition_id="publish" />
+  <exit-transition transition_id="submit" />
+  <permission-map name="Access contents information" acquired="False">
+   <permission-role>Manager</permission-role>
+   <permission-role>Owner</permission-role>
+   <permission-role>Editor</permission-role>
+   <permission-role>Reader</permission-role>
+   <permission-role>Contributor</permission-role>
+   <permission-role>Site Administrator</permission-role>
+  </permission-map>
+  <permission-map name="Change portal events" acquired="False">
+   <permission-role>Manager</permission-role>
+   <permission-role>Owner</permission-role>
+   <permission-role>Editor</permission-role>
+   <permission-role>Site Administrator</permission-role>
+  </permission-map>
+  <permission-map name="Modify portal content" acquired="False">
+   <permission-role>Manager</permission-role>
+   <permission-role>Owner</permission-role>
+   <permission-role>Editor</permission-role>
+   <permission-role>Site Administrator</permission-role>
+  </permission-map>
+  <permission-map name="View" acquired="False">
+   <permission-role>Manager</permission-role>
+   <permission-role>Owner</permission-role>
+   <permission-role>Editor</permission-role>
+   <permission-role>Reader</permission-role>
+   <permission-role>Contributor</permission-role>
+   <permission-role>Site Administrator</permission-role>
+  </permission-map>
+  
+  
+ </state>
+ <state state_id="published" title="Published" >
+  <description>Visible to everyone, editable by the owner.</description>
+  <exit-transition transition_id="retract" />
+  <exit-transition transition_id="reject" />
+  <permission-map name="Access contents information" acquired="False">
+   <permission-role>Authenticated</permission-role>
+  </permission-map>
+  <permission-map name="Change portal events" acquired="False">
+   <permission-role>Manager</permission-role>
+   <permission-role>Owner</permission-role>
+   <permission-role>Editor</permission-role>
+   <permission-role>Site Administrator</permission-role>
+  </permission-map>
+  <permission-map name="Modify portal content" acquired="False">
+   <permission-role>Manager</permission-role>
+   <permission-role>Owner</permission-role>
+   <permission-role>Editor</permission-role>
+   <permission-role>Site Administrator</permission-role>
+  </permission-map>
+  <permission-map name="View" acquired="False">
+   <permission-role>Authenticated</permission-role>
+  </permission-map>
+  
+  
+ </state>
+ <transition transition_id="publish" title="Reviewer publishes content" new_state="published" trigger="USER" before_script="" after_script="" >
+  <description>Publishing the item makes it visible to other logged-in users.</description>
+  <action url="%(content_url)s/content_status_modify?workflow_action=publish" category="workflow" icon="">Publish</action>
+  <guard >
+   <guard-permission>Review portal content</guard-permission>
+  </guard>
+  
+ </transition>
+ <transition transition_id="reject" title="Reviewer sends content back for re-drafting" new_state="private" trigger="USER" before_script="" after_script="" >
+  <description>Sending the item back will return the item to the original author instead of publishing it. You should preferably include a reason for why it was not published.</description>
+  <action url="%(content_url)s/content_status_modify?workflow_action=reject" category="workflow" icon="">Send back</action>
+  <guard >
+   <guard-permission>Review portal content</guard-permission>
+  </guard>
+  
+ </transition>
+ <transition transition_id="retract" title="Member retracts submission" new_state="private" trigger="USER" before_script="" after_script="" >
+  <description>If you submitted the item by mistake or want to perform additional edits, this will take it back.</description>
+  <action url="%(content_url)s/content_status_modify?workflow_action=retract" category="workflow" icon="">Retract</action>
+  <guard >
+   <guard-permission>Request review</guard-permission>
+  </guard>
+  
+ </transition>
+ <transition transition_id="submit" title="Member submits content for publication" new_state="pending" trigger="USER" before_script="" after_script="" >
+  <description>Puts your item in a review queue, so it can be published on the site.</description>
+  <action url="%(content_url)s/content_status_modify?workflow_action=submit" category="workflow" icon="">Submit for publication</action>
+  <guard >
+   <guard-permission>Request review</guard-permission>
+  </guard>
+  
+ </transition>
+ <worklist worklist_id="reviewer_queue" title="" >
+  <description>Reviewer tasks</description>
+  <action url="%(portal_url)s/search?review_state=pending" category="global" icon="">Pending (%(count)d)</action>
+  <guard >
+   <guard-permission>Review portal content</guard-permission>
+  </guard>
+  <match name="review_state" values="pending" />
+ </worklist>
+ <variable variable_id="action" for_catalog="False" for_status="True" update_always="True" >
+  <description>Previous transition</description>
+  <default>
+   
+   <expression>transition/getId|nothing</expression>
+  </default>
+  <guard >
+  </guard>
+ </variable>
+ <variable variable_id="actor" for_catalog="False" for_status="True" update_always="True" >
+  <description>The ID of the user who performed the previous transition</description>
+  <default>
+   
+   <expression>user/getId</expression>
+  </default>
+  <guard >
+  </guard>
+ </variable>
+ <variable variable_id="comments" for_catalog="False" for_status="True" update_always="True" >
+  <description>Comment about the last transition</description>
+  <default>
+   
+   <expression>python:state_change.kwargs.get('comment', '')</expression>
+  </default>
+  <guard >
+  </guard>
+ </variable>
+ <variable variable_id="review_history" for_catalog="False" for_status="False" update_always="False" >
+  <description>Provides access to workflow history</description>
+  <default>
+   
+   <expression>state_change/getHistory</expression>
+  </default>
+  <guard >
+   <guard-permission>Request review</guard-permission>
+   <guard-permission>Review portal content</guard-permission>
+  </guard>
+ </variable>
+ <variable variable_id="time" for_catalog="False" for_status="True" update_always="True" >
+  <description>When the previous transition was performed</description>
+  <default>
+   
+   <expression>state_change/getDateTime</expression>
+  </default>
+  <guard >
+  </guard>
+ </variable>
+ 
+</dc-workflow>

--- a/src/ploneintranet/suite/profiles/default/workflows/simple_intranet_workflow/definition.xml
+++ b/src/ploneintranet/suite/profiles/default/workflows/simple_intranet_workflow/definition.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<dc-workflow workflow_id="simple_intranet_workflow" title="Simple Publication Workflow" description=" - Simple workflow that is useful for basic intranets. Based on simple_publication_workflow but does not allow access to Anonymous at all: replaces Anonymous with Authenticated. - Things start out as private, and can either be submitted for review, or published directly. - The creator of a content item can edit the item even after it is published." state_variable="review_state"         initial_state="private" manager_bypass="False" >
+<dc-workflow workflow_id="simple_intranet_workflow" title="Simple Intranet Workflow" description=" - Simple workflow that is useful for basic intranets. Based on simple_publication_workflow but does not allow access to Anonymous at all: replaces Anonymous with Authenticated. - Things start out as private, and can either be submitted for review, or published directly. - The creator of a content item can edit the item even after it is published." state_variable="review_state"         initial_state="private" manager_bypass="False" >
  <permission>Access contents information</permission>
  <permission>Change portal events</permission>
  <permission>Modify portal content</permission>

--- a/src/ploneintranet/suite/setuphandlers.py
+++ b/src/ploneintranet/suite/setuphandlers.py
@@ -582,6 +582,7 @@ def create_library_content(parent, spec, force=False):
             roles=['Contributor', 'Reviewer', 'Editor'],
             obj=portal.library
         )
+        api.content.transition(portal.library, 'publish')
         # check only on initial call
         if not force and len(portal.library.objectIds()) > 0:
             log.info("library already setup. skipping for speed.")


### PR DESCRIPTION
Security fixes for library. Good for merge if Jenkins is green.

Test coverage is missing. To test manually:
- run suite testcontent profile
- log into cms.localhost:8080 as alice_lindstrom:secret. She's the library editor and content owner
- log into localhost:8080 as allan_neece (normal intranet user)

Manipulating as Alice, library content states between published and other states should change what Allan sees.
