### PR TITLE
Correct log message for failed text extraction from binary data.

### DIFF
--- a/src/ploneintranet/search/solr/indexers.py
+++ b/src/ploneintranet/search/solr/indexers.py
@@ -79,8 +79,8 @@ class BinaryAdder(ContentAdder):
                 if elems:
                     data['SearchableText'] = elems[0].text
                 else:
-                    logger.error('Could extract text for file upload: %r',
-                                 data)
+                    logger.error(u'Failed to extract text from binary data '
+                                 u'for file upload: %r', data)
         super(BinaryAdder, self).add(data)
 
 


### PR DESCRIPTION
@mattss Small fix to incorrect logging message.
