### PR TITLE
Correctly check for missing catalog values

### DIFF
--- a/src/ploneintranet/search/zcatalog.py
+++ b/src/ploneintranet/search/zcatalog.py
@@ -97,7 +97,7 @@ class SearchResponse(base.SearchResponse):
                                       for y in x[catalog_field] if y}
             else:
                 self.facets[field] = {x[catalog_field]
-                                      for x in all_results if x}
+                                      for x in all_results if x[catalog_field]}
 
 
 @implementer(ISearchResult)


### PR DESCRIPTION
This code was meant to exclude blank/Missing.values from the lists of facets generated in the zcatalog search, but it was checking the brain itself rather than the column/metadata value!

FYI @cillianderoiste 
