### PR TITLE
Fix userprofile import step order

### DIFF
--- a/src/ploneintranet/userprofile/configure.zcml
+++ b/src/ploneintranet/userprofile/configure.zcml
@@ -43,7 +43,9 @@
       title="Plone Intranet User Profiles: import steps"
       description="Prepare the site for Ploneintranet users"
       handler=".setuphandlers.on_install"
-      />
+      >
+    <depends name="typeinfo" />
+  </genericsetup:importStep>
 
   <genericsetup:registerProfile
       name="uninstall"


### PR DESCRIPTION
Install step needs the typeinfo to be set up first.
(Need to make sure we've registered the profiles 
container type before we try and add one.)

Without this I was getting errors building out a fresh site.
