### PR TITLE
keep the milestone belonging to the currently viewed task open in the sidebar

### DIFF
--- a/src/ploneintranet/workspace/browser/tiles/sidebar.py
+++ b/src/ploneintranet/workspace/browser/tiles/sidebar.py
@@ -292,6 +292,10 @@ class Sidebar(BaseTile):
                 ws.reindexObject()
         return self.render()
 
+    def is_open_task_in_milestone(self, milestone_tasks):
+        open_item_url = self.request.get('PARENT_REQUEST')['ACTUAL_URL']
+        return open_item_url in [task['url'] for task in milestone_tasks]
+
     def logical_parent(self):
         """
         Needed for the back button in the sidebar.

--- a/src/ploneintranet/workspace/browser/tiles/templates/sidebar.pt
+++ b/src/ploneintranet/workspace/browser/tiles/templates/sidebar.pt
@@ -313,9 +313,12 @@ Supported types include (class names):
                                       token context/@@authenticator/token;">
                 <tal:milestone repeat="milestone milestones">
 
-                  <fieldset class="object-list tasks pat-checklist pat-collapsible closed" data-pat-collapsible="store: local"
-                            tal:attributes="id string:milestone-${milestone}">
-                    <h4 class="section-label state-finished" tal:content="python:milestones[milestone]['title']"/>
+                  <fieldset class="object-list tasks pat-checklist pat-collapsible" data-pat-collapsible="store: local"
+                            tal:define="keep_open python:view.is_open_task_in_milestone(tasks[milestone])"
+                            tal:attributes="id string:milestone-${milestone};
+                                            class python:attrs['class'] + (keep_open and ' open' or ' closed');
+                                            data-pat-collapsible python:keep_open and 'store: none' or 'store: local'">
+                    <h4 class="section-label state-finished" tal:content="python:milestones[milestone]['title']" i18n:translate=""/>
                     <tal:task repeat="task python:tasks[milestone]">
                       <label>
                         <input type="hidden" name="current-tasks:list" tal:attributes="value task/id"/>


### PR DESCRIPTION
Helpful e.g. when clicking on a task in the metro map.
