### PR TITLE
Add shortener, shorten text in workspace tile

### DIFF
--- a/src/ploneintranet/layout/utils.py
+++ b/src/ploneintranet/layout/utils.py
@@ -1,0 +1,15 @@
+"""
+Utilities for general purposes. Meant to be imported from other packages
+and have no dependencies of other packages
+"""
+
+from Products.CMFPlone.utils import safe_unicode
+
+
+def shorten(text, length=20, ellipse=u'\u2026'):
+    text = text.replace('_', ' ').replace('-', ' ')
+    if len(text) <= length:
+        return text
+    if ' ' not in text:
+        return u'%s %s' % (safe_unicode(text[:length - 4]), ellipse)
+    return u" ".join(safe_unicode(text)[:length].split(" ")[:-1] + [ellipse])

--- a/src/ploneintranet/layout/utils.py
+++ b/src/ploneintranet/layout/utils.py
@@ -6,10 +6,10 @@ and have no dependencies of other packages
 from Products.CMFPlone.utils import safe_unicode
 
 
-def shorten(text, length=20, ellipse=u'\u2026'):
+def shorten(text, length=20, ellipsis=u'\u2026'):
     text = text.replace('_', ' ').replace('-', ' ')
     if len(text) <= length:
         return text
     if ' ' not in text:
-        return u'%s %s' % (safe_unicode(text[:length - 4]), ellipse)
-    return u" ".join(safe_unicode(text)[:length].split(" ")[:-1] + [ellipse])
+        return u'%s %s' % (safe_unicode(text[:length - 4]), ellipsis)
+    return u" ".join(safe_unicode(text)[:length].split(" ")[:-1] + [ellipsis])

--- a/src/ploneintranet/workspace/browser/tiles/templates/workspaces.pt
+++ b/src/ploneintranet/workspace/browser/tiles/templates/workspaces.pt
@@ -15,11 +15,11 @@
                         <h4 class="title">${workspace/title}</h4>
                         <tal:activities repeat="activity workspace/activities">
                             <p class="byline">
-                                <strong class="subjects"> <!-- This is still a mock -->
+                                <strong class="subjects">
                                     <span class="subject">${activity/subject}</span>
                                 </strong>
                                 <span class="verb">${activity/verb}</span>
-                                <strong class="object" tal:content="structure activity/object">Object</strong>
+                                <strong class="object" tal:content="structure python:view.shorten(activity['object'])">Object</strong>
                                 <time class="datestamp" tal:content="activity/time/title">2 Hours ago</time>
                             </p>
                         </tal:activities>

--- a/src/ploneintranet/workspace/browser/tiles/workspaces.py
+++ b/src/ploneintranet/workspace/browser/tiles/workspaces.py
@@ -6,6 +6,7 @@ from plone import api
 from ploneintranet.microblog.interfaces import IMicroblogTool
 from ploneintranet.core import ploneintranetCoreMessageFactory as _
 from zope.component import queryUtility
+from ploneintranet.layout.utils import shorten
 
 
 class WorkspacesTile(Tile):
@@ -17,6 +18,9 @@ class WorkspacesTile(Tile):
 
     def __call__(self):
         return self.render()
+
+    def shorten(self, text):
+        return shorten(text, length=60)
 
     @memoize
     def workspaces(self):


### PR DESCRIPTION
To avoid problems like 
<img width="427" alt="bildschirmfoto 2015-08-08 um 14 47 49" src="https://cloud.githubusercontent.com/assets/138906/9150508/7d0b5800-3ddc-11e5-903f-89c09d1f0fb4.png">
