### PR TITLE
Fix robot-server: disable commits for robot-server too

### DIFF
--- a/src/ploneintranet/suite/setuphandlers.py
+++ b/src/ploneintranet/suite/setuphandlers.py
@@ -43,7 +43,9 @@ def testing(context):
     # plone.api.env.test_mode doesn't support collective.xmltestreport
     is_test = False
     for frame in traceback.extract_stack():
-        if 'testrunner' in frame[0] or 'testreport/runner' in frame[0]:
+        if 'testrunner' in frame[0] or \
+           'testreport/runner' in frame[0] or \
+           'robot-server' in frame[0]:
             is_test = True
             break
 


### PR DESCRIPTION
This can be tested by running:

```
    bin/robot-server -d \
    ploneintranet.suite.testing.PLONEINTRANET_SUITE_ROBOT
```

Without this change the layer setup fails when trying to create
workspaces:

```
    ComponentLookupError: (<InterfaceClass
    zope.component.interfaces.IFactory>,
    'ploneintranet.workspace.workspacefolder')
```
