### PR TITLE
connected "delete" buttons to delete_confirmation modal, refs #11910

### DIFF
--- a/src/ploneintranet/workspace/basecontent/templates/document_view.pt
+++ b/src/ploneintranet/workspace/basecontent/templates/document_view.pt
@@ -32,7 +32,7 @@
                     <a href="${context/absolute_url}/external_edit"
                        tal:condition="context/externalEditorEnabled/available"
                        class="${view/icon_class} iconified">Open in External Editor</a>
-                    <a href="#confirm-delete" class="icon-trash iconified">Delete</a>
+                    <a href="${context/absolute_url}/delete_confirmation#content" title="Delete this document" i18n:attributes="title" i18n:translate="" data-pat-inject="source: #content" class="pat-modal icon-trash iconified">Delete</a>
                     <a href="" class="icon-copy iconified">Copy</a>
                     <a href="#share-panel" class="icon-export iconified pat-modal">Share</a>
                     <a class="icon-info-circle meta-data-toggle iconified">Toggle extra metadata</a>

--- a/src/ploneintranet/workspace/basecontent/templates/event_view.pt
+++ b/src/ploneintranet/workspace/basecontent/templates/event_view.pt
@@ -36,7 +36,7 @@
                             <button class="pat-switch back-to-parent icon-left-open" data-pat-switch="body focus-* focus-sidebar">${python:context.__parent__.title}</button>
                             <input type="text" name="title" tal:attributes="disabled read_only" placeholder="Document title" class="doc-title pat-content-mirror" data-pat-content-mirror="target: #document-title" value="${context/title}" />
                             <div class="quick-functions">
-                                <a href="#confirm-delete" class="icon-trash iconified" title="Delete this event" i18n:attributes="title" i18n:translate="">
+                                <a href="${context/absolute_url}/delete_confirmation#content" title="Delete this event" i18n:attributes="title" i18n:translate="" data-pat-inject="source: #content" class="pat-modal icon-trash iconified">
                                     Delete
                                 </a>
                                 <a href="/feedback/panel-event-attachments.html#content" class="icon-attach iconified pat-tooltip" data-pat-tooltip="source: ajax" title="Attach documents" i18n:attributes="title" i18n:translate="">

--- a/src/ploneintranet/workspace/browser/tiles/templates/sidebar.pt
+++ b/src/ploneintranet/workspace/browser/tiles/templates/sidebar.pt
@@ -396,7 +396,7 @@ Supported types include (class names):
                         <li tal:define="location event/location" tal:condition="location">Location <span class="location" tal:content="location"></span></li>
                       </ul>
 
-                      <form tal:attributes="action string:${event/getURL}/delete_confirmation">
+                      <form class="pat-modal" tal:attributes="action string:${event/getURL}/delete_confirmation#content">
                         <button class="iconified icon-trash" type="submit">Delete event</button>
                       </form>
                     </li>


### PR DESCRIPTION
Known issue: The delete modal on the document view has a garbled header even though the markup of the link and the delete_confirmation page looks exactly the same to me as on the other views.
