### PR TITLE
Dexterity update handle no value

### DIFF
--- a/src/ploneintranet/workspace/basecontent/baseviews.py
+++ b/src/ploneintranet/workspace/basecontent/baseviews.py
@@ -63,7 +63,7 @@ class ContentView(BrowserView):
             modified = True
             messages.append("The workflow state has been changed.")
 
-        if self.can_edit:
+        elif self.can_edit:
             mod = False
             if self.validate():
                 mod, errors = dexterity_update(context)

--- a/src/ploneintranet/workspace/basecontent/templates/document_view.pt
+++ b/src/ploneintranet/workspace/basecontent/templates/document_view.pt
@@ -87,10 +87,14 @@
                     <img src="${python:context.absolute_url()}/docconv_image_preview.jpg?page=${preview}&salt=${preview_hash}" />
                   </tal:previews>
                 </article>
+                <tal:file_nochange condition="python: context.portal_type == 'File'">
+                  <input type="hidden" name="file.action" value="nochange"/>
+                </tal:file_nochange>
 
                 <article class="document preview" tal:condition="python: context.portal_type == 'Image'">
                   <figure>
                     <img src="${view/image_url}" title="${context/title}" alt="${context/title}" />
+                    <input type="hidden" name="image.action" value="nochange"/>
                   </figure>
                 </article>
               </div><!-- #document-content -->

--- a/src/ploneintranet/workspace/basecontent/utils.py
+++ b/src/ploneintranet/workspace/basecontent/utils.py
@@ -70,9 +70,9 @@ def dexterity_update(obj, request=None):
                 continue
 
             if raw is NO_VALUE:
-                continue
-
-            value = IDataConverter(widget).toFieldValue(safe_unicode(raw))
+                value = field.default
+            else:
+                value = IDataConverter(widget).toFieldValue(safe_unicode(raw))
 
             try:
                 field.validate(value)

--- a/src/ploneintranet/workspace/basecontent/utils.py
+++ b/src/ploneintranet/workspace/basecontent/utils.py
@@ -69,7 +69,7 @@ def dexterity_update(obj, request=None):
             if raw is NOT_CHANGED:
                 continue
 
-            if raw is NO_VALUE:
+            if raw is NO_VALUE and name in request.form:
                 value = field.default
             else:
                 value = IDataConverter(widget).toFieldValue(safe_unicode(raw))

--- a/src/ploneintranet/workspace/basecontent/utils.py
+++ b/src/ploneintranet/workspace/basecontent/utils.py
@@ -53,6 +53,10 @@ def dexterity_update(obj, request=None):
     errors = []
     for schema in get_dexterity_schemas(context=obj):
         for name in getFieldNames(schema):
+            if name not in request.form:
+                # Skipping fields not in the form keeps the last set value.
+                # It it was never set it'll be the default-value.
+                continue
             field = schema[name]
             widget = component.getMultiAdapter(
                 (field, request), IFieldWidget)
@@ -69,7 +73,7 @@ def dexterity_update(obj, request=None):
             if raw is NOT_CHANGED:
                 continue
 
-            if raw is NO_VALUE and name in request.form:
+            if raw is NO_VALUE:
                 value = field.default
             else:
                 value = IDataConverter(widget).toFieldValue(safe_unicode(raw))


### PR DESCRIPTION
This is a follow up from #390 which was merged and then reverted. It needs further work and testing before it can be merged. The problem it addresses is that submitting the correct empty value for a field (NO_VALUE) is currently ignored. This means that some fields can't be reset. We have this problem with a field we added to iKath (registration_number).

The current problem with this PR is that a POST request to the (edit) view of an item will cause any fields not included in the request to be set to the default. Perhaps it is enough to only update the fields which are in the request.form (in dexterity_update).
