### PR TITLE
Dynamic search UI

### DIFF
--- a/docs/development/components/search.rst
+++ b/docs/development/components/search.rst
@@ -104,6 +104,7 @@ Adding facets
 
 Valid facets can be configured using the `ploneintranet.search.facet_fields` registry value. These will be returned on the `ISearchResponse` object (see below).
 
+
 .. code:: xml
 
   <record name="ploneintranet.search.facet_fields">
@@ -113,10 +114,17 @@ Valid facets can be configured using the `ploneintranet.search.facet_fields` reg
       <value_type type="plone.registry.field.TextLine" />
     </field>
     <value>
-      <element>tags</element>
       <element>friendly_type_name</element>
+      <element>tags</element>
     </value>
   </record>
+
+Adding options to the site search interface
+-------------------------------------------
+
+The refinement options shown in the main search interface
+are auto-generated from any fields registered as 
+*both* a facet and a filter field (see above for adding facets/fields).
 
 Adding search fields ('phrase fields')
 --------------------------------------

--- a/docs/development/components/search.rst
+++ b/docs/development/components/search.rst
@@ -102,7 +102,7 @@ To register a new filter:
 Adding facets
 -------------
 
-Valid facets can be configured using the `ploneintranet.search.facet_fields` registry value. These will be returned on the `ISearchResponse` object (see below).
+Valid facets can be configured using the `ploneintranet.search.facet_fields` registry value. These will be returned on the :class:`ISearchResponse<ploneintranet.search.interfaces.ISearchResponse>` object (see below).
 
 
 .. code:: xml

--- a/src/ploneintranet/search/base.py
+++ b/src/ploneintranet/search/base.py
@@ -155,6 +155,7 @@ class SearchResponse(collections.Iterable):
 
     total_results = FEATURE_NOT_IMPLEMENTED
     spell_corrected_search = FEATURE_NOT_IMPLEMENTED
+    facets = FEATURE_NOT_IMPLEMENTED
 
     def __init__(self, context):
         super(SearchResponse, self).__init__()

--- a/src/ploneintranet/search/browser/searchresults.py
+++ b/src/ploneintranet/search/browser/searchresults.py
@@ -6,7 +6,8 @@ from datetime import datetime
 from datetime import timedelta
 from ..interfaces import ISiteSearch
 
-SUPPORTED_FILTERS = ['friendly_type_name', 'Subject']
+from plone import api as plone_api
+
 RESULTS_PER_PAGE = 10
 
 
@@ -73,11 +74,30 @@ class SearchResultsView(BrowserView):
         else:
             return 'file'
 
+    def search_options(self):
+        """Get the currently options for refining results.
+
+        These are generated from all fields registered as
+        *both* a facet field and a filter field
+        """
+        filter_names = set(plone_api.portal.get_registry_record(
+            'ploneintranet.search.filter_fields'))
+        facet_names = set(plone_api.portal.get_registry_record(
+            'ploneintranet.search.facet_fields'))
+        options = [x for x in filter_names if x in facet_names]
+        # content type is rendered separately by the UI
+        if 'friendly_type_name' in options:
+            options.remove('friendly_type_name')
+        return options
+
     def search_response(self):
         form = self.request.form
         filters = {}
         start_date = None
         end_date = None
+
+        supported_filters = plone_api.portal.get_registry_record(
+            'ploneintranet.search.filter_fields')
 
         if form.get('SearchableText'):
             # This means that the main search form was submitted,
@@ -87,7 +107,7 @@ class SearchResultsView(BrowserView):
             # This means that the filters were changed, so
             # we refine an existing search
             keywords = form.get('SearchableText_filtered')
-            for filt in SUPPORTED_FILTERS:
+            for filt in supported_filters:
                 if form.get(filt):
                     filters[filt] = form.get(filt)
             if form.get('created'):

--- a/src/ploneintranet/search/browser/templates/all_results.pt
+++ b/src/ploneintranet/search/browser/templates/all_results.pt
@@ -51,10 +51,10 @@
                     </label>
                 </fieldset>
                 <label>
-                    <span i18n:translate="" tal:omit-tag="">Created</span>
+                    <span i18n:translate="" tal:omit-tag="">Last Modified</span>
                     <select name="created" id="">
                     <option value="" i18n:translate="">
