### PR TITLE
449 workspace ui permissions

### DIFF
--- a/src/ploneintranet/suite/tests/acceptance/workspace.robot
+++ b/src/ploneintranet/suite/tests/acceptance/workspace.robot
@@ -149,6 +149,15 @@ Member cannot create content in a Consumers workspace
     Given I am in a Consumers workspace as a workspace member
      Then I cannot create a new document
 
+Member cannot create content in a workspace changed from Produce to Consume
+    Given I am logged in as the user christian_stoney
+      And I go to the Open Parliamentary Papers Guidance Workspace
+     Then I can open the workspace security settings tab
+      And I can set the participant policy to Consume
+     When I am logged in as the user allan_neece
+      And I go to the Open Parliamentary Papers Guidance Workspace
+     Then I cannot create a new document
+
 Non-Member can view published content in an open workspace
     Given I am in an open workspace as a non-member
      Then I can see the document  Terms and conditions

--- a/src/ploneintranet/suite/tests/lib/keywords.robot
+++ b/src/ploneintranet/suite/tests/lib/keywords.robot
@@ -257,8 +257,7 @@ I cannot create a new document
     Click link  Documents
     Wait until page contains  Test Document
     Page Should Not Contain   Create document
-    Click link  Functions
-    Page Should Not Contain   Create document
+    Page Should Not Contain Link  Functions
 
 I can create a new folder
     Click link  Documents

--- a/src/ploneintranet/suite/tests/lib/keywords.robot
+++ b/src/ploneintranet/suite/tests/lib/keywords.robot
@@ -182,6 +182,14 @@ I can set the participant policy to Moderate
     Click link  link=Security
     Wait until page contains  Workspace members can do everything
 
+I can set the participant policy to Consume
+    Comment  AFAICT selenium doesn't yet have support to set the value of a range input field, using JavaScript instead
+    Execute JavaScript  jQuery("[name='participant_policy']")[0].value = 1
+    Submit form  css=#sidebar-settings-security
+    Wait Until Page Contains  Security
+    Click link  link=Security
+    Wait until page contains  They cannot add
+
 I can see upcoming events
     Page Should Contain Element  xpath=//a[.='Plone Conf']
 
@@ -255,7 +263,7 @@ I can create a new document
 
 I cannot create a new document
     Click link  Documents
-    Wait until page contains  Test Document
+    Wait until page contains  Expand sidebar
     Page Should Not Contain   Create document
     Page Should Not Contain Link  Functions
 

--- a/src/ploneintranet/workspace/browser/tiles/sidebar.py
+++ b/src/ploneintranet/workspace/browser/tiles/sidebar.py
@@ -71,12 +71,23 @@ class BaseTile(BrowserView):
     def can_add(self):
         """
         Is this user allowed to add content?
-        Cave. This was an easy way when we had archetypes.
-        With Dexterity, each content type is protected by its own
-        permission. Use more specific checks, if you can.
+        Cave. We don't use the plone.app.contenttypes per-type permissions.
+        Our workflows don't map those, only cmf.AddPortalContent.
         """
         return api.user.has_permission(
             "Add portal content",
+            obj=self.context,
+        )
+
+    @memoize
+    def can_edit(self):
+        """
+        Is this user allowed to add content?
+        Cave. We don't use the plone.app.contenttypes per-type permissions.
+        Our workflows don't map those, only cmf.ModifyPortalContent.
+        """
+        return api.user.has_permission(
+            "Modify portal content",
             obj=self.context,
         )
 

--- a/src/ploneintranet/workspace/browser/tiles/sidebar.py
+++ b/src/ploneintranet/workspace/browser/tiles/sidebar.py
@@ -190,6 +190,7 @@ class SidebarSettingsSecurity(BaseTile):
                 )
 
         if self.request.method == 'POST':
+            self.form_submitted = True
             if not self.can_manage_workspace():
                 msg = _(u'You do not have permission to change the workspace '
                         u'policy')

--- a/src/ploneintranet/workspace/browser/tiles/sidebar.py
+++ b/src/ploneintranet/workspace/browser/tiles/sidebar.py
@@ -67,6 +67,7 @@ class BaseTile(BrowserView):
             obj=self.context,
         )
 
