### PR TITLE
Improve updating of previews when a file gets replaced

### DIFF
--- a/src/ploneintranet/workspace/basecontent/baseviews.py
+++ b/src/ploneintranet/workspace/basecontent/baseviews.py
@@ -184,6 +184,16 @@ class ContentView(BrowserView):
             return name.capitalize()
         return "unknown"
 
+    def preview_hash(self):
+        """ We want to be able to create a simple hash-string that we can
+        pass as URL parameter when fetching document previews. This string
+        will change every time the file, and thereby potentially the
+        preview image, changes. """
+        # For a start, we take the modification date, since the hash is cheap
+        # to compute. For more aggressive caching we would need to compute the
+        # hash based on the file contents.
+        return hash(self.context.modification_date)
+
 
 class HelperView(BrowserView):
     ''' Use this to provide helper methods

--- a/src/ploneintranet/workspace/basecontent/templates/document_view.pt
+++ b/src/ploneintranet/workspace/basecontent/templates/document_view.pt
@@ -82,9 +82,9 @@
                   </textarea>
                   <span tal:condition="python:read_only and context.text" tal:replace="structure context/text/output" />
                 </article>
-                <article class="document preview" tal:condition="number_of_file_previews" tal:define="number_of_file_previews view/number_of_file_previews">
+                <article class="document preview" tal:condition="number_of_file_previews" tal:define="number_of_file_previews view/number_of_file_previews; preview_hash view/preview_hash">
                   <tal:previews tal:repeat="preview python:range(1, number_of_file_previews + 1)">
-                    <img src="${python:context.absolute_url()}/docconv_image_preview.jpg?page=${preview}" />
+                    <img src="${python:context.absolute_url()}/docconv_image_preview.jpg?page=${preview}&salt=${preview_hash}" />
                   </tal:previews>
                 </article>
 


### PR DESCRIPTION
When referencing a document (file) preview, include a hash in the query-string, so that cache invalidation can happen