-                        Any creation date
+                        Any modification date
                     </option>
                     <option value="today" i18n:translate="">
                         Today

--- a/src/ploneintranet/search/browser/templates/all_results.pt
+++ b/src/ploneintranet/search/browser/templates/all_results.pt
@@ -18,6 +18,7 @@
                        name="SearchableText_filtered"
                        tal:attributes="value request/SearchableText|nothing" />
                 <fieldset class="pat-checklist"
+                      tal:condition="search_response/facets/friendly_type_name|nothing"
                       id="content-types">
                     <span class="small button-cluster">
                     <button type="button" class="pat-button select-all" i18n:translate="">All</button>
@@ -31,23 +32,6 @@
                            name="friendly_type_name:list"
                            tal:attributes="value ctype" />
                     <span tal:replace="ctype" />
-                    </label>
-                </fieldset>
-                <fieldset class="pat-checklist"
-                      id="tags"
-                      tal:condition="search_response/facets/tags">
-                    <span class="small button-cluster">
-                    <button type="button" class="pat-button select-all" i18n:translate="">All</button>
-                    <button type="button" class="pat-button deselect-all" i18n:translate="">None</button>
-                    </span>
-                    <legend i18n:translate="">Tags</legend>
-                    <!-- Only list tags in this list that are relevant for this search result. -->
-                    <label
-                     tal:repeat="tag search_response/facets/tags">
-                    <input checked type="checkbox"
-                           name="tags"
-                           tal:attributes="value tag" />
-                    <span tal:replace="tag" />
                     </label>
                 </fieldset>
                 <label>
@@ -70,6 +54,31 @@
                     </option>
                     </select>
                 </label>
+		<tal:other_options
+		     repeat="option_name view/search_options">
+                <fieldset 
+		     class="pat-checklist"
+                     id="${option_name}"
+		     tal:define="facet_values
+				 search_response/facets/?option_name|nothing"
+                     tal:condition="facet_values">
+                    <span class="small button-cluster">
+                    <button type="button" class="pat-button select-all" 
+			    i18n:translate="">All</button>
+                    <button type="button" class="pat-button deselect-all" 
+			    i18n:translate="">None</button>
+                    </span>
+                    <legend i18n:translate="" tal:content="option_name/title">
+                    <!-- Only list tags in this list that are relevant for this search result. -->
+                    <label
+                     tal:repeat="value facet_values">
+                    <input checked type="checkbox"
+                           name="${option_name}"
+                           tal:attributes="value value" />
+                    <span tal:replace="value" />
+                    </label>
+                </fieldset>
+		</tal:other_options>
                 </fieldset>
             </div>
             <div class="nine columns last document-listing"

--- a/src/ploneintranet/search/solr/utilities.py
+++ b/src/ploneintranet/search/solr/utilities.py
@@ -193,11 +193,11 @@ class SiteSearch(base.SiteSearch):
     def _apply_date_range(self, query, start_date, end_date):
         filter_query = query.filter
         if start_date and end_date:
-            query = filter_query(created__range=(start_date, end_date))
+            query = filter_query(modified__range=(start_date, end_date))
         elif end_date is not None:
-            query = filter_query(created__lt=end_date)
+            query = filter_query(modified__lt=end_date)
         else:
-            query = filter_query(created__gt=start_date)
+            query = filter_query(modified__gt=start_date)
         return query
 
     def _apply_spellchecking(self, query, phrase):

--- a/src/ploneintranet/search/tests/base.py
+++ b/src/ploneintranet/search/tests/base.py
@@ -48,7 +48,7 @@ class SiteSearchContentsTestMixin(SiteSearchTestBaseMixin):
             subject=(u'test', u'my-tag'),
             safe_id=False
         )
-        self.doc1.creation_date = datetime.datetime(2001, 9, 11, 0, 10, 1)
+        self.doc1.modification_date = datetime.datetime(2001, 9, 11, 0, 10, 1)
 
         self.doc2 = self.create_doc(
             title=u'Test Doc 2',
@@ -56,7 +56,7 @@ class SiteSearchContentsTestMixin(SiteSearchTestBaseMixin):
                          u'Please let some stuff be indexed. '),
             subject=(u'test', u'my-other-tag'),
         )
