### PR TITLE
Enable download

### DIFF
--- a/src/ploneintranet/workspace/basecontent/baseviews.py
+++ b/src/ploneintranet/workspace/basecontent/baseviews.py
@@ -162,6 +162,21 @@ class ContentView(BrowserView):
                 return 'icon-file-{0}'.format(icon_name)
         return 'icon-file-code'
 
+    def content_type_name(self):
+        """Gets a name for the type of the primary field of this content"""
+        # Need this to be able to describe what is going to be downloaded
+        # in the sharing tooltip. Cornelis seems to want to name the content
+        # type in cleartext (Download as Microsoft Word) so we might will need
+        # to extend this with a clear name mapper that then again might need
+        # translation support. For now, return the name only.
+        primary_field_info = IPrimaryFieldInfo(self.context)
+        if hasattr(primary_field_info.value, "contentType"):
+            contenttype = primary_field_info.value.contentType
+            name = map_content_type(contenttype)
+        if name:
+            return name.capitalize()
+        return "unknown"
+
 
 class HelperView(BrowserView):
     ''' Use this to provide helper methods

--- a/src/ploneintranet/workspace/basecontent/baseviews.py
+++ b/src/ploneintranet/workspace/basecontent/baseviews.py
@@ -170,6 +170,7 @@ class ContentView(BrowserView):
         # to extend this with a clear name mapper that then again might need
         # translation support. For now, return the name only.
         primary_field_info = IPrimaryFieldInfo(self.context)
+        name = ''
         if hasattr(primary_field_info.value, "contentType"):
             contenttype = primary_field_info.value.contentType
             name = map_content_type(contenttype)

--- a/src/ploneintranet/workspace/basecontent/templates/document_view.pt
+++ b/src/ploneintranet/workspace/basecontent/templates/document_view.pt
@@ -34,7 +34,7 @@
                        class="${view/icon_class} iconified">Open in External Editor</a>
                     <a tal:condition="view/can_edit" href="${context/absolute_url}/delete_confirmation#content" title="Delete this document" i18n:attributes="title" data-pat-inject="source: #content" class="pat-modal icon-trash iconified" i18n:translate="">Delete</a>
                     <a href="" class="icon-copy iconified" title="Copy this document" i18n:attributes="title" i18n:translate="">Copy</a>
-                    <a href="#share-panel" class="icon-export iconified pat-modal" title="Share this document" i18n:attributes="title" i18n:translate="">Share</a>
+                    <a href="#share-panel" class="icon-export iconified pat-tooltip" data-pat-tooltip="source: ajax" title="Share this document" i18n:attributes="title" i18n:translate="">Share</a>
                     <a class="icon-info-circle meta-data-toggle iconified" title="Show extra metadata fields" i18n:attributes="title" i18n:translate="">Toggle extra metadata</a>
                     <fieldset tal:condition="view/has_workflow" id="workflow-menu" class="pat-subform pat-autosubmit pat-inject"
                               tal:attributes="data-pat-inject string:target: #global-statusmessage;; url: ${here_url}/view;; source: #global-statusmessage && url: ${here_url}/view;; source: #application-body;; target: #application-body">
@@ -102,6 +102,14 @@
         </div>
         <nav class="navigation workspace-tabs" id="workspace-tabs" data-tile="./@@workspace.tabs.tile" tal:attributes="data-tile string:${workspace_url}/@@workspace.tabs.tile" />
       </div>
+      <div id="share-panel" hidden>
+        <ul class="menu">
+          <li>
+            <a href="${context/absolute_url}" class="icon-file-word" tal:attributes="class view/icon_class"><tal:label i18n:translate="">Download as</tal:label> <tal:type replace="view/content_type_name"/></a>
+          </li>
+        </ul>
+      </div>
+
     </metal:content>
   </body>
 </html>

--- a/src/ploneintranet/workspace/basecontent/templates/document_view.pt
+++ b/src/ploneintranet/workspace/basecontent/templates/document_view.pt
@@ -104,9 +104,10 @@
       </div>
       <div id="share-panel" hidden>
         <ul class="menu">
-          <li>
+          <li tal:condition="python:context.portal_type in ('File', 'Image')">
             <a href="${context/absolute_url}" class="icon-file-word" tal:attributes="class view/icon_class"><tal:label i18n:translate="">Download as</tal:label> <tal:type replace="view/content_type_name"/></a>
           </li>
+          <li><em i18n:translate="">More sharing options coming soon…</em></li>
         </ul>
       </div>
 


### PR DESCRIPTION
Currently, files can't be downloaded anymore. This reenables the sharing icon on the document view with the only action to download the item.
