### PR TITLE
Solr robot test support

### DIFF
--- a/src/ploneintranet/search/solr/tests/search.robot
+++ b/src/ploneintranet/search/solr/tests/search.robot
@@ -1,0 +1,32 @@
+# SOLR search robot tests
+    
+*** Settings ***
+
+Resource  plone/app/robotframework/selenium.robot
+Resource  plone/app/robotframework/keywords.robot
+Resource  ploneintranet/suite/tests/lib/keywords.robot
+
+Library  Remote  ${PLONE_URL}/RobotRemote
+Library  DebugLibrary
+
+Test Setup  Open test browser
+Test Teardown  Close all browsers
+
+*** Test Cases ***
+
+# XXX These are currently duplicates of the
+# basic search tests in the suite. They should be replaced
+# with ones that test the advanced features of solr
+
+Allan can see the search button in header
+    Given I am logged in as the user allan_neece
+    Then I can see the site search button
+
+Allan can search and find the Budget Proposal
+    Given I am logged in as the user allan_neece
+    I can search in the site header for Budget
+    And I can see the search result Budget Proposal
+    And I can follow the search result Budget Proposal
+
+
+

--- a/src/ploneintranet/search/solr/tests/test_robot.py
+++ b/src/ploneintranet/search/solr/tests/test_robot.py
@@ -1,0 +1,16 @@
+import unittest
+
+import robotsuite
+from ploneintranet.search.solr.testing import ROBOT_TESTING
+from ploneintranet.search.solr.testing import SOLR_ENABLED
+from plone.testing import layered
+
+
+def test_suite():
+    suite = unittest.TestSuite()
+    if SOLR_ENABLED:
+        suite.addTests([
+            layered(robotsuite.RobotTestSuite('search.robot'),
+                    layer=ROBOT_TESTING),
+        ])
+    return suite

--- a/src/ploneintranet/suite/tests/acceptance/search.robot
+++ b/src/ploneintranet/suite/tests/acceptance/search.robot
@@ -60,34 +60,4 @@ Allan can search for user Guy Hackey
     And I can see the search result Guy Hackey
 
 
-*** Keywords ***
 
-I can see the site search button
-    Page Should Contain Element  css=#global-header input.search
-
-I can search in the site header for ${SEARCH_STRING}
-    Input text  css=#global-header input.search  ${SEARCH_STRING}
-    Submit Form  css=#global-header form#searchGadget_form
-
-I can see the search result ${SEARCH_RESULT_TITLE}
-    Element should be visible  link=${SEARCH_RESULT_TITLE}
-
-I cannot see the search result ${SEARCH_RESULT_TITLE}
-    Element should not be visible  link=${SEARCH_RESULT_TITLE}
-
-I can follow the search result ${SEARCH_RESULT_TITLE}
-    Click Link  link=${SEARCH_RESULT_TITLE}
-    Page should contain  ${SEARCH_RESULT_TITLE}
-
-I can exclude content of type ${CONTENT_TYPE}
-    Unselect Checkbox  css=input[type="checkbox"][value="${CONTENT_TYPE}"]
-
-The search results do not contain ${STRING_IN_SEARCH_RESULTS}
-    Wait Until Keyword Succeeds  1  3  Page should not contain  ${STRING_IN_SEARCH_RESULTS}
-
-I can set the date range to ${DATE_RANGE_VALUE}
-    Select From List By Value  css=select[name="created"]  ${DATE_RANGE_VALUE}
-    Wait Until Element is Visible  css=dl.search-results[data-search-string*="created=${DATE_RANGE_VALUE}"]
-
-I can click the ${TAB_NAME} tab
-    Click Link  link=${TAB_NAME}

--- a/src/ploneintranet/suite/tests/lib/keywords.robot
+++ b/src/ploneintranet/suite/tests/lib/keywords.robot
@@ -714,3 +714,37 @@ I can mention the user
     Click element  xpath=//form[@id='postbox-users']//label/a/strong[contains(text(), '${username}')]/../..
     Wait Until Element Is visible  xpath=//p[@class='content-mirror']//a[contains(text(), '@${username}')][1]  2
     Click element    css=textarea.pat-content-mirror
+
+# *** search related keywords ***
+
+I can see the site search button
+    Page Should Contain Element  css=#global-header input.search
+
+I can search in the site header for ${SEARCH_STRING}
+    Input text  css=#global-header input.search  ${SEARCH_STRING}
+    Submit Form  css=#global-header form#searchGadget_form
+
+I can see the search result ${SEARCH_RESULT_TITLE}
+    Element should be visible  link=${SEARCH_RESULT_TITLE}
+
+I cannot see the search result ${SEARCH_RESULT_TITLE}
+    Element should not be visible  link=${SEARCH_RESULT_TITLE}
+
+I can follow the search result ${SEARCH_RESULT_TITLE}
+    Click Link  link=${SEARCH_RESULT_TITLE}
+    Page should contain  ${SEARCH_RESULT_TITLE}
+
+I can exclude content of type ${CONTENT_TYPE}
+    Unselect Checkbox  css=input[type="checkbox"][value="${CONTENT_TYPE}"]
+
+The search results do not contain ${STRING_IN_SEARCH_RESULTS}
+    Wait Until Keyword Succeeds  1  3  Page should not contain  ${STRING_IN_SEARCH_RESULTS}
+
+I can set the date range to ${DATE_RANGE_VALUE}
+    Select From List By Value  css=select[name="created"]  ${DATE_RANGE_VALUE}
+    Wait Until Element is Visible  css=dl.search-results[data-search-string*="created=${DATE_RANGE_VALUE}"]
+
+I can click the ${TAB_NAME} tab
+    Click Link  link=${TAB_NAME}
+
+# *** END search related keywords ***


### PR DESCRIPTION
Resolves #565 

Adds a test content layer inside ploneintranet.search that sets up the suite content, and a robot test fixture that uses it.

Added some placeholder robot tests for now. @gyst feel free to add more.
