### PR TITLE
Added a saving badge macro

### DIFF
--- a/src/ploneintranet/suite/tests/lib/keywords.robot
+++ b/src/ploneintranet/suite/tests/lib/keywords.robot
@@ -455,7 +455,7 @@ I can edit an event
     Input Text  css=div.event-details input[name=start]  text=${start}
     Input Text  css=div.event-details input[name=end]  text=${end}
     Select From List  timezone  ${timezone}
-    Click Button  Save
+    Click Button  Last saved
     Wait Until Page Contains Element  jquery=#workspace-events a:contains(updated)
     Textfield Value Should Be  start  ${start}
     List selection should be  timezone  ${timezone}

--- a/src/ploneintranet/workspace/basecontent/templates/event_view.pt
+++ b/src/ploneintranet/workspace/basecontent/templates/event_view.pt
@@ -70,8 +70,7 @@
                                 </fieldset -->
                                 <!--
                  -->
-                                <button type="submit" tal:condition="not:read_only" class="icon-floppy" title="Save this document" i18n:attributes="title" i18n:translate="">Save</button>
-
+                              <metal:macro use-macro="context/content_macros/saving_badge" />
                             </div>
                         </div>
                         <fieldset class="pat-collapsible closed meta-extra" data-pat-collapsible="trigger: .meta-data-toggle" id="meta-extra">

--- a/src/ploneintranet/workspace/browser/templates/content_macros.pt
+++ b/src/ploneintranet/workspace/browser/templates/content_macros.pt
@@ -167,5 +167,21 @@
 
     </metal:event_fields>
 
+    <metal:saving_badge define-macro="saving_badge">
+      <p id="saving-badge"
+         class="saving-badge"
+         tal:define="
+           toLocalizedtime nocall:here/@@plone/toLocalizedTime;
+           last_modified python:toLocalizedtime(here.modified(), long_format=1);
+         ">
+        <button tal:omit-tag="read_only"
+             type="submit"
+             class="saved-tag focus"
+          >Last saved
+          <time class="modification-date pat-display-time" datetime="${last_modified}">${last_modified}</time>
+        </button>
+      </p>
+    </metal:saving_badge>
+
   </body>
 </html>


### PR DESCRIPTION
This is an experimental pull request trying to:
- implement the saving badge seen in the prototype
- provide an element reusable in the form of macro for all our views
- check what tests need to be updated in order to use this badge
