### PR TITLE
Reply security

### DIFF
--- a/src/ploneintranet/microblog/configure.zcml
+++ b/src/ploneintranet/microblog/configure.zcml
@@ -47,7 +47,6 @@
     source="0001"
     destination="0002"
     handler=".migration.setup_uuid_mapping"
-    sortkey="1"
     profile="ploneintranet.microblog:default"
     />
 
@@ -57,7 +56,6 @@
     source="0002"
     destination="0003"
     handler=".migration.setup_threadids"
-    sortkey="1"
     profile="ploneintranet.microblog:default"
     />
 
@@ -67,7 +65,15 @@
     source="*"
     destination="0004"
     handler=".migration.uuid_to_microblog_uuid"
-    sortkey="1"
+    profile="ploneintranet.microblog:default"
+    />
+
+  <genericsetup:upgradeStep
+    title="enforce parent context"
+    description="Fix security context for replies"
+    source="0004"
+    destination="0005"
+    handler=".migration.enforce_parent_context"
     profile="ploneintranet.microblog:default"
     />
 

--- a/src/ploneintranet/microblog/profiles/default/metadata.xml
+++ b/src/ploneintranet/microblog/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>0004</version>
+  <version>0005</version>
 </metadata>

--- a/src/ploneintranet/microblog/statusupdate.py
+++ b/src/ploneintranet/microblog/statusupdate.py
@@ -68,11 +68,6 @@ class StatusUpdate(Persistent):
         else:
             # microblog_context UUID
             self._microblog_context_uuid = self._context2uuid(m_context)
-        if m_context is context:
-            self.context_object = None
-        else:
-            # actual object context
-            self.context_object = context
 
     def _init_mentions(self, mention_ids):
         self.mentions = {}

--- a/src/ploneintranet/microblog/statusupdate.py
+++ b/src/ploneintranet/microblog/statusupdate.py
@@ -95,7 +95,7 @@ class StatusUpdate(Persistent):
         uuid = self._microblog_context_uuid
         if not uuid:
             return None
-        microblog_context = uuidToObject(uuid)
+        microblog_context = self._uuid2object(uuid)
         if microblog_context is None:
             raise AttributeError(
                 "Microblog context with uuid {0} could not be "
@@ -106,6 +106,10 @@ class StatusUpdate(Persistent):
     # unittest override point
     def _context2uuid(self, context):
         return IUUID(context)
+
+    # unittest override point
+    def _uuid2object(self, uuid):
+        return uuidToObject(uuid)
 
     # Act a bit more like a catalog brain:
     def getURL(self):

--- a/src/ploneintranet/microblog/tests/test_statusupdate.py
+++ b/src/ploneintranet/microblog/tests/test_statusupdate.py
@@ -129,31 +129,6 @@ class TestStatusUpdate(unittest.TestCase):
         with self.assertRaises(AttributeError):
             su._microblog_context_uuid
 
-    def test_context_object_microblog(self):
-        import ExtensionClass
-
-        class MockMicroblogContext(ExtensionClass.Base):
-            implements(IMicroblogContext)
-
-        su = StatusUpdate('foo', microblog_context=MockMicroblogContext())
-        self.assertEqual(su, su.getObject())
-
-    def test_context_object_object(self):
-        import Acquisition
-        import ExtensionClass
-
-        class MockContext(Acquisition.Implicit):
-            pass
-
-        class MockMicroblogContext(ExtensionClass.Base):
-            implements(IMicroblogContext)
-
-        a = MockContext()
-        b = MockMicroblogContext()
-        wrapped = a.__of__(b)
-        su = StatusUpdate('foo', microblog_context=wrapped)
-        self.assertEquals(a, su.getObject())
-
     def test_thread_id(self):
         su = StatusUpdate('foo bar', thread_id='jawel')
         self.assertEquals(su.thread_id, 'jawel')

--- a/src/ploneintranet/suite/tests/acceptance/posting.robot
+++ b/src/ploneintranet/suite/tests/acceptance/posting.robot
@@ -69,6 +69,21 @@ Member can reply to a reply in a workspace
     And Both replies are visible    ${MESSAGE1}    ${MESSAGE3}    ${MESSAGE2}
     and Both replies are visible after a reload    ${MESSAGE1}    ${MESSAGE3}    ${MESSAGE2}
 
+Global stream replies to workspace posts are only visible for members of that workspace
+    Given I am in a workspace as a workspace member
+    and I post a status update    ${MESSAGE1}
+    and The message is visible as new status update    ${MESSAGE1}
+    and I open the Dashboard
+    and I post a reply on a status update    ${MESSAGE1}    ${MESSAGE2}
+    and The reply is visibile as a comment    ${MESSAGE1}    ${MESSAGE2}
+    and I post a status update    ${MESSAGE3}
+    and The message is visible as new status update    ${MESSAGE3}    
+    When I am logged in as the user alice_lindstrom
+    and I open the Dashboard
+    Then the message is not visible    ${MESSAGE1}
+    and the message is not visible    ${MESSAGE2}
+    and The message is visible as new status update    ${MESSAGE3}    
+
 Member can mention a user
     Given I am in a workspace as a workspace member
     and I write a status update    ${MESSAGE1}
@@ -106,6 +121,10 @@ Neil can tag a post by searching for a tag
 The message is visible as new status update
     [arguments]  ${message}
     Wait Until Element Is visible  xpath=//div[@id='activity-stream']//div[@class='post item']//section[@class='post-content']//p[contains(text(), '${message}')][1]  2
+
+The message is not visible
+    [arguments]  ${message}
+    Element should not be visible  xpath=//div[@id='activity-stream']//div[@class='post item']//section[@class='post-content']//p[contains(text(), '${message}')][1]  2
 
 The message is visible as new status update that mentions the user
     [arguments]  ${message}  ${username}


### PR DESCRIPTION
This fixes the following scenario:
- Workspace member Alex posts a statusupdate in the workspace
- Workspace member Bernard replies to this update in the global stream. He can view it in the stream because he is a workspace member.
- Non-workspace-member Clare loads the dashboard. She should see neither the original post nor the reply.

The bug was that until now the reply was rendered, which then broke on Unauthorized (yay! for our security!).

The fix is to make replies to a toplevel post inherit the security context of that toplevel post.
This fix includes a database migration to also fix existing older replies.
As part of this PR a bit of test refactoring and cleanup was needed.

A robot test for the scenario is provided.