-        self.doc2.creation_date = datetime.datetime(2002, 9, 11, 0, 10, 1)
+        self.doc2.modification_date = datetime.datetime(2002, 9, 11, 0, 10, 1)
 
         self.doc3 = self.create_doc(
             title=u'Lucid Dreaming',
@@ -65,28 +65,28 @@ class SiteSearchContentsTestMixin(SiteSearchTestBaseMixin):
                 u'which may leave the casual reader perplexed. '
                 u'Nothing to do with the weather.')
         )
-        self.doc3.creation_date = datetime.datetime(2002, 9, 11, 1, 10, 1)
+        self.doc3.modification_date = datetime.datetime(2002, 9, 11, 1, 10, 1)
 
         self.doc4 = self.create_doc(
             title=u'Weather in Wales',
             description=u'Its raining cats and dogs, usually.',
             subject=(u'trivia', u'boredom', u'british-hangups')
         )
-        self.doc4.creation_date = datetime.datetime(2002, 9, 11, 1, 10, 1)
+        self.doc4.modification_date = datetime.datetime(2002, 9, 11, 1, 10, 1)
 
         self.doc5 = self.create_doc(
             title=u'Sorted and indexed.',
             description=u'Not relevant',
             subject=(u'solr', u'boost', u'values')
         )
-        self.doc5.creation_date = datetime.datetime(1999, 01, 11, 2, 3, 8)
+        self.doc5.modification_date = datetime.datetime(1999, 01, 11, 2, 3, 8)
 
         self.doc6 = self.create_doc(
             title=u'Another relevant title',
             description=u'Is Test Doc 2 Sorted and indexed?',
             subject=(u'abra', u'cad', u'abra')
         )
-        self.doc6.creation_date = datetime.datetime(1994, 04, 05, 2, 3, 4)
+        self.doc6.modification_date = datetime.datetime(1994, 04, 05, 2, 3, 4)
 
 
 class SiteSearchTestsMixin(SiteSearchContentsTestMixin):

--- a/src/ploneintranet/search/zcatalog.py
+++ b/src/ploneintranet/search/zcatalog.py
@@ -38,17 +38,17 @@ class SiteSearch(base.SiteSearch):
         return query
 
     def _apply_date_range(self, query, start_date=None, end_date=None):
-        query = dict(query, created=dict.fromkeys(('query', 'range')))
-        created = query['created']
+        query = dict(query, modified=dict.fromkeys(('query', 'range')))
+        modified = query['modified']
         if all((start_date, end_date)):
-            created['query'] = (start_date, end_date)
-            created['range'] = 'min:max'
+            modified['query'] = (start_date, end_date)
+            modified['range'] = 'min:max'
         elif start_date is not None:
-            created['query'] = start_date
-            created['range'] = 'min'
+            modified['query'] = start_date
+            modified['range'] = 'min'
         else:
-            created['query'] = end_date
-            created['range'] = 'max'
+            modified['query'] = end_date
+            modified['range'] = 'max'
         return query
 
     def _paginate(self, query, start, step):

--- a/src/ploneintranet/suite/setuphandlers.py
+++ b/src/ploneintranet/suite/setuphandlers.py
@@ -271,7 +271,7 @@ def workspaces_spec(context):
                      'owner': 'allan_neece',
                      'description': u'Meeting Minutes Overview',
                      'type': 'Document',
-                     'created': now - timedelta(days=60),
+                     'modification_date': now - timedelta(days=60),
                      },
                     {'title': 'Open Market Day',
                      'type': 'Event',
@@ -532,6 +532,11 @@ def create_ws_content(parent, contents):
                 raise api.exc.InvalidParameterError, ipe
 
             obj.reindexObject()
+            # Avoid 'reindexObject' overriding custom
+            # modification dates
+            if 'modification_date' in content:
+                obj.modification_date = content['modification_date']
+                obj.reindexObject(idxs=['modified', ])
         if state is not None:
             api.content.transition(obj, to_state=state)
         if sub_contents is not None:


### PR DESCRIPTION
This updates the search UI so that the search options in the LH column can be customised using the existing registry settings.

See doc updates for details - bottom line is that any field registered as _both_ a filter and a facet field will appear in the LH column and allow users to limit their results using that field.

Also in this PR - date range now uses 'modified' as per prototype (rather than 'created') as previously)
