### PR TITLE
Fix unicode searches

### DIFF
--- a/src/ploneintranet/search/browser/searchresults.py
+++ b/src/ploneintranet/search/browser/searchresults.py
@@ -127,7 +127,7 @@ class SearchResultsView(BrowserView):
 
         search_util = getUtility(ISiteSearch)
         response = search_util.query(
-            keywords,
+            keywords.decode('utf-8'),
             filters=filters,
             start_date=start_date,
             end_date=end_date,

--- a/src/ploneintranet/search/solr/search.py
+++ b/src/ploneintranet/search/solr/search.py
@@ -42,5 +42,6 @@ class Search(search.SolrSearch):
     def spellcheck(self, **kw):
         newself = self.clone()
         spellchecker = newself.spellchecker
+        kw['q'] = kw['q'].encode('utf-8')
         spellchecker.update(**kw)
         return newself


### PR DESCRIPTION
IIUC Solr expects the query to be a bytestring, and the spellchecker
expects a unicode string.

To reproduce the issue, search for "Zürich".
