### PR TITLE
remove '_()', joined strings are already translated

### DIFF
--- a/src/ploneintranet/workspace/basecontent/baseviews.py
+++ b/src/ploneintranet/workspace/basecontent/baseviews.py
@@ -68,8 +68,8 @@ class ContentView(BrowserView):
                 type="error")
 
         elif modified:
-            api.portal.show_message(_(
-                ' '.join(messages)), request=self.request,
+            api.portal.show_message(
+                ' '.join(messages), request=self.request,
                 type="success")
             context.reindexObject()
             notify(ObjectModifiedEvent(context))


### PR DESCRIPTION
The joined messages are already translated. _() only causes the empty string to be translated, so i removed it.