+    @memoize
     def can_add(self):
         """
         Is this user allowed to add content?
@@ -76,78 +77,6 @@ class BaseTile(BrowserView):
         """
         return api.user.has_permission(
             "Add portal content",
-            obj=self.context,
-        )
-
-    @memoize
-    def can_add_documents(self):
-        """
-        Check if user is allowed to add documents
-        """
-        return api.user.has_permission(
-            'plone.app.contenttypes: Add Document',
-            obj=self.context,
-        )
-
-    @memoize
-    def can_add_folders(self):
-        """
-        Check if user is allowed to add folders
-        """
-        return api.user.has_permission(
-            'plone.app.contenttypes: Add Folder',
-            obj=self.context,
-        )
-
-    @memoize
-    def can_add_files(self):
-        """
-        Check if user is allowed to add files
-        """
-        return api.user.has_permission(
-            'plone.app.contenttypes: Add File',
-            obj=self.context,
-        )
-
-    @memoize
-    def can_add_images(self):
-        """
-        Check if user is allowed to add images
-        """
-        return api.user.has_permission(
-            'plone.app.contenttypes: Add Image',
-            obj=self.context,
-        )
-
-    @memoize
-    def can_add_events(self):
-        """
-        Check if user is allowed to add files
-        """
-        return api.user.has_permission(
-            'plone.app.contenttypes: Add Event',
-            obj=self.context,
-        )
-
-    @memoize
-    def can_add_links(self):
-        """
-        Check if user is allowed to add links
-        """
-        return api.user.has_permission(
-            'plone.app.contenttypes: Add Link',
-            obj=self.context,
-        )
-
-    @memoize
-    def can_add_todos(self):
-        """
-        Check if user is allowed to add todos
-        XXX: To be consistent, todos may also want to declare
-        their own permission. Then this needs changing.
-        """
-        return api.user.has_permission(
-            'Add portal content',
             obj=self.context,
         )
 

--- a/src/ploneintranet/workspace/browser/tiles/templates/sidebar.pt
+++ b/src/ploneintranet/workspace/browser/tiles/templates/sidebar.pt
@@ -221,7 +221,7 @@ Supported types include (class names):
             <div class="pat-collapsible more-menu closed" data-pat-collapsible="trigger: .selector-toggle-select" id="selector-more-menu">
               <ul class="menu">
                 <tal:can_add condition="view/can_add">
-                  <li tal:content="view/can_add">
+                  <li tal:condition="view/can_add">
                     <a href="@@add_content" tal:attributes="href string:${context/absolute_url}/add_content" class="icon-doc-text create-document pat-modal" data-pat-modal="class: large" i18n:translate="">Create document</a>
                   </li>
                   <li tal:condition="view/can_add">

--- a/src/ploneintranet/workspace/browser/tiles/templates/sidebar.pt
+++ b/src/ploneintranet/workspace/browser/tiles/templates/sidebar.pt
@@ -48,7 +48,7 @@
               <div class="quick-functions">
                 <a class="toggle-sidebar-size pat-toggle" data-pat-toggle="selector: body; value: sidebar-normal sidebar-large" title="expand/reduce sidebar">Expand sidebar</a>
                 <a class="selector-toggle-select more-menu-trigger">Functions</a>
-                <a tal:condition="view/can_add_documents" title="Create document" href="/panel-create-document.html#document-content" class="create-document pat-modal icon-doc-text" data-pat-modal="class: large"
+                <a tal:condition="view/can_add" title="Create document" href="/panel-create-document.html#document-content" class="create-document pat-modal icon-doc-text" data-pat-modal="class: large"
                    tal:attributes="href string:${context/absolute_url}/add_content"
                    i18n:attributes="title" i18n:translate="">Create document</a>
                 <!-- XXX: This is not yet completed -->
@@ -201,12 +201,12 @@ Supported types include (class names):
               </fieldset>
             </form>
 
-            <tal:can_add condition="view/can_add_documents | view/can_add_images | view/can_add_folders">
+            <tal:can_add condition="view/can_add">
               <div class="button-bar create-buttons">
                 <a href="@@add_content" tal:attributes="href string:${context/absolute_url}/add_content" class="button create-document pat-modal icon-doc-text" data-pat-modal="class: large"
-                   i18n:translate="" tal:condition="view/can_add_documents | view/can_add_images">Create document</a>
+                   i18n:translate="" tal:condition="view/can_add">Create document</a>
                 <a href="@@add_folder" tal:attributes="href string:${context/absolute_url}/add_folder" class="button create-folder pat-modal icon-folder" data-pat-modal="class: large"
