### PR TITLE
Correct i18n attribute

### DIFF
--- a/src/ploneintranet/userprofile/browser/templates/userprofile.pt
+++ b/src/ploneintranet/userprofile/browser/templates/userprofile.pt
@@ -20,7 +20,7 @@
         			 tal:attributes="src string:${context/absolute_url}/@@avatar_profile.jpg"
         			 src="{{ page.image_url }}"
                      alt="Image of {{ page.title }}"
-                     i18n:translate="alt" />
+                     i18n:attribute="alt" />
                     <figcaption class="status-message">
 			<h1 tal:content="context/fullname" />
                     </figcaption>

--- a/src/ploneintranet/userprofile/browser/templates/userprofile.pt
+++ b/src/ploneintranet/userprofile/browser/templates/userprofile.pt
@@ -20,7 +20,7 @@
         			 tal:attributes="src string:${context/absolute_url}/@@avatar_profile.jpg"
         			 src="{{ page.image_url }}"
                      alt="Image of {{ page.title }}"
-                     i18n:attribute="alt" />
+                     i18n:attributes="alt" />
                     <figcaption class="status-message">
 			<h1 tal:content="context/fullname" />
                     </figcaption>


### PR DESCRIPTION
i18n:translate should be i18n:attributes. Second commit corrects typo in first commit.
