### PR TITLE
Fix solr/workspace test conflicts

### DIFF
--- a/src/ploneintranet/search/solr/testing.py
+++ b/src/ploneintranet/search/solr/testing.py
@@ -171,9 +171,10 @@ class PloneIntranetSearchSolrTestContentLayer(PloneIntranetSearchSolrLayer):
         portal.portal_workflow.setDefaultChain('simple_publication_workflow')
         # Install into Plone site using portal_setup
         self.applyProfile(portal, 'ploneintranet.suite:testing')
-        self.applyProfile(portal, 'ploneintranet.workspace:default')
 
     def tearDownPloneSite(self, portal):
+        self.applyProfile(portal, 'ploneintranet.suite:uninstall')
+
         if not SOLR_ENABLED:
             return
 

--- a/src/ploneintranet/search/solr/testing.py
+++ b/src/ploneintranet/search/solr/testing.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 import time
 
+from plone.app.contenttypes.testing import PLONE_APP_CONTENTTYPES_FIXTURE
 from plone.app.robotframework.testing import AUTOLOGIN_LIBRARY_FIXTURE
 from plone.app.testing import IntegrationTesting, PloneSandboxLayer
 from plone.app.testing import FunctionalTesting
@@ -137,9 +138,6 @@ class PloneIntranetSearchSolrLayer(PloneSandboxLayer):
         self.loadZCML(package=ploneintranet.search.solr,
                       name='testing.zcml')
 
-    def tearDownZope(self, app):
-        super(PloneIntranetSearchSolrLayer, self).tearDownZope(app)
-
     def testTearDown(self):
         if not SOLR_ENABLED:
             return
@@ -151,11 +149,13 @@ class PloneIntranetSearchSolrLayer(PloneSandboxLayer):
 class PloneIntranetSearchSolrTestContentLayer(PloneIntranetSearchSolrLayer):
     """ Layer with SOLR support *and* example content """
 
+    defaultBases = (testing.FIXTURE, SOLR_FIXTURE,
+                    PLONE_APP_CONTENTTYPES_FIXTURE)
+
     def setUpZope(self, app, configuration_context):
         super(PloneIntranetSearchSolrTestContentLayer, self).setUpZope(
             app, configuration_context,
         )
-        # Load ZCML
         import ploneintranet.suite
         self.loadZCML(package=ploneintranet.suite)
 
@@ -171,6 +171,7 @@ class PloneIntranetSearchSolrTestContentLayer(PloneIntranetSearchSolrLayer):
         portal.portal_workflow.setDefaultChain('simple_publication_workflow')
         # Install into Plone site using portal_setup
         self.applyProfile(portal, 'ploneintranet.suite:testing')
+        self.applyProfile(portal, 'ploneintranet.workspace:default')
 
     def tearDownPloneSite(self, portal):
         if not SOLR_ENABLED:

--- a/src/ploneintranet/suite/testing.py
+++ b/src/ploneintranet/suite/testing.py
@@ -73,6 +73,9 @@ class PloneIntranetSuite(PloneSandboxLayer):
         # Install into Plone site using portal_setup
         self.applyProfile(portal, 'ploneintranet.suite:testing')
 
+    def tearDownPloneSite(self, portal):
+        self.applyProfile(portal, 'ploneintranet.suite:uninstall')
+
     def tearDownZope(self, app):
         # reset sync mode
         import ploneintranet.microblog.statuscontainer

--- a/src/ploneintranet/todo/profiles/default/metadata.xml
+++ b/src/ploneintranet/todo/profiles/default/metadata.xml
@@ -1,7 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
   <version>1</version>
-  <dependencies>
-      <dependency>profile-plone.app.contenttypes:default</dependency>
-  </dependencies>
 </metadata>

--- a/src/ploneintranet/workspace/profiles/uninstall/types/File.xml
+++ b/src/ploneintranet/workspace/profiles/uninstall/types/File.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<object name="File" meta_type="Dexterity FTI" i18n:domain="plone"
+        xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+  <property name="model_file">plone.app.contenttypes.schema:file.xml</property>
+  <property name="behaviors"
+            purge="false">
+    <element value="ploneintranet.workspace.behaviors.file.IFileFields"
+             remove="True" />
+  </property>
+</object>

--- a/src/ploneintranet/workspace/profiles/uninstall/types/Image.xml
+++ b/src/ploneintranet/workspace/profiles/uninstall/types/Image.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<object name="Image" meta_type="Dexterity FTI" i18n:domain="plone"
+        xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+  <property name="model_file">plone.app.contenttypes.schema:image.xml</property>
+  <property name="behaviors" purge="false">
+    <element value="ploneintranet.workspace.behaviors.image.IImageField"
+             remove="True" />
+  </property>
+</object>

--- a/src/ploneintranet/workspace/tests/test_custom_schema.py
+++ b/src/ploneintranet/workspace/tests/test_custom_schema.py
@@ -1,0 +1,42 @@
+from ploneintranet.workspace.tests.base import BaseTestCase
+from ploneintranet.workspace.behaviors.image import IImageField
+from ploneintranet.workspace.behaviors.file import IFileField
+from plone.rfc822.interfaces import IPrimaryFieldInfo
+from plone import api
+
+
+class TestCustomSchema(BaseTestCase):
+
+    def test_custom_image_schema(self):
+        workspace = api.content.create(
+            self.workspace_container,
+            'ploneintranet.workspace.workspacefolder',
+            'example-workspace',
+            title='Welcome to my workspace'
+        )
+        image = api.content.create(
+            workspace,
+            'Image',
+            title='An image',
+        )
+
+        self.assertTrue(IImageField.providedBy(image))
+        primary = IPrimaryFieldInfo(image)
+        self.assertFalse(primary.field.required)
+
+    def test_custom_file_schema(self):
+        workspace = api.content.create(
+            self.workspace_container,
+            'ploneintranet.workspace.workspacefolder',
+            'example-workspace',
+            title='Welcome to my workspace'
+        )
+        thefile = api.content.create(
+            workspace,
+            'File',
+            title='An file',
+        )
+
+        self.assertTrue(IFileField.providedBy(thefile))
+        primary = IPrimaryFieldInfo(thefile)
+        self.assertFalse(primary.field.required)


### PR DESCRIPTION
Resolves #692

Conclusion: ploneintranet.workspace had no uninstall config for the types customisations to image and file, which was causing test conflicts. This was only exposed in the solr tests, as the robot tests (which install workspace via the suite) were run before the integration tests (which don't). In the main tests, robot tests are run last which is (I think) why they were not picked up.
