### PR TITLE
allow hiding time zone with a macro parameter, refs #11929

### DIFF
--- a/src/ploneintranet/workspace/browser/templates/content_macros.pt
+++ b/src/ploneintranet/workspace/browser/templates/content_macros.pt
@@ -110,7 +110,7 @@
           </fieldset>
         </fieldset>
 
-        <label class="timezone"><span tal:omit-tag="" i18n:translate="">Timezone</span>
+        <label class="timezone" tal:condition="not:hide_timezone|nothing"><span tal:omit-tag="" i18n:translate="">Timezone</span>
         <select class="timezone"  tal:attributes="disabled read_only" >
           <option data-timezone-id="80" gmt-adjustment="GMT+12:00" data-use-daylight-time="1" value="12">(GMT+12:00) Auckland, Wellington</option>
           <option data-timezone-id="81" gmt-adjustment="GMT+12:00" data-use-daylight-time="0" value="12">(GMT+12:00) Fiji, Kamchatka, Marshall Is.</option>


### PR DESCRIPTION
A customer wants to hide the time zone field and always use the default one. This change allows setting hide_timezone to accommodate that.
