### PR TITLE
Ditch the notifications views and handlers for now

### DIFF
--- a/src/ploneintranet/notifications/browser/configure.zcml
+++ b/src/ploneintranet/notifications/browser/configure.zcml
@@ -3,6 +3,10 @@
     xmlns:browser="http://namespaces.zope.org/browser"
     i18n_domain="ploneintranet.notifications">
 
+  <!--
+      These views are disabled for now, as the implementation
+      is incomplete and missing any security considerations
+
   <browser:page
       for="*"
       name="notifications"
@@ -20,5 +24,6 @@
       template="notificationsviewlet.pt"
       layer=".interfaces.IPloneintranetNotificationsLayer"
       />
+  -->
 
 </configure>

--- a/src/ploneintranet/notifications/events/configure.zcml
+++ b/src/ploneintranet/notifications/events/configure.zcml
@@ -2,6 +2,10 @@
   xmlns="http://namespaces.zope.org/zope"
   i18n_domain="ploneintranet.notifications">
 
+  <!--
+      These views are disabled for now, as the implementation
+      is incomplete and missing any security considerations
+      
   <subscriber
     for="..interfaces.INotifiable
          zope.lifecycleevent.interfaces.IObjectAddedEvent"
@@ -18,5 +22,6 @@
     for="..interfaces.INotifiable
          Products.CMFCore.interfaces.IActionSucceededEvent"
     handler=".base.base_handler" />
+  -->
 
 </configure>

--- a/src/ploneintranet/notifications/tests/test_adapters.py
+++ b/src/ploneintranet/notifications/tests/test_adapters.py
@@ -47,6 +47,9 @@ class TestAdapters(SetUpMixin, unittest.TestCase):
 
     layer = PLONEINTRANET_NOTIFICATIONS_INTEGRATION_TESTING
 
+    # These tests are disabled for now, as the implementation
+    # is incomplete and missing any security considerations
+    @unittest.skip('Skipping disabled features of pi.notifications')
     def test_page(self):
         ''' Let's try to create a page and inspect the created adapter
         '''
@@ -88,6 +91,9 @@ class TestStatusAdapters(SetUpMixin, unittest.TestCase):
         container = api.portal.get_tool('ploneintranet_microblog')
         tearDownContainer(container)
 
+    # These tests are disabled for now, as the implementation
+    # is incomplete and missing any security considerations
+    @unittest.skip('Skipping disabled features of pi.notifications')
     def test_status_update(self):
         ''' Let's try to create a status_update and inspect the created adapter
         '''
@@ -118,6 +124,9 @@ class TestStatusAdapters(SetUpMixin, unittest.TestCase):
             datetime
         )
 
+    # These tests are disabled for now, as the implementation
+    # is incomplete and missing any security considerations
+    @unittest.skip('Skipping disabled features of pi.notifications')
     def test_multiple_status_updates(self):
         ''' Let's try to create multiple status updates.
 


### PR DESCRIPTION
This was an initial, unfinished implementation with no security considerations. It needs overhauling but for now we're just disabling it.
