### PR TITLE
Support tagging while creating new content objects

### DIFF
--- a/src/ploneintranet/network/behaviors/metadata.py
+++ b/src/ploneintranet/network/behaviors/metadata.py
@@ -361,7 +361,12 @@ class Categorization(MetadataBase):
         self.context.subject = value
         graph = getUtility(INetworkTool)
         user = api.user.get_current()
-        uuid = IUUID(self.context)
+        try:
+            uuid = IUUID(self.context)
+        except TypeError:
+            # new factory document, not registered yet
+            # we'll come back to this with an event listener
+            return
         if value:
             graph.tag('content', uuid, user.id, *value)
         # else value==() -> cleaned up below

--- a/src/ploneintranet/network/configure.zcml
+++ b/src/ploneintranet/network/configure.zcml
@@ -21,6 +21,10 @@
     name="ploneintranet.network.vocabularies.Keywords"
     />
 
+  <subscriber
+      for="plone.dexterity.interfaces.IDexterityContent
+           zope.lifecycleevent.interfaces.IObjectAddedEvent"
+      handler=".subscribers.tag_subjects"/>
 
   <genericsetup:registerProfile
       name="default"

--- a/src/ploneintranet/network/subscribers.py
+++ b/src/ploneintranet/network/subscribers.py
@@ -1,0 +1,16 @@
+import logging
+
+from ploneintranet.network.behaviors.metadata import IDublinCore
+
+log = logging.getLogger(__name__)
+
+
+def tag_subjects(context, event):
+    """
+    We can resolve a UUID and store subjects as tags
+    only after a new content item has been added to it's container.
+    """
+    wrapped = IDublinCore(context, None)
+    if wrapped:  # only if the behavior is enabled
+        # re-setting subjects should now trigger graph.tag()
+        wrapped.subjects = context.subject

--- a/src/ploneintranet/network/tests/test_subscribers.py
+++ b/src/ploneintranet/network/tests/test_subscribers.py
@@ -1,0 +1,56 @@
+from plone import api
+from plone.app.testing import SITE_OWNER_NAME
+from plone.app.testing import SITE_OWNER_PASSWORD
+from plone.testing.z2 import Browser
+from plone.uuid.interfaces import IUUID
+import transaction
+
+
+from ploneintranet.network.setuphandlers import restore_all_dublincore
+from ploneintranet.network.testing import FunctionalTestCase
+
+
+class TestSubscribers(FunctionalTestCase):
+
+    def setUp(self):
+        app = self.layer['app']
+        self.portal = self.layer['portal']
+        self.request = self.layer['request']
+        self.portal_url = self.portal.absolute_url()
+        self.graph = api.portal.get_tool('ploneintranet_network')
+        self.browser = Browser(app)
+        self.browser.handleErrors = False
+        self.browser.addHeader(
+            'Authorization',
+            'Basic %s:%s' % (SITE_OWNER_NAME, SITE_OWNER_PASSWORD,)
+        )
+
+    def add_testdocument(self):
+        """Helper method"""
+        self.browser.open(self.portal_url + '/++add++Document')
+        self.browser.getControl(
+            name="form.widgets.IDublinCore.title"
+        ).value = 'TestDocument'
+        self.browser.getControl(
+            name="form.widgets.IDublinCore.subjects"
+        ).value = "foo;bar;foobar"
+        self.browser.getControl('Save').click()
+        self.assertTrue("foobar" in self.browser.contents)
+        self.assertFalse("foo;bar" in self.browser.contents)
+
+    def test_add_document_adds_tags(self):
+        self.add_testdocument()
+        doc = self.portal.testdocument
+        uuid = IUUID(doc)
+        tags = self.graph.unpack(
+            self.graph.get_tags('content', uuid, SITE_OWNER_NAME))
+        self.assertEqual(sorted(tags), [u'bar', u'foo', u'foobar'])
+
+    def test_add_document_standard_dublincore_does_not_add_tags(self):
+        restore_all_dublincore()
+        transaction.commit()
+        self.add_testdocument()
+        doc = self.portal.testdocument
+        uuid = IUUID(doc)
+        with self.assertRaises(KeyError):
+            self.graph.get_tags('content', uuid, SITE_OWNER_NAME)


### PR DESCRIPTION
Because tagging relies on uuids, and new content objects are not adaptable to uuids until they're actually added to their containers, this PR delays indexing personalized tags on newly created content objects until they are IUUID adaptable.