-                   i18n:translate="" tal:condition="view/can_add_folders">Create folder</a>
+                   i18n:translate="" tal:condition="view/can_add">Create folder</a>
               </div>
               <form action="workspaceFileUpload" method="POST" class="pat-inject" data-pat-inject="#items" enctype="multipart/form-data" tal:attributes="action string:${context/absolute_url}/workspaceFileUpload">
                 <fieldset class="pat-upload" data-pat-upload="label: ${view/drop_files_label}; trigger: auto;" tal:attributes="data-pat-upload string:label: ${view/drop_files_label};; trigger: auto;">
@@ -220,14 +220,14 @@ Supported types include (class names):
 
             <div class="pat-collapsible more-menu closed" data-pat-collapsible="trigger: .selector-toggle-select" id="selector-more-menu">
               <ul class="menu">
-                <tal:can_add condition="view/can_add_documents | view/can_add_images | view/can_add_folders">
-                  <li tal:content="view/can_add_documents | view/can_add_images">
+                <tal:can_add condition="view/can_add">
+                  <li tal:content="view/can_add">
                     <a href="@@add_content" tal:attributes="href string:${context/absolute_url}/add_content" class="icon-doc-text create-document pat-modal" data-pat-modal="class: large" i18n:translate="">Create document</a>
                   </li>
-                  <li tal:condition="view/can_add_folders">
+                  <li tal:condition="view/can_add">
                     <a href="@@add_folder" tal:attributes="href string:${context/absolute_url}/add_folder" class="icon-folder create-folder pat-modal" data-pat-modal="class: large" i18n:translate="">Create folder</a>
                   </li>
-                  <li tal:condition="view/can_add_images | view/can_add_folders">
+                  <li tal:condition="view/can_add">
                     <label class=" icon-upload-cloud"><input multiple="multiple" type="file"/> <span tal:omit-tag="" i18n:translate="">Upload file(s)</span></label>
                   </li>
                 </tal:can_add>
@@ -277,7 +277,7 @@ Supported types include (class names):
               <a title="Create new task"
                  class="create-document pat-modal icon-doc-text" data-pat-modal="class: large" data-pat-inject="source:#content"
                  tal:attributes="href string:${ws/absolute_url}/add_task"
-                 tal:condition="view/can_add_todos">Create task</a>
+                 tal:condition="view/can_add">Create task</a>
             </div>
           </div>
           <tal:no-tasks condition="python:not ws.is_case and not tasks ">
@@ -336,7 +336,7 @@ Supported types include (class names):
                     <p class="button-bar">
                       <a class="icon-plus-circle small button pat-modal" data-pat-modal="class: large" data-pat-inject="source:#content"
                          tal:attributes="href string:${ws/absolute_url}/add_task?milestone=${milestone}"
-                         tal:condition="view/can_add_todos">Create new task</a>
+                         tal:condition="view/can_add">Create new task</a>
                       <a class="small icon-stage success button"
                          tal:condition="python:milestones[milestone]['enabled']"
                          tal:attributes="href python:'{0}/content_status_modify?workflow_action={1}&_authenticator={2}'.format(ws.absolute_url(), milestones[milestone]['transition_id'], token);">Close milestone</a>
@@ -370,7 +370,7 @@ Supported types include (class names):
           <div class="button-bar functions" id="-functions">
             <div class="quick-functions">
               <a class="toggle-sidebar-size pat-toggle" data-pat-toggle="selector: body; value: sidebar-normal sidebar-large" title="expand/reduce sidebar">Expand sidebar</a>
-              <a tal:condition="view/can_add_events" title="Create new event" href="/panel-create-event.html#document-content" class="create-document pat-modal icon-doc-text" data-pat-modal="class: large" data-pat-inject="source:#content" tal:attributes="href string:${ws/absolute_url}/add_event">Create event</a>
+              <a tal:condition="view/can_add" title="Create new event" href="/panel-create-event.html#document-content" class="create-document pat-modal icon-doc-text" data-pat-modal="class: large" data-pat-inject="source:#content" tal:attributes="href string:${ws/absolute_url}/add_event">Create event</a>
             </div>
           </div>
           <div class="content">

