### PR TITLE
use ttp to parse urls and urls only

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setup(name='ploneintranet',
           'collective.externaleditor >= 1.0.2',
           'tablib',
           'collective.dexteritytextindexer',
+          'twitter-text-python'
       ],
       extras_require={
           'test': [

--- a/src/ploneintranet/core/browser/utils.py
+++ b/src/ploneintranet/core/browser/utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import re
+from ttp import ttp
 from Products.CMFPlone.utils import safe_unicode
 
 
@@ -30,5 +30,6 @@ def link_urls(text):
     """
     Enriches urls in the comment text with an anchor.
     """
-    urlfinder = re.compile('(http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+)')  # noqa
-    return urlfinder.sub(r'<a href="\1" target="_blank">\1</a>', text)
+    parser = ttp.Parser(max_url_length=40)
+    parser._urls = []
+    return ttp.URL_REGEX.sub(parser._parse_urls, text)

--- a/src/ploneintranet/suite/tests/test_utility_methods.py
+++ b/src/ploneintranet/suite/tests/test_utility_methods.py
@@ -7,9 +7,9 @@ from ploneintranet.layout import utils as layout_utils
 text_with_links = "I want to link to http://ploneintranet.org or " \
     "https://plone.org in my text."  # noqa
 text_with_links_replaced = "I want to link to " \
-    """<a href="http://ploneintranet.org" target="_blank">"""\
-    """http://ploneintranet.org</a> or <a href="https://plone.org" """\
-    """target="_blank">https://plone.org</a> in my text."""
+    """<a href="http://ploneintranet.org">"""\
+    """http://ploneintranet.org</a> or <a href="https://plone.org">"""\
+    """https://plone.org</a> in my text."""
 
 string_with_unicode = "This is a ∞ string that contains non-ascii"
 string_with_unicode_shortened = u"This is a ∞ string …"

--- a/versions.cfg
+++ b/versions.cfg
@@ -11,6 +11,7 @@ Products.CMFQuickInstallerTool = 3.0.9
 
 # upgrade plone.app.discussion - pin can be removed after next Plone version
 plone.app.discussion = 2.4.4
+twitter-text-python = 1.1.0
 
 # NOTE: setuptools and zc.buildout versions must be in sync with:
 # - /requirements.txt


### PR DESCRIPTION
Much better url detection. Works also for www.google.de (not requiring the http). Does not hook up mentions and tags, this is left to the content mirror extension. See discussion on mailinglist between @gyst @ale-rt et al
