### PR TITLE
MetroMap: show final node as finished when appropriate

### DIFF
--- a/src/ploneintranet/workspace/browser/case.py
+++ b/src/ploneintranet/workspace/browser/case.py
@@ -20,3 +20,23 @@ class CaseView(WorkspaceView):
     @property
     def metromap_sequence(self):
         return IMetroMap(self.context).metromap_sequence
+
+    def milestone_state(self, milestone_id):
+        """
+        Determine whether the milestone should be considered finished or not.
+
+        If it is the last milestone and it has no tasks, the final node should
+        be considered finished so that the line is all green.
+        """
+        mm_seq = self.metromap_sequence
+        milestone_ids = mm_seq.keys()
+        is_last = milestone_id == milestone_ids[-1]
+        second_last_milestone_id = milestone_ids[-2]
+        state = 'unfinished'
+        if mm_seq[milestone_id]['finished']:
+            state = 'finished'
+        elif is_last and mm_seq[second_last_milestone_id]['finished']:
+            tasks = self.context.tasks()
+            if not tasks[milestone_id]:
+                state = 'finished'
+        return state

--- a/src/ploneintranet/workspace/browser/templates/case.pt
+++ b/src/ploneintranet/workspace/browser/templates/case.pt
@@ -29,10 +29,9 @@
 		    <ul class="timeline pat-equaliser"
                 tal:define="tasks context/tasks; task_number python:0; milestones python:mm_seq.keys()">
               <tal:milestone repeat="milestone_id milestones">
-			    <li class="section actioned state-unfinished"
+			    <li class="section actioned state-${python:view.milestone_state(milestone_id)}"
                     tal:define="milestone_title python:mm_seq[milestone_id]['title']"
-                    tal:attributes="title milestone_title;
-                                    class python:'{0} state-{1}'.format(attrs['class'],'finished' if mm_seq[milestone_id]['finished'] else 'unfinished')">
+                    tal:attributes="title milestone_title">
                   <tal:state_index define="global task_number python:task_number + repeat['milestone_id'].index">
 				    <h3 class="section-label" tal:content="milestone_title"/>
 				    <ul>


### PR DESCRIPTION
When all milestones are closed, and there are no open tasks assigned to
the final milestone the full line should be green.

SLC Redmine: 12220