--- a/src/ploneintranet/workspace/browser/tiles/templates/sidebar.pt
+++ b/src/ploneintranet/workspace/browser/tiles/templates/sidebar.pt
@@ -45,7 +45,8 @@
                 </form>
               </div>
 
-              <div class="quick-functions">
+              <div class="quick-functions"
+                   tal:condition="python:view.can_add() or view.can_edit()">
                 <a class="toggle-sidebar-size pat-toggle" data-pat-toggle="selector: body; value: sidebar-normal sidebar-large" title="expand/reduce sidebar">Expand sidebar</a>
                 <a class="selector-toggle-select more-menu-trigger">Functions</a>
                 <a tal:condition="view/can_add" title="Create document" href="/panel-create-document.html#document-content" class="create-document pat-modal icon-doc-text" data-pat-modal="class: large"

--- a/src/ploneintranet/workspace/browser/tiles/templates/sidebar.pt
+++ b/src/ploneintranet/workspace/browser/tiles/templates/sidebar.pt
@@ -45,10 +45,10 @@
                 </form>
               </div>
 
-              <div class="quick-functions"
-                   tal:condition="python:view.can_add() or view.can_edit()">
+              <div class="quick-functions">
                 <a class="toggle-sidebar-size pat-toggle" data-pat-toggle="selector: body; value: sidebar-normal sidebar-large" title="expand/reduce sidebar">Expand sidebar</a>
-                <a class="selector-toggle-select more-menu-trigger">Functions</a>
+                <a class="selector-toggle-select more-menu-trigger"
+                   tal:condition="python:view.can_add() or view.can_edit()">Functions</a>
                 <a tal:condition="view/can_add" title="Create document" href="/panel-create-document.html#document-content" class="create-document pat-modal icon-doc-text" data-pat-modal="class: large"
                    tal:attributes="href string:${context/absolute_url}/add_content"
                    i18n:attributes="title" i18n:translate="">Create document</a>

--- a/src/ploneintranet/workspace/configure.zcml
+++ b/src/ploneintranet/workspace/configure.zcml
@@ -47,7 +47,8 @@
   <!-- Subscribe to ParticipationPolicyChangedEvent in order to
        update existing users-->
   <subscriber
-     for=".interfaces.IParticipationPolicyChangedEvent"
+     for="ploneintranet.workspace.workspacefolder.IWorkspaceFolder
+          ploneintranet.workspace.interfaces.IParticipationPolicyChangedEvent"
      handler=".subscribers.participation_policy_changed"
      />
 

--- a/src/ploneintranet/workspace/configure.zcml
+++ b/src/ploneintranet/workspace/configure.zcml
@@ -47,8 +47,7 @@
   <!-- Subscribe to ParticipationPolicyChangedEvent in order to
        update existing users-->
   <subscriber
-     for=".workspacefolder.IWorkspaceFolder
-          .interfaces.IParticipationPolicyChangedEvent"
+     for=".interfaces.IParticipationPolicyChangedEvent"
      handler=".subscribers.participation_policy_changed"
      />
 

--- a/src/ploneintranet/workspace/events.py
+++ b/src/ploneintranet/workspace/events.py
@@ -1,16 +1,15 @@
-from zope.component.interfaces import ObjectEvent
 from zope.interface import implements
 
 from ploneintranet.workspace.interfaces import IParticipationPolicyChangedEvent
 
 
-class ParticipationPolicyChangedEvent(ObjectEvent):
+class ParticipationPolicyChangedEvent(object):
     """ Event class, which is fired once the participation policy
     of the workspace has changed
     """
     implements(IParticipationPolicyChangedEvent)
 
     def __init__(self, ob, old_policy, new_policy):
-        super(ParticipationPolicyChangedEvent, self).__init__(ob)
+        self.workspace = ob
         self.old_policy = old_policy
         self.new_policy = new_policy

--- a/src/ploneintranet/workspace/events.py
+++ b/src/ploneintranet/workspace/events.py
@@ -1,15 +1,16 @@
 from zope.interface import implements
+from zope.component.interfaces import ObjectEvent
 
 from ploneintranet.workspace.interfaces import IParticipationPolicyChangedEvent
 
 
-class ParticipationPolicyChangedEvent(object):
+class ParticipationPolicyChangedEvent(ObjectEvent):
     """ Event class, which is fired once the participation policy
     of the workspace has changed
     """
     implements(IParticipationPolicyChangedEvent)
 
     def __init__(self, ob, old_policy, new_policy):
