### PR TITLE
Override path_bar viewlet in library with an empty one.

### DIFF
--- a/src/ploneintranet/library/browser/configure.zcml
+++ b/src/ploneintranet/library/browser/configure.zcml
@@ -44,4 +44,13 @@
      permission="zope2.View"
      />
 
+  <browser:viewlet
+     name="plone.path_bar"
+     manager="plone.app.layout.viewlets.interfaces.IAboveContent"
+     class="plone.app.layout.viewlets.common.PathBarViewlet"
+     template="templates/path_bar.pt"
+     layer="ploneintranet.library.interfaces.ILibraryContentLayer"
+     permission="zope2.View"
+     />
+
 </configure>

--- a/src/ploneintranet/library/browser/templates/path_bar.pt
+++ b/src/ploneintranet/library/browser/templates/path_bar.pt
@@ -1,0 +1,6 @@
+<nav id="breadcrumbs" class="breadcrumbs" role="navigation"
+         i18n:domain="plone"
+         tal:define="breadcrumbs view/breadcrumbs">
+
+         <a class="current" href="#"></a>
+</nav>


### PR DESCRIPTION
This hides the incomplete stub "Library >". Compare prototype.
