### PR TITLE
Show only one workflow transition per target state. Refs #11982

### DIFF
--- a/src/ploneintranet/workspace/basecontent/baseviews.py
+++ b/src/ploneintranet/workspace/basecontent/baseviews.py
@@ -119,13 +119,16 @@ class ContentView(BrowserView):
             if action['category'] != 'workflow':
                 continue
             new_state_id = action['transition'].new_state_id
-            title = getattr(available_states, new_state_id).title
-            states.append(dict(
-                action=action['id'],
-                title=title,
-                new_state_id=new_state_id,
-                selected=None,
-            ))
+            # Only target states are shown in the UI. If two transitions lead
+            # to the same state we want to show the state only once.
+            if not new_state_id in [item['new_state_id'] for item in states]:
+                title = getattr(available_states, new_state_id).title
+                states.append(dict(
+                    action=action['id'],
+                    title=title,
+                    new_state_id=new_state_id,
+                    selected=None,
+                ))
         # Todo: enforce a given order?
         return states
 


### PR DESCRIPTION
In the workflow picker only target states are shown, not transition names. If two transitions lead to the same state we want to show the state only once.
This is the case for e.g. retract and send_back. If a user has permission for both transitions then "Draft" is shown twice which is confusing.
