### PR TITLE
Tag search in status update: bugfix for non-ascii Subjects from catalog

### DIFF
--- a/src/ploneintranet/core/browser/panel_tags.py
+++ b/src/ploneintranet/core/browser/panel_tags.py
@@ -29,6 +29,10 @@ class Tags(BrowserView):
         self.selected_tags = [
             safe_unicode(tag) for tag in self.request.form.get('tags', [])]
         tags.update(self.selected_tags)
+        # It is mandatory that all tags are actually unicode. It might happen
+        # that `tags` contains strings with non-ascii characters encoded with a
+        # different encoding than utf-8. In this case sorted() will bail.
+        tags = set([safe_unicode(x) for x in tags if x])
         tags = sorted(tags)
         if search_string:
             search_string = safe_unicode(search_string)


### PR DESCRIPTION
When assembling the list of tags to offer for posting a status update take special care to ensure all are unicode. The portal_catalog might give us back strings that contain non-ascii chars in an encoding that might or might not be utf-8. In the latter cases, calling sorted() on such a list will fail.
