### PR TITLE
Code-analysis checking for Jenkins

### DIFF
--- a/jenkins.cfg
+++ b/jenkins.cfg
@@ -13,6 +13,9 @@ input = inline:
     #!/bin/bash
     set -e
     source bin/activate
+    # First we check for pep8 in case anyone
+    # decided to disable their pre-commit hooks ;)
+    bin/code-analysis
     echo "Current settings for LC_CTYPE, LC_ALL, LANG:"
     echo $LC_CTYPE
     echo $LC_ALL


### PR DESCRIPTION
Please note: this initial PR _should_ fail because it contains a pep8
failure that should be picked up by the changes to jenkins.cfg
