### PR TITLE
todo, complete_action: handle an empty list of user actions

### DIFF
--- a/src/ploneintranet/todo/tests/test_todo_utility.py
+++ b/src/ploneintranet/todo/tests/test_todo_utility.py
@@ -258,3 +258,15 @@ class TestTodoUtility(IntegrationTestCase):
             user1_id
         )
         self.assertEqual(len(results), 0)
+
+    def test_add_remove_complete_action(self):
+        """
+        Ensure that complete_action can be performed after adding and removing
+        all actions.
+        """
+        user1_id = self.user1.getId()
+        doc1_uid = self.doc1.UID()
+        self.util.add_action(doc1_uid, TODO)
+        self.util.remove_action(doc1_uid, TODO)
+        self.util.complete_action(doc1_uid, TODO)
+

--- a/src/ploneintranet/todo/tests/test_todo_utility.py
+++ b/src/ploneintranet/todo/tests/test_todo_utility.py
@@ -264,9 +264,7 @@ class TestTodoUtility(IntegrationTestCase):
         Ensure that complete_action can be performed after adding and removing
         all actions.
         """
-        user1_id = self.user1.getId()
         doc1_uid = self.doc1.UID()
         self.util.add_action(doc1_uid, TODO)
         self.util.remove_action(doc1_uid, TODO)
         self.util.complete_action(doc1_uid, TODO)
-

--- a/src/ploneintranet/todo/todo_utility.py
+++ b/src/ploneintranet/todo/todo_utility.py
@@ -179,7 +179,7 @@ class TodoUtility(object):
         storage = self._get_storage()
 
         for userid in userids:
-            if userid in storage:
+            if userid in storage and storage[userid]:
                 users_actions = storage[userid]
                 action, users_actions = self._get_action_for_user(
                     content_uid,


### PR DESCRIPTION
This bug prevented objects from being deleted.

Syslab Refs #12132