-        self.workspace = ob
+        super(ParticipationPolicyChangedEvent, self).__init__(ob)
         self.old_policy = old_policy
         self.new_policy = new_policy

--- a/src/ploneintranet/workspace/profiles/default/types/Collection.xml
+++ b/src/ploneintranet/workspace/profiles/default/types/Collection.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<object name="Collection"
+   meta_type="Dexterity FTI"
+   i18n:domain="plone" xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+ <property name="add_permission">cmf.AddPortalContent</property>
+</object>

--- a/src/ploneintranet/workspace/profiles/default/types/Document.xml
+++ b/src/ploneintranet/workspace/profiles/default/types/Document.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<object name="Document" meta_type="Dexterity FTI" i18n:domain="plone"
+   xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+ <property name="add_permission">cmf.AddPortalContent</property>
+</object>

--- a/src/ploneintranet/workspace/profiles/default/types/Event.xml
+++ b/src/ploneintranet/workspace/profiles/default/types/Event.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<object name="Event" meta_type="Dexterity FTI" i18n:domain="plone"
+   xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+ <property name="add_permission">cmf.AddPortalContent</property>
+</object>

--- a/src/ploneintranet/workspace/profiles/default/types/File.xml
+++ b/src/ploneintranet/workspace/profiles/default/types/File.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<object name="File" meta_type="Dexterity FTI" i18n:domain="plone"
+   xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+ <property name="add_permission">cmf.AddPortalContent</property>
+</object>

--- a/src/ploneintranet/workspace/profiles/default/types/Folder.xml
+++ b/src/ploneintranet/workspace/profiles/default/types/Folder.xml
@@ -3,6 +3,7 @@
 	meta_type="Factory-based Type Information with dynamic views"
 	i18n:domain="plone"
 	xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+ <property name="add_permission">cmf.AddPortalContent</property>
  <property name="allowed_content_types"
 	   purge="False">
    <element value="ploneintranet.workspace.workspacefolder" />

--- a/src/ploneintranet/workspace/profiles/default/types/Image.xml
+++ b/src/ploneintranet/workspace/profiles/default/types/Image.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<object name="Image" meta_type="Dexterity FTI" i18n:domain="plone"
+   xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+ <property name="add_permission">cmf.AddPortalContent</property>
+</object>

--- a/src/ploneintranet/workspace/profiles/default/types/Link.xml
+++ b/src/ploneintranet/workspace/profiles/default/types/Link.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<object name="Link" meta_type="Dexterity FTI" i18n:domain="plone"
+   xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+ <property name="add_permission">cmf.AddPortalContent</property>
+</object>

--- a/src/ploneintranet/workspace/profiles/default/types/News_Item.xml
+++ b/src/ploneintranet/workspace/profiles/default/types/News_Item.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<object name="News Item" meta_type="Dexterity FTI" i18n:domain="plone"
+   xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+ <property name="add_permission">cmf.AddPortalContent</property>
+</object>

--- a/src/ploneintranet/workspace/subscribers.py
+++ b/src/ploneintranet/workspace/subscribers.py
@@ -74,19 +74,20 @@ def workspace_added(ob, event):
         pc.setPolicyBelow('ploneintranet_policy')
 
 
-def participation_policy_changed(event):
+def participation_policy_changed(ob, event):
     """ Move all the existing users to a new group """
-    workspace = IWorkspace(event.workspace)
-    old_group_name = workspace.group_for_policy(event.old_policy)
-    old_group = api.group.get(old_group_name)
-    members = old_group.getAllGroupMembers()
-    for member in members:
-        groups = workspace.get(member.getId()).groups
+    workspace = IWorkspace(ob)
+    members = workspace.members
+
+    for userid in members:
+        groups = workspace.get(userid).groups
         groups -= set([event.old_policy.title()])
         groups.add(event.new_policy.title())
+        workspace.add_to_team(user=userid, groups=groups)
+
     user = api.user.get_current()
     log.info("%s changed policy on %s from %s to %s for %s members",
-             user.getId(), repr(event.workspace),
+             user.getId(), repr(workspace),
              event.old_policy.title(), event.new_policy.title(),
              len(members))
 

