### PR TITLE
Allow setting custom email addresses in test data import

### DIFF
--- a/src/ploneintranet/suite/profiles/testing/users.csv
+++ b/src/ploneintranet/suite/profiles/testing/users.csv
@@ -1,19 +1,19 @@
-userid,fullname,location,description,follows
-admin,Guido Stevens,Amsterdam,"Donec posuere augue in quam.",allan_neece alice_lindstrom
-alice_lindstrom,Alice Lindström,Malmö,"Sed bibendum.",guy_hackey admin
-allan_neece,Allan Neece,Bristol,"Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis varius mi purus non odio.",jorge_primavera guy_hackey admin
-christian_stoney,Christian Stoney,Springfield,"Lorem ipsum dolor sit amet, consectetuer adipiscing elit.",dollie_nocera
-jorge_primavera,Jorge Primavera,Buenos Aires,"Donec pretium posuere tellus.",esmeralda_claassen francois_gast
-dollie_nocera,Dollie Nocera,New York,"Pellentesque tristique imperdiet tortor.",guy_hackey francois_gast
-esmeralda_claassen,Esmeralda Claassen,Oslo,"In id erat non orci commodo lobortis.",jorge_primavera
-fernando_poulter,Fernando Poulter,Barcelona,"Nam a sapien.",dollie_nocera
-francois_gast,François Gast,Tolouse,"Praesent augue.",
-guy_hackey,Guy Hackey,Melbourne,"Nam euismod tellus id erat.",jorge_primavera
-jamie_jacko,Jamie Jacko,Los Angeles,"Fusce commodo.",
-jesse_shaik,Jesse Shaik,London,"Curabitur lacinia pulvinar nibh.",jorge_primavera
-kurt_weissman,Kurt Weißman,Dresden,"Fusce sagittis, libero non molestie mollis, magna orci ultrices dolor, at vulputate neque nulla lacinia eros.",neil_wichmann
-lance_stockstill,Lance Stockstill,Dallas,"Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.",neil_wichmann
-neil_wichmann,Neil Wichmann,Boston,"Phasellus purus.",kurt_weissman lance_stockstill pearlie_whitby
-pearlie_whitby,Pearlie Whitby,Philadelphia,"Nulla facilisis, risus a rhoncus fermentum, tellus tellus lacinia purus, et dictum nunc justo sit amet elit.",neil_wichmann
-rosalinda_roache,Rosalinda Roache,Brussels,"Sed bibendum.",guy_hackey
-silvio_depaoli,Silvio De Paoli,Genoa,"Phasellus neque orci, porta a, aliquet quis, semper a, massa.",jamie_jacko esmeralda_claassen
+userid,email,fullname,location,description,follows
+admin,admin@example.com,Guido Stevens,Amsterdam,"Donec posuere augue in quam.",allan_neece alice_lindstrom
+alice_lindstrom,,Alice Lindström,Malmö,"Sed bibendum.",guy_hackey admin
+allan_neece,,Allan Neece,Bristol,"Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis varius mi purus non odio.",jorge_primavera guy_hackey admin
+christian_stoney,somebody@something.com,Christian Stoney,Springfield,"Lorem ipsum dolor sit amet, consectetuer adipiscing elit.",dollie_nocera
+jorge_primavera,,Jorge Primavera,Buenos Aires,"Donec pretium posuere tellus.",esmeralda_claassen francois_gast
+dollie_nocera,,Dollie Nocera,New York,"Pellentesque tristique imperdiet tortor.",guy_hackey francois_gast
+esmeralda_claassen,,Esmeralda Claassen,Oslo,"In id erat non orci commodo lobortis.",jorge_primavera
+fernando_poulter,,Fernando Poulter,Barcelona,"Nam a sapien.",dollie_nocera
+francois_gast,,François Gast,Tolouse,"Praesent augue.",
+guy_hackey,,Guy Hackey,Melbourne,"Nam euismod tellus id erat.",jorge_primavera
+jamie_jacko,,Jamie Jacko,Los Angeles,"Fusce commodo.",
+jesse_shaik,,Jesse Shaik,London,"Curabitur lacinia pulvinar nibh.",jorge_primavera
+kurt_weissman,,Kurt Weißman,Dresden,"Fusce sagittis, libero non molestie mollis, magna orci ultrices dolor, at vulputate neque nulla lacinia eros.",neil_wichmann
+lance_stockstill,,Lance Stockstill,Dallas,"Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.",neil_wichmann
+neil_wichmann,,Neil Wichmann,Boston,"Phasellus purus.",kurt_weissman lance_stockstill pearlie_whitby
+pearlie_whitby,,Pearlie Whitby,Philadelphia,"Nulla facilisis, risus a rhoncus fermentum, tellus tellus lacinia purus, et dictum nunc justo sit amet elit.",neil_wichmann
+rosalinda_roache,,Rosalinda Roache,Brussels,"Sed bibendum.",guy_hackey
+silvio_depaoli,,Silvio De Paoli,Genoa,"Phasellus neque orci, porta a, aliquet quis, semper a, massa.",jamie_jacko esmeralda_claassen

--- a/src/ploneintranet/suite/setuphandlers.py
+++ b/src/ploneintranet/suite/setuphandlers.py
@@ -92,7 +92,8 @@ def users_spec(context):
             user = {
                 k: v.decode('utf-8') for k, v in user.iteritems()
             }
-            user['email'] = '{}@example.com'.format(decode(user['userid']))
+            if not user.get('email', '').strip():
+                user['email'] = '{}@example.com'.format(decode(user['userid']))
             user['follows'] = [
                 decode(u) for u in user['follows'].split(' ') if u
             ]


### PR DESCRIPTION
A small change to allow importing test data with email addresses other than example.com. Falls back to example.com if the email field is not present or not set.
