### PR TITLE
Fix double close button in delete popup

### DIFF
--- a/src/ploneintranet/workspace/browser/tiles/templates/sidebar.pt
+++ b/src/ploneintranet/workspace/browser/tiles/templates/sidebar.pt
@@ -432,7 +432,7 @@ Supported types include (class names):
                       </ul>
 
                       <form tal:condition="python:view.can_delete(event)"
-                          class="pat-modal"
+                          class="pat-modal pat-inject"
                           action="${string:${event/getURL}/delete_confirmation#content}">
                         <button class="iconified icon-trash" type="submit">Delete event</button>
                       </form>


### PR DESCRIPTION
Fixes double cancel button when clicking on the trash icon in the events sidebar:

![image](https://cloud.githubusercontent.com/assets/1300763/9248370/83294e58-41bb-11e5-9be1-fca69e97e5d3.png)