--- a/src/ploneintranet/workspace/subscribers.py
+++ b/src/ploneintranet/workspace/subscribers.py
@@ -1,3 +1,4 @@
+import logging
 from collective.workspace.interfaces import IWorkspace
 from plone import api
 from Products.CMFPlacefulWorkflow.PlacefulWorkflowTool \
@@ -16,6 +17,7 @@ from zope.lifecycleevent.interfaces import IObjectRemovedEvent
 from Acquisition import aq_base
 from OFS.CopySupport import cookie_path
 
+log = logging.getLogger(__name__)
 
 WORKSPACE_INTERFACE = 'collective.workspace.interfaces.IHasWorkspace'
 
@@ -72,15 +74,19 @@ def workspace_added(ob, event):
         pc.setPolicyBelow('ploneintranet_policy')
 
 
-def participation_policy_changed(ob, event):
+def participation_policy_changed(event):
     """ Move all the existing users to a new group """
-    workspace = IWorkspace(ob)
+    workspace = IWorkspace(event.workspace)
     old_group_name = workspace.group_for_policy(event.old_policy)
     old_group = api.group.get(old_group_name)
     for member in old_group.getAllGroupMembers():
         groups = workspace.get(member.getId()).groups
         groups -= set([event.old_policy.title()])
         groups.add(event.new_policy.title())
+    user = api.user.get_current()
+    log.info("%s changed policy on %s from %s to %s",
+             user.getId(), repr(event.workspace),
+             event.old_policy.title(), event.new_policy.title())
 
 
 def invitation_accepted(event):

--- a/src/ploneintranet/workspace/subscribers.py
+++ b/src/ploneintranet/workspace/subscribers.py
@@ -87,7 +87,7 @@ def participation_policy_changed(ob, event):
 
     user = api.user.get_current()
     log.info("%s changed policy on %s from %s to %s for %s members",
-             user.getId(), repr(workspace),
+             user.getId(), repr(ob),
              event.old_policy.title(), event.new_policy.title(),
              len(members))
 

--- a/src/ploneintranet/workspace/subscribers.py
+++ b/src/ploneintranet/workspace/subscribers.py
@@ -79,14 +79,16 @@ def participation_policy_changed(event):
     workspace = IWorkspace(event.workspace)
     old_group_name = workspace.group_for_policy(event.old_policy)
     old_group = api.group.get(old_group_name)
-    for member in old_group.getAllGroupMembers():
+    members = old_group.getAllGroupMembers()
+    for member in members:
         groups = workspace.get(member.getId()).groups
         groups -= set([event.old_policy.title()])
         groups.add(event.new_policy.title())
     user = api.user.get_current()
-    log.info("%s changed policy on %s from %s to %s",
+    log.info("%s changed policy on %s from %s to %s for %s members",
              user.getId(), repr(event.workspace),
-             event.old_policy.title(), event.new_policy.title())
+             event.old_policy.title(), event.new_policy.title(),
+             len(members))
 
 
 def invitation_accepted(event):

--- a/src/ploneintranet/workspace/tests/test_permissions.py
+++ b/src/ploneintranet/workspace/tests/test_permissions.py
@@ -58,6 +58,31 @@ class TestPermissions(BaseTestCase):
         # Published doc is OK
         self.traverse_to_item(doc_published)
 
+    def test_consumers_cannot_add(self):
+        """Consumers cannot add content to the workspace"""
+        self.login_as_portal_owner()
+        self.workspace.participant_policy = 'consumers'
+        self.login('user1')
+        with self.assertRaises(Unauthorized):
+            api.content.create(
+                self.workspace,
+                'Document',
+                'my-test-page',
+            )
+
+    def test_consumers_cannot_add_after_change(self):
+        """Consumers cannot add content to the workspace"""
+        self.login_as_portal_owner()
+        self.workspace.participant_policy = 'producers'
+        self.workspace.participant_policy = 'consumers'
+        self.login('user1')
+        with self.assertRaises(Unauthorized):
+            api.content.create(
+                self.workspace,
+                'Document',
+                'my-test-page',
+            )
+
     def test_producers_can_add(self):
         """
         Producers can add content to the workspace, and


### PR DESCRIPTION
Tries to fix workspace UI permissions, undoing the fine grained permission checks and using only the workflow managed cmf.AddPortalContent.

Doesn't work though. May indicate a deeper security issue in the "Consume" policy.
