### PR TITLE
show the images that are available as previews

### DIFF
--- a/src/ploneintranet/library/browser/templates/library.html
+++ b/src/ploneintranet/library/browser/templates/library.html
@@ -112,7 +112,12 @@
                    tal:define="has_img child/context/image|nothing;
                                scales child/context/@@images|nothing;"
                    tal:condition="python:has_img and scales" >
-                  <img tal:replace="structure python: scales.scale('image', scale='mini').tag()" />
+                   <!-- images must not have height and width attrs, this is determined by styling -->
+                  <img tal:attributes="src string:${child/absolute_url}/@@images/image/preview" />
+                </p>
+                <p class="hero"
+                   tal:condition="child/preview">
+                  <img tal:attributes="src string:${child/absolute_url}/docconv_image_preview.jpg" title="preview image"/>
                 </p>
 	        <p class="summary" tal:content="child/description">
 	          At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum.

--- a/src/ploneintranet/library/browser/templates/page.pt
+++ b/src/ploneintranet/library/browser/templates/page.pt
@@ -46,6 +46,12 @@
                tal:content="context/description">
 	      Das katholische Kirchenparlament im Kanton Zürich.
 	    </p>
+
+      <p tal:define="has_img context/image|nothing;
+                     scales context/@@images|nothing;"
+         tal:condition="python:has_img and scales">
+          <img tal:attributes="src string:${context/absolute_url}/@@images/image/large" />
+      </p>
             
 	    <div class="main-content"
                  tal:condition="context/text|nothing"

--- a/src/ploneintranet/library/browser/templates/page.pt
+++ b/src/ploneintranet/library/browser/templates/page.pt
@@ -41,19 +41,18 @@
 	      <a href="#" class="tag">Finanzplanung</a>
 	      <a href="#" class="tag">Statuten</a>
 	    </nav>
-            
+      <figure class="hero"
+              tal:define="has_img context/image|nothing;
+                          scales context/@@images|nothing;"
+              tal:condition="python:has_img and scales">
+          <img tal:attributes="src string:${context/absolute_url}/@@images/image/large" />
+      </figure>
 	    <p class="summary"
                tal:content="context/description">
 	      Das katholische Kirchenparlament im Kanton Zürich.
 	    </p>
 
-      <p tal:define="has_img context/image|nothing;
-                     scales context/@@images|nothing;"
-         tal:condition="python:has_img and scales">
-          <img tal:attributes="src string:${context/absolute_url}/@@images/image/large" />
-      </p>
-            
-	    <div class="main-content"
+      <div class="main-content"
                  tal:condition="context/text|nothing"
                  tal:content="structure context/text/output">
               <p>body text</p>

--- a/src/ploneintranet/library/browser/utils.py
+++ b/src/ploneintranet/library/browser/utils.py
@@ -1,4 +1,5 @@
 import logging
+from ploneintranet.docconv.client.interfaces import IDocconv
 
 log = logging.getLogger(__name__)
 
@@ -31,6 +32,7 @@ def sections_of(context, **kwargs):
                        description=item.description,
                        absolute_url=item.getURL(),
                        type=type_,
+                       preview=IDocconv(child).has_thumbs(),
                        context=child)
         section['content'] = children_of(child)
         struct.append(section)


### PR DESCRIPTION
A small change to the library display. Don't use tag() which generates the height and width attributes. Css is setting these. Show a docconv preview, if one is available. And Show any lead image also in content, to avoid that users have to fiddle with the image once again.
