### PR TITLE
Improving the delete story

### DIFF
--- a/src/ploneintranet/layout/browser/actions.py
+++ b/src/ploneintranet/layout/browser/actions.py
@@ -26,9 +26,26 @@ class PIDeleteConfirmationForm(DeleteConfirmationForm):
         return context_state.view_url()
 
     def updateActions(self):
+        ''' This method updates the actions to enable some dynamic behaviours
+
+        In particular it understands the request parametes:
+         - pat-modal
+         - pat-inject
+
+        If pat-modal is truish we add to the action buttons the class
+        'close-panel'
+        If pat-inject is truish the pat-inject class is added to the form
+        and a data attribute data-pat-inject is filled we the value
+        read from the request
+        '''
         super(PIDeleteConfirmationForm, self).updateActions()
-        self.actions['Delete'].klass = 'icon-ok-circle'
-        self.actions['Cancel'].klass = 'close-panel icon-cancel-circle'
+
+        if self.request.get('pat-modal'):
+            self.actions['Delete'].klass = 'close-panel icon-ok-circle'
+            self.actions['Cancel'].klass = 'close-panel icon-cancel-circle'
+        else:
+            self.actions['Delete'].klass = 'icon-ok-circle'
+            self.actions['Cancel'].klass = 'icon-cancel-circle'
 
     @button.buttonAndHandler(_(u'I am sure, delete now'), name='Delete')
     def handle_delete(self, action):

--- a/src/ploneintranet/layout/browser/templates/delete_confirmation.pt
+++ b/src/ploneintranet/layout/browser/templates/delete_confirmation.pt
@@ -17,9 +17,12 @@
                     folder_warning python:useSelf and context.portal_type != 'Topic';
                     number_of_objects_to_delete python:folder_warning and view.items_to_delete;
                 ">
-      <div id="document-content" class="pat-modal">
+      <div class="pat-modal">
         <h1 i18n:translate="">Delete confirmation</h1>
-        <form action="${view/action}" method="post" enctype="${view/enctype}" class="wizard-box pat-inject" data-pat-inject="">
+        <form action="${view/action}" method="post" enctype="${view/enctype}"
+            class="wizard-box ${python:request.get('pat-inject') and 'pat-inject' or ''}"
+            data-pat-inject="${python:request.get('pat-inject') or None}"
+        >
           <div class="panel-body">
             <article>
               <p i18n:translate="alert_deleting_locked_item" tal:condition="view/is_locked">

--- a/src/ploneintranet/suite/tests/acceptance/workspace.robot
+++ b/src/ploneintranet/suite/tests/acceptance/workspace.robot
@@ -129,6 +129,7 @@ Member can create an event
     Given I am in a workspace as a workspace member
      When I can create a new event  Christmas  2014-12-25  2014-12-26
      Then I can edit an event  Christmas  2120-12-25  2121-12-26  Europe/Rome
+     Then I can delete an event  Christmas (updated)
 
 Member can submit and retract a document
     Given I am in a workspace as a workspace member

--- a/src/ploneintranet/suite/tests/lib/keywords.robot
+++ b/src/ploneintranet/suite/tests/lib/keywords.robot
@@ -227,6 +227,8 @@ I can delete an old event
     Wait until page contains element    xpath=//div[@class='panel-content']//button[@name='form.buttons.Delete']
     Click Button    I am sure, delete now
     Wait Until Page Contains    has been deleted    5
+    Element should not be visible  css=#workspace-documents
+    Element should be visible  css=#workspace-events
 
 I can go to the sidebar tasks tile
     Go To  ${PLONE_URL}/workspaces/open-market-committee
@@ -460,6 +462,18 @@ I can edit an event
     Textfield Value Should Be  start  ${start}
     List selection should be  timezone  ${timezone}
     Element should contain  css=#workspace-events [href$="open-market-committee/christmas#document-body"]  ${title} (updated)
+
+Then I can delete an event
+    [arguments]  ${title}
+    Debug
+    Click link  ${title}
+    Wait Until Page Contains Element  css=div.event-details
+    Click Element  css=.meta-bar .icon-trash
+    Wait until page contains element    xpath=//div[@class='panel-content']//button[@name='form.buttons.Delete']
+    Click Button  I am sure, delete now
+    Wait Until Page Contains  has been deleted
+    Element should not be visible  css=#workspace-documents
+    Element should be visible  css=#workspace-events
 
 The file appears in the sidebar
     Wait until Page contains Element  xpath=//fieldset/label/a/strong[text()='bärtige_flößer.odt']  timeout=20

