### PR TITLE
Fix pep8 problems

### DIFF
--- a/src/ploneintranet/workspace/basecontent/baseviews.py
+++ b/src/ploneintranet/workspace/basecontent/baseviews.py
@@ -121,7 +121,7 @@ class ContentView(BrowserView):
             new_state_id = action['transition'].new_state_id
             # Only target states are shown in the UI. If two transitions lead
             # to the same state we want to show the state only once.
-            if not new_state_id in [item['new_state_id'] for item in states]:
+            if new_state_id not in [item['new_state_id'] for item in states]:
                 title = getattr(available_states, new_state_id).title
                 states.append(dict(
                     action=action['id'],

--- a/src/ploneintranet/workspace/basecontent/widgets.py
+++ b/src/ploneintranet/workspace/basecontent/widgets.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from plone.app.dexterity.behaviors.metadata import IDublinCore
 from plone.app.event.base import default_timezone
 from plone.app.event.dx.behaviors import IEventBasic
 from ploneintranet.workspace.interfaces import IWorkspaceAppFormLayer


### PR DESCRIPTION
This prevents developers to make any further commit

```
ale@kenobi ploneintranet]$ ./bin/flake8 src/ploneintranet/
src/ploneintranet/workspace/basecontent/baseviews.py:124:16: E713 test for membership should be 'not in'
src/ploneintranet/workspace/basecontent/widgets.py:2:1: F401 'IDublinCore' imported but unused
```
