### PR TITLE
dexterity_update: reset value to default when we get NO_VALUE

### DIFF
--- a/src/ploneintranet/workspace/basecontent/baseviews.py
+++ b/src/ploneintranet/workspace/basecontent/baseviews.py
@@ -56,7 +56,7 @@ class ContentView(BrowserView):
             modified = True
             messages.append("The workflow state has been changed.")
 
-        if self.can_edit:
+        elif self.can_edit:
             mod, errors = dexterity_update(context)
             if mod:
                 messages.append("Your changes have been saved.")

--- a/src/ploneintranet/workspace/basecontent/templates/document_view.pt
+++ b/src/ploneintranet/workspace/basecontent/templates/document_view.pt
@@ -72,12 +72,17 @@
                 <article class="document preview" tal:condition="number_of_file_previews" tal:define="number_of_file_previews view/number_of_file_previews">
                   <tal:previews tal:repeat="preview python:range(1, number_of_file_previews + 1)">
                     <img src="${python:context.absolute_url()}/docconv_image_preview.jpg?page=${preview}" />
+
                   </tal:previews>
                 </article>
+                <tal:file_nochange condition="python: context.portal_type == 'File'">
+                  <input type="hidden" name="file.action" value="nochange"/>
+                </tal:file_nochange>
 
                 <article class="document preview" tal:condition="python: context.portal_type == 'Image'">
                   <figure>
                     <img src="${view/image_url}" title="${context/title}" alt="${context/title}" />
+                    <input type="hidden" name="image.action" value="nochange"/>
                   </figure>
                 </article>
               </div><!-- #document-content -->

--- a/src/ploneintranet/workspace/basecontent/utils.py
+++ b/src/ploneintranet/workspace/basecontent/utils.py
@@ -70,9 +70,9 @@ def dexterity_update(obj, request=None):
                 continue
 
             if raw is NO_VALUE:
-                continue
-
-            value = IDataConverter(widget).toFieldValue(safe_unicode(raw))
+                value = field.default
+            else:
+                value = IDataConverter(widget).toFieldValue(safe_unicode(raw))
 
             try:
                 field.validate(value)


### PR DESCRIPTION
I suspect this has just worked by fluke up to now, e.g. for tags, the
extract method returns an empty tuple instead of NO_VALUE, so the field
value is actually updated. We now need to use a vocabulary for a field
for iKath and resetting it doesn't update the field.
