### PR TITLE
Delete confirmation template looks like prototype

### DIFF
--- a/src/ploneintranet/layout/browser/actions.py
+++ b/src/ploneintranet/layout/browser/actions.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from Products.CMFPlone import PloneMessageFactory as _
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from plone.app.content.browser.actions import DeleteConfirmationForm
 from z3c.form import button
 from zope.component import getMultiAdapter
@@ -13,6 +14,8 @@ class PIDeleteConfirmationForm(DeleteConfirmationForm):
     Caveat: we need to reimplement all the actions while overriding,
     because of the button.buttonAndHandler implementation
     '''
+    template = ViewPageTemplateFile('templates/delete_confirmation.pt')
+
     def view_url(self):
         ''' Facade to the homonymous plone_context_state method
         '''

--- a/src/ploneintranet/layout/browser/actions.py
+++ b/src/ploneintranet/layout/browser/actions.py
@@ -1,7 +1,7 @@
 # coding=utf-8
-from Products.CMFPlone import PloneMessageFactory as _
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from plone.app.content.browser.actions import DeleteConfirmationForm
+from ploneintranet.core import ploneintranetCoreMessageFactory as _
 from z3c.form import button
 from zope.component import getMultiAdapter
 
@@ -25,7 +25,12 @@ class PIDeleteConfirmationForm(DeleteConfirmationForm):
         )
         return context_state.view_url()
 
-    @button.buttonAndHandler(_(u'Delete'), name='Delete')
+    def updateActions(self):
+        super(PIDeleteConfirmationForm, self).updateActions()
+        self.actions['Delete'].klass = 'icon-ok-circle'
+        self.actions['Cancel'].klass = 'close-panel icon-cancel-circle'
+
+    @button.buttonAndHandler(_(u'I am sure, delete now'), name='Delete')
     def handle_delete(self, action):
         base_handler = super(PIDeleteConfirmationForm, self).handle_delete
         return base_handler(self, action)

--- a/src/ploneintranet/layout/browser/templates/delete_confirmation.pt
+++ b/src/ploneintranet/layout/browser/templates/delete_confirmation.pt
@@ -1,0 +1,52 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      metal:use-macro="context/main_template/macros/master"
+      i18n:domain="plone">
+
+    <metal:block fill-slot="top_slot"
+                 tal:define="dummy python:request.set('disable_border',1)" />
+
+    <body>
+
+        <metal:main fill-slot="main"
+            tal:define="useSelf python:context_state.is_structural_folder() and not context_state.is_default_page();
+                        folder_warning python:useSelf and context.portal_type != 'Topic';
+                        number_of_objects_to_delete python:folder_warning and view.items_to_delete">
+
+        <h1 class="documentFirstHeading"
+            i18n:translate="alert_deleting_locked_item"
+            tal:condition="view/is_locked">
+            This item can not be deleted because it is currently locked by another user.
+        </h1>
+
+        <tal:block condition="not:view/is_locked">
+            <h1 class="documentFirstHeading"
+                tal:condition="folder_warning">
+                <span i18n:translate="alert_really_delete_folder">
+                    Do you really want to delete this folder and all its contents?
+                </span>
+                <span i18n:translate="alert_deleting_x_number_of_items" tal:condition="python:number_of_objects_to_delete>1">
+                    (This will delete a total of <span i18n:name="number_of_items_to_delete" tal:content="python:number_of_objects_to_delete">22</span> items.)
+                </span>
+            </h1>
+
+            <h1 class="documentFirstHeading"
+                i18n:translate="alert_really_delete"
+                tal:condition="not:folder_warning">
+                Do you really want to delete this item?
+            </h1>
+        </tal:block>
+
+        <div id="content-core">
+            <ul>
+                <li tal:content="context/@@plone_context_state/object_title">The item title (ID)</li>
+            </ul>
+
+            <form metal:use-macro="context/@@ploneform-macros/titlelessform" />
+        </div>
+
+        </metal:main>
+    </body>
+</html>

--- a/src/ploneintranet/layout/browser/templates/delete_confirmation.pt
+++ b/src/ploneintranet/layout/browser/templates/delete_confirmation.pt
@@ -95,6 +95,7 @@
               <button type="submit" name="${action/name}" class="${action/klass}">${action/title}</button>
             </tal:block>
           </div>
+          <tal:block tal:condition="view/enableCSRFProtection" tal:replace="structure context/@@authenticator/authenticator" />
         </form>
       </div>
 

--- a/src/ploneintranet/layout/browser/templates/delete_confirmation.pt
+++ b/src/ploneintranet/layout/browser/templates/delete_confirmation.pt
@@ -1,52 +1,104 @@
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xml:lang="en"
+      lang="en"
       xmlns:tal="http://xml.zope.org/namespaces/tal"
       xmlns:metal="http://xml.zope.org/namespaces/metal"
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       metal:use-macro="context/main_template/macros/master"
       i18n:domain="plone">
 
-    <metal:block fill-slot="top_slot"
-                 tal:define="dummy python:request.set('disable_border',1)" />
+  <metal:block fill-slot="top_slot" tal:define="dummy python:request.set('disable_border',1)" />
 
-    <body>
+  <body>
 
-        <metal:main fill-slot="main"
-            tal:define="useSelf python:context_state.is_structural_folder() and not context_state.is_default_page();
-                        folder_warning python:useSelf and context.portal_type != 'Topic';
-                        number_of_objects_to_delete python:folder_warning and view.items_to_delete">
+    <metal:main fill-slot="main"
+                tal:define="
+                    useSelf python:context_state.is_structural_folder() and not context_state.is_default_page();
+                    folder_warning python:useSelf and context.portal_type != 'Topic';
+                    number_of_objects_to_delete python:folder_warning and view.items_to_delete;
+                ">
+      <div id="document-content" class="pat-modal">
+        <h1 i18n:translate="">Delete confirmation</h1>
+        <form action="${view/action}" method="post" enctype="${view/enctype}" class="wizard-box pat-inject" data-pat-inject="">
+          <div class="panel-body">
+            <article>
+              <p i18n:translate="alert_deleting_locked_item" tal:condition="view/is_locked">
+                This item can not be deleted because it is currently locked by another user.
+              </p>
 
-        <h1 class="documentFirstHeading"
-            i18n:translate="alert_deleting_locked_item"
-            tal:condition="view/is_locked">
-            This item can not be deleted because it is currently locked by another user.
-        </h1>
-
-        <tal:block condition="not:view/is_locked">
-            <h1 class="documentFirstHeading"
-                tal:condition="folder_warning">
-                <span i18n:translate="alert_really_delete_folder">
+              <tal:block condition="not:view/is_locked">
+                <p tal:condition="folder_warning">
+                  <span i18n:translate="alert_really_delete_folder">
                     Do you really want to delete this folder and all its contents?
-                </span>
-                <span i18n:translate="alert_deleting_x_number_of_items" tal:condition="python:number_of_objects_to_delete>1">
-                    (This will delete a total of <span i18n:name="number_of_items_to_delete" tal:content="python:number_of_objects_to_delete">22</span> items.)
-                </span>
-            </h1>
+                  </span>
+                  <span i18n:translate="alert_deleting_x_number_of_items" tal:condition="python:number_of_objects_to_delete>1">
+                    (This will delete a total of
+                    <span i18n:name="number_of_items_to_delete" tal:content="python:number_of_objects_to_delete">22</span> items.)
+                  </span>
+                </p>
 
-            <h1 class="documentFirstHeading"
-                i18n:translate="alert_really_delete"
-                tal:condition="not:folder_warning">
-                Do you really want to delete this item?
-            </h1>
-        </tal:block>
+                <p tal:condition="not:folder_warning">
+                  You are about to delete ${context/@@plone_context_state/object_title}. Are you sure?
+                </p>
+              </tal:block>
+            </article>
+          </div>
 
-        <div id="content-core">
-            <ul>
-                <li tal:content="context/@@plone_context_state/object_title">The item title (ID)</li>
-            </ul>
+          <metal:define define-macro="fields">
 
-            <form metal:use-macro="context/@@ploneform-macros/titlelessform" />
-        </div>
+            <tal:widgets repeat="widget view/widgets/values">
+              <div class="row" tal:define="hidden python:widget.mode == 'hidden'" tal:omit-tag="hidden">
 
-        </metal:main>
-    </body>
+                <metal:field-slot define-slot="field">
+                  <metal:field define-macro="field">
+                    <div class="field"
+                         tal:define="
+                             error widget/error;
+                             hidden python:widget.mode == 'hidden';
+                         "
+                         tal:attributes="
+                           class python:'field' + (error and ' error' or '');
+                         "
+                    >
+                      <label for="" tal:attributes="for widget/id" tal:condition="not:hidden">
+                        <span i18n:translate="" tal:content="widget/label">label</span>
+                      </label>
+
+                      <span class="fieldRequired" title="Required"
+                          tal:condition="python:widget.required and not hidden"
+                          i18n:translate="label_required" i18n:attributes="title title_required;">
+                        (Required)
+                      </span>
+
+                      <div class="formHelp" tal:define="description widget/field/description"
+                           i18n:translate="" tal:content="description"
+                           tal:condition="python:description and not hidden">field description</div>
+
+                      <div tal:condition="error" tal:content="structure error/render">
+                        Error
+                      </div>
+
+                      <div class="widget">
+                        <input type="text" tal:replace="structure widget/render" />
+                      </div>
+                    </div>
+                  </metal:field>
+                </metal:field-slot>
+
+              </div>
+            </tal:widgets>
+
+          </metal:define>
+
+          <div class="buttons panel-footer" tal:condition="view/actions/values|nothing">
+            <tal:block repeat="action view/actions/values">
+              <button type="submit" name="${action/name}" class="${action/klass}">${action/title}</button>
+            </tal:block>
+          </div>
+        </form>
+      </div>
+
+    </metal:main>
+  </body>
+
 </html>

--- a/src/ploneintranet/suite/tests/acceptance/case.robot
+++ b/src/ploneintranet/suite/tests/acceptance/case.robot
@@ -30,8 +30,8 @@ Manager can create a template case workspace
     Given I'm logged in as a 'Manager'
      Then I can create a new template case    New template
      Then I can create a new case from a template  New template  A new type of case
-     Then I can delete a case  a-new-type-of-case
      Then I can delete a template case  new-template
+     Then I can delete a case  a-new-type-of-case
 
 Manager can toggle the state of a task
     Given I'm logged in as a 'Manager'

--- a/src/ploneintranet/suite/tests/lib/keywords.robot
+++ b/src/ploneintranet/suite/tests/lib/keywords.robot
@@ -224,8 +224,9 @@ I can delete an old event
     Mouse Over  xpath=//div[@id='older-events']//li[@class='cal-event']
     Focus  xpath=//div[@id='older-events']//li[@class='cal-event']
     Click Element  css=div#older-events button[type='submit']
-    Wait Until Page Contains  Do you really want to delete this item
-    Click Button  css=#form-buttons-Delete
+    Wait until page contains element    xpath=//div[@class='panel-content']//button[@name='form.buttons.Delete']
+    Click Button    I am sure, delete now
+    Wait Until Page Contains    has been deleted    5
 
 I can go to the sidebar tasks tile
     Go To  ${PLONE_URL}/workspaces/open-market-committee

--- a/src/ploneintranet/suite/tests/lib/keywords.robot
+++ b/src/ploneintranet/suite/tests/lib/keywords.robot
@@ -642,14 +642,16 @@ I can create a new case from a template
 I can delete a case
     [arguments]  ${case_id}
     Go To  ${PLONE_URL}/workspaces/${case_id}/delete_confirmation
-    Click Button  Delete
-    Page Should Contain  has been deleted
+    Wait until page contains element    xpath=//div[@class='panel-content']//button[@name='form.buttons.Delete']
+    Click Button    I am sure, delete now
+    Wait Until Page Contains    has been deleted    5
 
 I can delete a template case
     [arguments]  ${case_id}
     Go To  ${PLONE_URL}/templates/${case_id}/delete_confirmation
-    Click Button  Delete
-    Page Should Contain  has been deleted
+    Wait until page contains element    xpath=//div[@class='panel-content']//button[@name='form.buttons.Delete']
+    Click Button    I am sure, delete now
+    Wait Until Page Contains    has been deleted    5
 
 I go to the dashboard
     Go To  ${PLONE_URL}


### PR DESCRIPTION
This pull request changes the template of the delete_confirmation form.
I would like to have this merged before making some modification to the delete flow.

![image](https://cloud.githubusercontent.com/assets/1300763/9117602/b0a2b194-3c6b-11e5-9043-8a388343c0b3.png)
