### PR TITLE
Move the general sidebar settings to a tile

### DIFF
--- a/src/ploneintranet/workspace/browser/tiles/configure.zcml
+++ b/src/ploneintranet/workspace/browser/tiles/configure.zcml
@@ -57,6 +57,17 @@
     />
 
   <plone:tile
+    name="sidebar.settings.general"
+    title="General settings"
+    description=""
+    add_permission="cmf.ManagePortal"
+    class=".sidebar.SidebarSettingsGeneral"
+    permission="zope2.View"
+    for="*"
+    layer="ploneintranet.workspace.interfaces.IPloneintranetWorkspaceLayer"
+    />
+
+  <plone:tile
     name="sidebar.settings.members"
     title="Sidebar Settings Members"
     description="Tile to show member roster in Settings"

--- a/src/ploneintranet/workspace/browser/tiles/sidebar.py
+++ b/src/ploneintranet/workspace/browser/tiles/sidebar.py
@@ -110,6 +110,11 @@ class BaseTile(BrowserView):
         )
 
 
+class SidebarSettingsGeneral(BaseTile):
+
+    index = ViewPageTemplateFile('templates/sidebar-settings-general.pt')
+
+
 class SidebarSettingsMembers(BaseTile):
 
     """

--- a/src/ploneintranet/workspace/browser/tiles/templates/sidebar-settings-general.pt
+++ b/src/ploneintranet/workspace/browser/tiles/templates/sidebar-settings-general.pt
@@ -1,0 +1,46 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      lang="en"
+      i18n:domain="ploneintranet">
+  <body>
+    <div id="sidebar-content">
+      <div id="workspace-settings">
+
+        <div class="tabs-content" tal:define="ws view/workspace">
+          <aside tal:condition="view/form_submitted" id="sidebar-statusmessage">
+            <tal:message tal:content="structure provider:plone.globalstatusmessage"/>
+          </aside>
+          <form action="#" tal:attributes="action string:${ws/absolute_url}/@@sidebar.default" method="post" class="pat-inject pat-autosubmit" data-pat-inject="target: #document-content::before; source: .sidebar-status-message">
+            <fieldset class="vertical">
+              <label>
+                <span tal:omit-tag="" i18n:translate="workspace_title">
+                Workspace titleYO</span>
+                <input type="text" value="{{ page.workspace_name }}"
+                       placeholder="Workspace title"
+                       i18n:attributes="placeholder workspace_title"
+                       data-pat-autosubmit="delay: defocus"
+                       tal:attributes="
+                                       value ws/Title;
+                                       disabled not: view/can_manage_workspace"
+                       name="title" />
+              </label>
+              <label>
+                <span tal:omit-tag="" i18n:translate="workspace_brief_description">
+                Workspace brief description</span>
+                <textarea rows="4"
+                          placeholder="Workspace brief description"
+                          tal:content="ws/Description"
+                          tal:attributes="disabled not: view/can_manage_workspace"
+                          name="description"
+                          i18n:attributes="placeholder workspace_brief_description"
+                          data-pat-autosubmit="delay: defocus">The goal of this project is to integrate CA to ADC product.</textarea>
+              </label>
+            </fieldset>
+          </form>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/src/ploneintranet/workspace/browser/tiles/templates/sidebar.pt
+++ b/src/ploneintranet/workspace/browser/tiles/templates/sidebar.pt
@@ -462,7 +462,7 @@ Supported types include (class names):
         <div id="workspace-settings" tal:define="ws view/workspace">
           <nav class="navigation tabs">
             <a href="/open-market-committee/"
-               tal:attributes="href string:${ws/absolute_url}/sidebar.default" class="pat-inject current"
+               tal:attributes="href string:${ws/absolute_url}/sidebar.settings.general" class="pat-inject current"
                data-pat-inject="target: #workspace-settings > .tabs-content; source: #workspace-settings > .tabs-content"
                i18n:translate="">General</a>
             <a href="/feedback/workspace-settings-members.html"
@@ -479,44 +479,8 @@ Supported types include (class names):
                i18n:translate="">Advanced</a>
           </nav>
           <div class="tabs-content">
-            <form action="#" tal:attributes="action string:${ws/absolute_url}/@@sidebar.default" method="post" class="pat-inject pat-autosubmit" data-pat-inject="target: #document-content::before; source: .sidebar-status-message">
-              <fieldset class="vertical">
-                <label>
-                  <span tal:omit-tag="" i18n:translate="workspace_title">
-                  Workspace title</span>
-                  <input type="text" value="{{ page.workspace_name }}"
-                         placeholder="Workspace title"
-                         i18n:attributes="placeholder workspace_title"
-                         data-pat-autosubmit="delay: defocus"
-                         tal:attributes="
-                                         value ws/Title;
-                                         disabled not: view/can_manage_workspace"
-                         name="title" />
-                </label>
-                <label>
-                  <span tal:omit-tag="" i18n:translate="workspace_brief_description">
-                  Workspace brief description</span>
-                  <textarea rows="4"
-                            placeholder="Workspace brief description"
-                            tal:content="ws/Description"
-                            tal:attributes="disabled not: view/can_manage_workspace"
-                            name="description"
-                            i18n:attributes="placeholder workspace_brief_description"
-                            data-pat-autosubmit="delay: defocus">The goal of this project is to integrate CA to ADC product.</textarea>
-                </label>
-                <!-- fieldset class="pat-checklist">
-                  <label>
-                    <input type="checkbox"
-                           name="calendar_visible"
-                           tal:attributes="
-                                           checked python:ws.calendar_visible == True and 'checked' or '';
-                                           disabled not: view/can_manage_workspace"
-                           data-pat-autosubmit="delay: 100ms"/>
-                    <span tal:omit-tag="" i18n:translate="">Workspace calendar visible in central calendar application</span>
-                  </label>
-                </fieldset-->
-              </fieldset>
-            </form>
+            <a href="${ws/absolute_url}/sidebar.settings.general" class="pat-inject"
+               data-pat-inject="trigger: autoload-visible; source: .tabs-content; target: .tabs-content"/>
           </div>
         </div>
       </div>


### PR DESCRIPTION
This makes it easier to customize.

We can't load a tile (sidebar.settings.general) within a
tile (sidebar.default) within view, but we can inject it using
pat-inject when visible.