--- a/src/ploneintranet/workspace/basecontent/configure.zcml
+++ b/src/ploneintranet/workspace/basecontent/configure.zcml
@@ -73,7 +73,7 @@
     for="plone.event.interfaces.IEvent"
     layer="ploneintranet.workspace.interfaces.IWorkspaceAppContentLayer"
     template="templates/event_view.pt"
-    class=".baseviews.ContentView"
+    class=".event.EventView"
     permission="zope2.View"
     />
 

--- a/src/ploneintranet/workspace/basecontent/event.py
+++ b/src/ploneintranet/workspace/basecontent/event.py
@@ -1,0 +1,25 @@
+# coding=utf-8
+from ploneintranet.workspace.basecontent.baseviews import ContentView
+from urllib import urlencode
+
+
+class EventView(ContentView):
+    ''' This view specializes the content view for events
+    '''
+    def delete_url(self):
+        ''' Prepare a url to the delete form triggering:
+         - pat-modal
+         - pat-inject
+        '''
+        options = {
+            'pat-modal': 'true',
+            'pat-inject': ' && '.join([
+                'source:#document-body; target:#document-body',
+                'source:#workspace-events; target:#workspace-events',
+                'target:#global-statusmessage; source:#global-statusmessage',
+            ])
+        }
+        return "%s/delete_confirmation?%s#content" % (
+            self.context.absolute_url(),
+            urlencode(options)
+        )

--- a/src/ploneintranet/workspace/basecontent/templates/event_view.pt
+++ b/src/ploneintranet/workspace/basecontent/templates/event_view.pt
@@ -41,7 +41,14 @@
                             <button class="pat-switch back-to-parent icon-left-open" data-pat-switch="body focus-* focus-sidebar">${python:context.__parent__.title}</button>
                             <input type="text" name="title" tal:attributes="disabled read_only" placeholder="Document title" class="doc-title pat-content-mirror" data-pat-content-mirror="target: #document-title" value="${context/title}" />
                             <div class="quick-functions">
-                                <a tal:condition="view/can_edit" href="${context/absolute_url}/delete_confirmation#content" title="Delete this event" i18n:attributes="title" i18n:translate="" data-pat-inject="source: #content" class="pat-modal icon-trash iconified">
+                                <a tal:condition="view/can_edit"
+                                   href="${view/delete_url}"
+                                   class="pat-modal icon-trash iconified"
+                                   data-pat-inject="source: #content"
+                                   title="Delete this event"
+                                   i18n:attributes="title"
+                                   i18n:translate=""
+                                   >
                                     Delete
                                 </a>
                                 <a tal:condition="nothing" href="/feedback/panel-event-attachments.html#content" class="icon-attach iconified pat-tooltip" data-pat-tooltip="source: ajax" title="Attach documents" i18n:attributes="title" i18n:translate="">

--- a/src/ploneintranet/workspace/browser/tiles/templates/sidebar.pt
+++ b/src/ploneintranet/workspace/browser/tiles/templates/sidebar.pt
@@ -433,7 +433,16 @@ Supported types include (class names):
 
                       <form tal:condition="python:view.can_delete(event)"
                           class="pat-modal"
-                          action="${string:${event/getURL}/delete_confirmation#content}">
+                          action="${event/getURL}/delete_confirmation#content">
+                        <input type="hidden" name="pat-inject"
+                               value="
+                                   source:#document-body; target:#document-body;
+                                   &amp;&amp;
+                                   source:#workspace-events; target:#workspace-events
+                                   &amp;&amp;
+                                   target: #global-statusmessage; source: #global-statusmessage
+                               " />
+                        <input type="hidden" name="pat-modal" value="true" />
                         <button class="iconified icon-trash" type="submit">Delete event</button>
                       </form>
                     </li>


### PR DESCRIPTION
Fixes #433

The delete_confirmation form can be now controlled through
post or get parameters to behave differently.
In particular it undersstands the parameters:
- pat-modal
- pat-inject

This allows powerfull dynamic behaviors
