### PR TITLE
Search results: translate friendly_type_name

### DIFF
--- a/src/ploneintranet/core/locales/de/LC_MESSAGES/ploneintranet.po
+++ b/src/ploneintranet/core/locales/de/LC_MESSAGES/ploneintranet.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone Intranet\n"
-"POT-Creation-Date: 2015-08-27 12:45+0000\n"
+"POT-Creation-Date: 2015-08-28 08:33+0000\n"
 "PO-Revision-Date: 2015-05-22 19:10+0000\n"
 "Last-Translator: Alexander Pilz <pilz@syslab.com>\n"
 "Language-Team: German (http://www.transifex.com/projects/p/plone-intranet/language/de/)\n"
@@ -962,7 +962,7 @@ msgstr ""
 msgid "Post"
 msgstr "Post"
 
-msgid "PowerPoint 2007 slide"
+msgid "PowerPoint 2007 presentation"
 msgstr "PowerPoint"
 
 #: ../userprofile/content/userprofile.py:85

--- a/src/ploneintranet/core/locales/de/LC_MESSAGES/ploneintranet.po
+++ b/src/ploneintranet/core/locales/de/LC_MESSAGES/ploneintranet.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone Intranet\n"
-"POT-Creation-Date: 2015-08-19 14:20+0000\n"
+"POT-Creation-Date: 2015-08-27 12:45+0000\n"
 "PO-Revision-Date: 2015-05-22 19:10+0000\n"
 "Last-Translator: Alexander Pilz <pilz@syslab.com>\n"
 "Language-Team: German (http://www.transifex.com/projects/p/plone-intranet/language/de/)\n"
@@ -93,7 +93,7 @@ msgstr "Verwaltet durch Administrator"
 
 #: ../workspace/browser/templates/roster-edit.pt:167
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:116
-#: ../workspace/browser/tiles/templates/sidebar.pt:480
+#: ../workspace/browser/tiles/templates/sidebar.pt:481
 msgid "Advanced"
 msgstr "Erweitert"
 
@@ -132,6 +132,10 @@ msgstr "Alle Zeiträume"
 msgid "All Types"
 msgstr "Alle Typen"
 
+#: ../workspace/browser/tiles/events.py:49
+msgid "All day"
+msgstr ""
+
 #: ../workspace/browser/templates/content_macros.pt:95
 msgid "All day event"
 msgstr ""
@@ -140,7 +144,7 @@ msgstr ""
 msgid "All notifications"
 msgstr "Alle Benachrichtigungen"
 
-#: ../library/browser/views.py:97
+#: ../library/browser/views.py:100
 msgid "All topics"
 msgstr ""
 
@@ -219,6 +223,9 @@ msgstr ""
 msgid "Bulk import users"
 msgstr ""
 
+msgid "CSV document"
+msgstr "CSV"
+
 #: ../messaging/browser/send-message.pt:63
 #: ../workspace/basecontent/document.py:77
 #: ../workspace/browser/templates/add_content.pt:36
@@ -228,6 +235,9 @@ msgstr "Abbrechen"
 #: ../workspace/browser/templates/workspace-add.pt:27
 msgid "Case"
 msgstr ""
+
+msgid "Case Workspace"
+msgstr "Geschäft"
 
 #: ../workspace/browser/templates/edit_folder.pt:7
 msgid "Change folder title and description"
@@ -251,6 +261,10 @@ msgstr ""
 msgid "Changes applied"
 msgstr "Änderungen gespeichert"
 
+#: ../workspace/browser/tiles/templates/sidebar.pt:357
+msgid "Close milestone"
+msgstr ""
+
 #: ../workspace/browser/templates/content_macros.pt:157
 msgid "Confirmed"
 msgstr ""
@@ -266,6 +280,10 @@ msgstr "Verbrauchen"
 
 #: ../userprofile/browser/templates/userprofile.pt:35
 msgid "Contact"
+msgstr ""
+
+#: ../userprofile/browser/tiles/templates/contacts_search.pt:9
+msgid "Contacts"
 msgstr ""
 
 #: ../search/browser/templates/all_results.pt:27
@@ -300,10 +318,15 @@ msgstr ""
 msgid "Create folder"
 msgstr "Verzeichnis erstellen"
 
+#: ../workspace/browser/tiles/templates/sidebar.pt:289
+msgid "Create new task"
+msgstr ""
+
 #: ../workspace/browser/templates/add_task.pt:2
 msgid "Create task"
 msgstr ""
 
+#: ../theme/browser/templates/workspaces.pt:25
 #: ../workspace/browser/templates/workspace-add.pt:11
 #: ../workspace/browser/templates/workspaces.pt:24
 msgid "Create workspace"
@@ -375,7 +398,7 @@ msgstr "Dokumente"
 msgid "Done"
 msgstr ""
 
-#: ../workspace/basecontent/templates/document_view.pt:108
+#: ../workspace/basecontent/templates/document_view.pt:109
 msgid "Download as"
 msgstr ""
 
@@ -404,7 +427,7 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:421
+#: ../workspace/browser/tiles/templates/sidebar.pt:422
 msgid "Ended"
 msgstr ""
 
@@ -420,6 +443,9 @@ msgstr ""
 msgid "Error while pasting items"
 msgstr ""
 
+msgid "Event"
+msgstr "Termin"
+
 #: ../workspace/browser/templates/add_event.pt:17
 msgid "Event title"
 msgstr ""
@@ -427,6 +453,9 @@ msgstr ""
 #: ../workspace/browser/tiles/templates/workspace-tabs-tile.pt:20
 msgid "Events"
 msgstr "Termine"
+
+msgid "Excel 2007 spreadsheet"
+msgstr "Excel"
 
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:24
 #: ../workspace/browser/tiles/templates/sidebar.pt:50
@@ -436,6 +465,9 @@ msgstr ""
 #: ../core/browser/stream.py:56
 msgid "Explore"
 msgstr "Durchsuchen"
+
+msgid "File"
+msgstr ""
 
 #: ../userprofile/browser/user_import.py:97
 msgid "File incorrectly formatted."
@@ -448,6 +480,9 @@ msgstr ""
 #: ../userprofile/content/userprofile.py:35
 msgid "First name"
 msgstr ""
+
+msgid "Folder"
+msgstr "Ordner"
 
 #: ../workspace/browser/templates/add_folder.pt:14
 msgid "Folder name"
@@ -495,11 +530,11 @@ msgstr ""
 msgid "Functions"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:468
+#: ../workspace/browser/tiles/templates/sidebar.pt:469
 msgid "General"
 msgstr "Allgemein"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:295
+#: ../workspace/browser/tiles/templates/sidebar.pt:296
 msgid "General tasks"
 msgstr ""
 
@@ -602,6 +637,9 @@ msgstr "Alles, was sich heute geändert hat"
 msgid "Items since ever"
 msgstr "Alles"
 
+msgid "JPEG image"
+msgstr "JPEG"
+
 #: ../userprofile/content/userprofile.py:60
 msgid "Job title"
 msgstr ""
@@ -646,6 +684,7 @@ msgstr "Aktuelle Nachrichten"
 msgid "Leave a comment"
 msgstr "Schreibe einen Kommentar"
 
+#: ../core/browser/tiles/templates/my_documents.pt:8
 #: ../library/profiles/default/actions.xml
 msgid "Library"
 msgstr ""
@@ -665,6 +704,9 @@ msgstr ""
 #: ../network/browser/likes.py:56
 msgid "Like"
 msgstr "Like"
+
+msgid "Link"
+msgstr "Link"
 
 #: ../workspace/browser/templates/content_macros.pt:79
 msgid "Location"
@@ -699,7 +741,7 @@ msgid "Member(s) removed"
 msgstr ""
 
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:20
-#: ../workspace/browser/tiles/templates/sidebar.pt:472
+#: ../workspace/browser/tiles/templates/sidebar.pt:473
 msgid "Members"
 msgstr "Benutzer"
 
@@ -775,6 +817,9 @@ msgstr "Neue Nachricht"
 msgid "News"
 msgstr ""
 
+msgid "News Item"
+msgstr "Nachricht"
+
 #: ../messaging/browser/send-message.pt:42
 #: ../messaging/browser/your-inbox.pt:130
 msgid "No attachments selected."
@@ -797,7 +842,7 @@ msgstr "Keine ungelesenen Benachrichtigungen"
 msgid "No such user ${userid}."
 msgstr "Benutzer ${userid} nicht gefunden."
 
-#: ../layout/browser/templates/tasks-tile.pt:10
+#: ../layout/browser/templates/tasks-tile.pt:9
 msgid "No tasks available"
 msgstr ""
 
@@ -838,7 +883,7 @@ msgstr "Das war jetzt unerwartet, aber Sie sind bereits ein Mitglied."
 msgid "Ok"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:450
+#: ../workspace/browser/tiles/templates/sidebar.pt:451
 msgid "Older events"
 msgstr "Ältere Termine"
 
@@ -863,9 +908,15 @@ msgstr ""
 msgid "Outsiders can self-join becoming a workspace member."
 msgstr "Aussenstehende können selbständig Mitglieder des Arbeitsbereichs werden."
 
+msgid "PDF document"
+msgstr "PDF"
+
 #: ../docconv/client/templates/pdf_not_available.pt:5
 msgid "PDF not generated yet"
 msgstr "Das PDF wurde noch nicht generiert. "
+
+msgid "Page"
+msgstr "Seite"
 
 #: ../workspace/browser/tiles/templates/sidebar.pt:102
 msgid "Paste"
@@ -877,6 +928,9 @@ msgstr ""
 
 #: ../search/browser/templates/search_template.pt:28
 msgid "People"
+msgstr ""
+
+msgid "Person"
 msgstr ""
 
 #: ../userprofile/content/userprofile.py:30
@@ -907,6 +961,9 @@ msgstr ""
 #: ../messaging/browser/your-inbox.pt:140
 msgid "Post"
 msgstr "Post"
+
+msgid "PowerPoint 2007 slide"
+msgstr "PowerPoint"
 
 #: ../userprofile/content/userprofile.py:85
 msgid "Primary location"
@@ -952,6 +1009,10 @@ msgstr ""
 msgid "Remove role"
 msgstr ""
 
+#: ../workspace/browser/tiles/templates/sidebar.pt:360
+msgid "Reopen milestone"
+msgstr ""
+
 #: ../workspace/browser/templates/add_content.pt:15
 msgid "Rich text"
 msgstr "Formatierter Text"
@@ -964,9 +1025,9 @@ msgstr ""
 msgid "Roster updated."
 msgstr "Mitgliederliste aktualisiert"
 
+#: ../todo/browser/templates/todo_view.pt:56
 #: ../userprofile/browser/templates/userprofile-edit.pt:47
 #: ../workspace/basecontent/document.py:73
-#: ../workspace/basecontent/templates/event_view.pt:86
 msgid "Save"
 msgstr "Sichern"
 
@@ -996,7 +1057,7 @@ msgstr ""
 msgid "Secret"
 msgstr "Geheimnis"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:476
+#: ../workspace/browser/tiles/templates/sidebar.pt:477
 msgid "Security"
 msgstr "Sicherheit"
 
@@ -1069,7 +1130,7 @@ msgstr ""
 msgid "Start date should be lower than end date"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:416
+#: ../workspace/browser/tiles/templates/sidebar.pt:417
 msgid "Starts"
 msgstr "Startet"
 
@@ -1085,7 +1146,6 @@ msgstr ""
 msgid "Task title"
 msgstr ""
 
-#: ../layout/browser/templates/tasks-tile.pt:9
 #: ../workspace/browser/tiles/templates/workspace-tabs-tile.pt:22
 msgid "Tasks"
 msgstr "Aufgaben"
@@ -1222,7 +1282,7 @@ msgstr ""
 msgid "There was a problem updating the content: %s."
 msgstr ""
 
-#: ../workspace/basecontent/baseviews.py:75
+#: ../workspace/basecontent/baseviews.py:76
 msgid "There was a problem: %s"
 msgstr ""
 
@@ -1268,6 +1328,9 @@ msgstr ""
 msgid "Today"
 msgstr "Heute"
 
+msgid "Todo"
+msgstr ""
+
 #: ../todo/browser/templates/todo_view.pt:43
 #: ../workspace/basecontent/templates/document_view.pt:38
 #: ../workspace/basecontent/templates/event_view.pt:63
@@ -1282,6 +1345,10 @@ msgstr "Token nicht länger gültig."
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:124
 msgid "Transfer members to another workspace."
 msgstr "Mitglieder zu anderem Arbeitsbereich übertragen."
+
+#: ../workspace/browser/tiles/templates/sidebar.pt:367
+msgid "Unassigned"
+msgstr ""
 
 #: ../workspace/browser/templates/content_macros.pt:156
 msgid "Undecided"
@@ -1299,7 +1366,8 @@ msgstr ""
 msgid "Unlike"
 msgstr "Unlike"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:399
+#: ../workspace/browser/tiles/templates/events.pt:9
+#: ../workspace/browser/tiles/templates/sidebar.pt:400
 msgid "Upcoming events"
 msgstr "Anstehende Termine"
 
@@ -1331,6 +1399,9 @@ msgstr "Willkommen in unserer Familie, Fremder."
 #: ../workspace/browser/templates/confirmation-remove-special-role.pt:21
 msgid "When you remove the special role from this member, this member will inherit the default role for this workspace. Are you sure?"
 msgstr ""
+
+msgid "Word 2007 document"
+msgstr "Word"
 
 #: ../workspace/profiles/default/types/ploneintranet.workspace.workspacefolder.xml
 msgid "Workspace"
@@ -1381,7 +1452,6 @@ msgid "Workspace security policy changes saved"
 msgstr "Die Änderungen an der Sicherheitsrichtlinie des Arbeitsbereiches wurden gesichert."
 
 #: ../layout/profiles/default/actions.xml
-#: ../workspace/browser/tiles/templates/workspaces.pt:9
 msgid "Workspaces"
 msgstr "Arbeitsbereiche"
 
@@ -1426,6 +1496,9 @@ msgstr "Die Änderungen wurden gespeichert."
 msgid "Your message here!"
 msgstr "Nachricht verfassen."
 
+msgid "Zip archive"
+msgstr "Zip"
+
 #. Default: "What are you doing?"
 #: ../microblog/browser/tiles/newpostbox.py:234
 #: ../microblog/interfaces.py:14
@@ -1436,6 +1509,9 @@ msgstr "Was steht gerade an?"
 #: ../workspace/browser/tiles/templates/sidebar.pt:39
 msgid "author"
 msgstr "Author"
+
+msgid "cases"
+msgstr "Geschäfte"
 
 #: ../workspace/browser/tiles/templates/navigation.pt:25
 #: ../workspace/browser/tiles/templates/sidebar.pt:41
@@ -1448,7 +1524,7 @@ msgid "document type"
 msgstr "Dokumenttyp"
 
 #. Default: "Download"
-#: ../library/browser/templates/library.html:150
+#: ../library/browser/templates/library.html:151
 msgid "download"
 msgstr ""
 
@@ -1548,7 +1624,7 @@ msgid "label_news"
 msgstr ""
 
 #. Default: "No events available"
-#: ../workspace/browser/tiles/templates/sidebar.pt:459
+#: ../workspace/browser/tiles/templates/sidebar.pt:460
 msgid "label_no_events_available"
 msgstr ""
 
@@ -1597,13 +1673,13 @@ msgstr ""
 msgid "leave_a_comment"
 msgstr "Kommentar verfassen"
 
-#. Default: "More sharing options coming soon…"
-#: ../workspace/basecontent/templates/document_view.pt:110
+#. Default: "More sharing options coming soon"
+#: ../workspace/basecontent/templates/document_view.pt:111
 msgid "more_sharing_soon"
 msgstr ""
 
 #. Default: "No tasks created yet"
-#: ../workspace/browser/tiles/templates/sidebar.pt:297
+#: ../workspace/browser/tiles/templates/sidebar.pt:298
 msgid "no-task-found"
 msgstr "Keine Aufgaben vorhanden"
 
@@ -1618,17 +1694,17 @@ msgid "participant_policy_label"
 msgstr "Teilnehmerrichtlinie"
 
 #. Default: "Description"
-#: ../workspace/basecontent/templates/event_view.pt:100
+#: ../workspace/basecontent/templates/event_view.pt:101
 msgid "placeholder"
 msgstr ""
 
-#: ../workspace/browser/tiles/workspaces.py:97
+#: ../workspace/browser/tiles/workspaces.py:109
 msgid "posted"
 msgstr "abgeschickt"
 
 #. Default: "Read more..."
 #: ../layout/browser/templates/news-tile.pt:19
-#: ../library/browser/templates/library.html:147
+#: ../library/browser/templates/library.html:148
 msgid "read-more"
 msgstr ""
 
@@ -1694,6 +1770,9 @@ msgstr "Einstellungen"
 msgid "workspace_title"
 msgstr "Titel"
 
+msgid "workspacefolders"
+msgstr "Arbeitsbereiche"
+
 #: ../layout/browser/apps.py:43
 msgid "{0} Application"
 msgstr ""
@@ -1707,8 +1786,3 @@ msgstr ""
 msgid "{} user(s) {}."
 msgstr ""
 
-msgid "workspacefolders"
-msgstr "Arbeitsbereiche"
-
-msgid "cases"
-msgstr "Geschäfte"

--- a/src/ploneintranet/core/locales/en/LC_MESSAGES/ploneintranet.po
+++ b/src/ploneintranet/core/locales/en/LC_MESSAGES/ploneintranet.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-08-19 14:20+0000\n"
+"POT-Creation-Date: 2015-08-27 12:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -89,7 +89,7 @@ msgstr ""
 
 #: ../workspace/browser/templates/roster-edit.pt:167
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:116
-#: ../workspace/browser/tiles/templates/sidebar.pt:480
+#: ../workspace/browser/tiles/templates/sidebar.pt:481
 msgid "Advanced"
 msgstr ""
 
@@ -128,6 +128,10 @@ msgstr ""
 msgid "All Types"
 msgstr ""
 
+#: ../workspace/browser/tiles/events.py:49
+msgid "All day"
+msgstr ""
+
 #: ../workspace/browser/templates/content_macros.pt:95
 msgid "All day event"
 msgstr ""
@@ -136,7 +140,7 @@ msgstr ""
 msgid "All notifications"
 msgstr ""
 
-#: ../library/browser/views.py:97
+#: ../library/browser/views.py:100
 msgid "All topics"
 msgstr ""
 
@@ -215,6 +219,9 @@ msgstr ""
 msgid "Bulk import users"
 msgstr ""
 
+msgid "CSV document"
+msgstr ""
+
 #: ../messaging/browser/send-message.pt:63
 #: ../workspace/basecontent/document.py:77
 #: ../workspace/browser/templates/add_content.pt:36
@@ -223,6 +230,9 @@ msgstr ""
 
 #: ../workspace/browser/templates/workspace-add.pt:27
 msgid "Case"
+msgstr ""
+
+msgid "Case Workspace"
 msgstr ""
 
 #: ../workspace/browser/templates/edit_folder.pt:7
@@ -247,6 +257,10 @@ msgstr ""
 msgid "Changes applied"
 msgstr ""
 
+#: ../workspace/browser/tiles/templates/sidebar.pt:357
+msgid "Close milestone"
+msgstr ""
+
 #: ../workspace/browser/templates/content_macros.pt:157
 msgid "Confirmed"
 msgstr ""
@@ -262,6 +276,10 @@ msgstr ""
 
 #: ../userprofile/browser/templates/userprofile.pt:35
 msgid "Contact"
+msgstr ""
+
+#: ../userprofile/browser/tiles/templates/contacts_search.pt:9
+msgid "Contacts"
 msgstr ""
 
 #: ../search/browser/templates/all_results.pt:27
@@ -296,10 +314,15 @@ msgstr ""
 msgid "Create folder"
 msgstr ""
 
+#: ../workspace/browser/tiles/templates/sidebar.pt:289
+msgid "Create new task"
+msgstr ""
+
 #: ../workspace/browser/templates/add_task.pt:2
 msgid "Create task"
 msgstr ""
 
+#: ../theme/browser/templates/workspaces.pt:25
 #: ../workspace/browser/templates/workspace-add.pt:11
 #: ../workspace/browser/templates/workspaces.pt:24
 msgid "Create workspace"
@@ -371,7 +394,7 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#: ../workspace/basecontent/templates/document_view.pt:108
+#: ../workspace/basecontent/templates/document_view.pt:109
 msgid "Download as"
 msgstr ""
 
@@ -400,7 +423,7 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:421
+#: ../workspace/browser/tiles/templates/sidebar.pt:422
 msgid "Ended"
 msgstr ""
 
@@ -416,12 +439,18 @@ msgstr ""
 msgid "Error while pasting items"
 msgstr ""
 
+msgid "Event"
+msgstr ""
+
 #: ../workspace/browser/templates/add_event.pt:17
 msgid "Event title"
 msgstr ""
 
 #: ../workspace/browser/tiles/templates/workspace-tabs-tile.pt:20
 msgid "Events"
+msgstr ""
+
+msgid "Excel 2007 spreadsheet"
 msgstr ""
 
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:24
@@ -431,6 +460,9 @@ msgstr ""
 
 #: ../core/browser/stream.py:56
 msgid "Explore"
+msgstr ""
+
+msgid "File"
 msgstr ""
 
 #: ../userprofile/browser/user_import.py:97
@@ -443,6 +475,9 @@ msgstr ""
 
 #: ../userprofile/content/userprofile.py:35
 msgid "First name"
+msgstr ""
+
+msgid "Folder"
 msgstr ""
 
 #: ../workspace/browser/templates/add_folder.pt:14
@@ -491,11 +526,11 @@ msgstr ""
 msgid "Functions"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:468
+#: ../workspace/browser/tiles/templates/sidebar.pt:469
 msgid "General"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:295
+#: ../workspace/browser/tiles/templates/sidebar.pt:296
 msgid "General tasks"
 msgstr ""
 
@@ -598,6 +633,9 @@ msgstr ""
 msgid "Items since ever"
 msgstr ""
 
+msgid "JPEG image"
+msgstr ""
+
 #: ../userprofile/content/userprofile.py:60
 msgid "Job title"
 msgstr ""
@@ -642,6 +680,7 @@ msgstr ""
 msgid "Leave a comment"
 msgstr ""
 
+#: ../core/browser/tiles/templates/my_documents.pt:8
 #: ../library/profiles/default/actions.xml
 msgid "Library"
 msgstr ""
@@ -660,6 +699,9 @@ msgstr ""
 
 #: ../network/browser/likes.py:56
 msgid "Like"
+msgstr ""
+
+msgid "Link"
 msgstr ""
 
 #: ../workspace/browser/templates/content_macros.pt:79
@@ -695,7 +737,7 @@ msgid "Member(s) removed"
 msgstr ""
 
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:20
-#: ../workspace/browser/tiles/templates/sidebar.pt:472
+#: ../workspace/browser/tiles/templates/sidebar.pt:473
 msgid "Members"
 msgstr ""
 
@@ -771,6 +813,9 @@ msgstr ""
 msgid "News"
 msgstr ""
 
+msgid "News Item"
+msgstr ""
+
 #: ../messaging/browser/send-message.pt:42
 #: ../messaging/browser/your-inbox.pt:130
 msgid "No attachments selected."
@@ -793,7 +838,7 @@ msgstr ""
 msgid "No such user ${userid}."
 msgstr ""
 
-#: ../layout/browser/templates/tasks-tile.pt:10
+#: ../layout/browser/templates/tasks-tile.pt:9
 msgid "No tasks available"
 msgstr ""
 
@@ -834,7 +879,7 @@ msgstr ""
 msgid "Ok"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:450
+#: ../workspace/browser/tiles/templates/sidebar.pt:451
 msgid "Older events"
 msgstr ""
 
@@ -859,8 +904,14 @@ msgstr ""
 msgid "Outsiders can self-join becoming a workspace member."
 msgstr ""
 
+msgid "PDF document"
+msgstr ""
+
 #: ../docconv/client/templates/pdf_not_available.pt:5
 msgid "PDF not generated yet"
+msgstr ""
+
+msgid "Page"
 msgstr ""
 
 #: ../workspace/browser/tiles/templates/sidebar.pt:102
@@ -873,6 +924,9 @@ msgstr ""
 
 #: ../search/browser/templates/search_template.pt:28
 msgid "People"
+msgstr ""
+
+msgid "Person"
 msgstr ""
 
 #: ../userprofile/content/userprofile.py:30
@@ -902,6 +956,9 @@ msgstr ""
 #: ../messaging/browser/send-message.pt:58
 #: ../messaging/browser/your-inbox.pt:140
 msgid "Post"
+msgstr ""
+
+msgid "PowerPoint 2007 slide"
 msgstr ""
 
 #: ../userprofile/content/userprofile.py:85
@@ -948,6 +1005,10 @@ msgstr ""
 msgid "Remove role"
 msgstr ""
 
+#: ../workspace/browser/tiles/templates/sidebar.pt:360
+msgid "Reopen milestone"
+msgstr ""
+
 #: ../workspace/browser/templates/add_content.pt:15
 msgid "Rich text"
 msgstr ""
@@ -960,9 +1021,9 @@ msgstr ""
 msgid "Roster updated."
 msgstr ""
 
+#: ../todo/browser/templates/todo_view.pt:56
 #: ../userprofile/browser/templates/userprofile-edit.pt:47
 #: ../workspace/basecontent/document.py:73
-#: ../workspace/basecontent/templates/event_view.pt:86
 msgid "Save"
 msgstr ""
 
@@ -992,7 +1053,7 @@ msgstr ""
 msgid "Secret"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:476
+#: ../workspace/browser/tiles/templates/sidebar.pt:477
 msgid "Security"
 msgstr ""
 
@@ -1065,7 +1126,7 @@ msgstr ""
 msgid "Start date should be lower than end date"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:416
+#: ../workspace/browser/tiles/templates/sidebar.pt:417
 msgid "Starts"
 msgstr ""
 
@@ -1081,7 +1142,6 @@ msgstr ""
 msgid "Task title"
 msgstr ""
 
-#: ../layout/browser/templates/tasks-tile.pt:9
 #: ../workspace/browser/tiles/templates/workspace-tabs-tile.pt:22
 msgid "Tasks"
 msgstr ""
@@ -1218,7 +1278,7 @@ msgstr ""
 msgid "There was a problem updating the content: %s."
 msgstr ""
 
-#: ../workspace/basecontent/baseviews.py:75
+#: ../workspace/basecontent/baseviews.py:76
 msgid "There was a problem: %s"
 msgstr ""
 
@@ -1264,6 +1324,9 @@ msgstr ""
 msgid "Today"
 msgstr ""
 
+msgid "Todo"
+msgstr ""
+
 #: ../todo/browser/templates/todo_view.pt:43
 #: ../workspace/basecontent/templates/document_view.pt:38
 #: ../workspace/basecontent/templates/event_view.pt:63
@@ -1277,6 +1340,10 @@ msgstr ""
 #: ../workspace/browser/templates/roster-edit.pt:176
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:124
 msgid "Transfer members to another workspace."
+msgstr ""
+
+#: ../workspace/browser/tiles/templates/sidebar.pt:367
+msgid "Unassigned"
 msgstr ""
 
 #: ../workspace/browser/templates/content_macros.pt:156
@@ -1295,7 +1362,8 @@ msgstr ""
 msgid "Unlike"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:399
+#: ../workspace/browser/tiles/templates/events.pt:9
+#: ../workspace/browser/tiles/templates/sidebar.pt:400
 msgid "Upcoming events"
 msgstr ""
 
@@ -1326,6 +1394,9 @@ msgstr ""
 
 #: ../workspace/browser/templates/confirmation-remove-special-role.pt:21
 msgid "When you remove the special role from this member, this member will inherit the default role for this workspace. Are you sure?"
+msgstr ""
+
+msgid "Word 2007 document"
 msgstr ""
 
 #: ../workspace/profiles/default/types/ploneintranet.workspace.workspacefolder.xml
@@ -1377,7 +1448,6 @@ msgid "Workspace security policy changes saved"
 msgstr ""
 
 #: ../layout/profiles/default/actions.xml
-#: ../workspace/browser/tiles/templates/workspaces.pt:9
 msgid "Workspaces"
 msgstr ""
 
@@ -1422,6 +1492,9 @@ msgstr ""
 msgid "Your message here!"
 msgstr ""
 
+msgid "Zip archive"
+msgstr ""
+
 #. Default: "What are you doing?"
 #: ../microblog/browser/tiles/newpostbox.py:234
 #: ../microblog/interfaces.py:14
@@ -1447,7 +1520,7 @@ msgid "document type"
 msgstr ""
 
 #. Default: "Download"
-#: ../library/browser/templates/library.html:150
+#: ../library/browser/templates/library.html:151
 msgid "download"
 msgstr ""
 
@@ -1542,7 +1615,7 @@ msgid "label_news"
 msgstr ""
 
 #. Default: "No events available"
-#: ../workspace/browser/tiles/templates/sidebar.pt:459
+#: ../workspace/browser/tiles/templates/sidebar.pt:460
 msgid "label_no_events_available"
 msgstr ""
 
@@ -1591,13 +1664,13 @@ msgstr ""
 msgid "leave_a_comment"
 msgstr ""
 
-#. Default: "More sharing options coming soon…"
-#: ../workspace/basecontent/templates/document_view.pt:110
+#. Default: "More sharing options coming soon"
+#: ../workspace/basecontent/templates/document_view.pt:111
 msgid "more_sharing_soon"
 msgstr ""
 
 #. Default: "No tasks created yet"
-#: ../workspace/browser/tiles/templates/sidebar.pt:297
+#: ../workspace/browser/tiles/templates/sidebar.pt:298
 msgid "no-task-found"
 msgstr ""
 
@@ -1612,17 +1685,17 @@ msgid "participant_policy_label"
 msgstr ""
 
 #. Default: "Description"
-#: ../workspace/basecontent/templates/event_view.pt:100
+#: ../workspace/basecontent/templates/event_view.pt:101
 msgid "placeholder"
 msgstr ""
 
-#: ../workspace/browser/tiles/workspaces.py:97
+#: ../workspace/browser/tiles/workspaces.py:109
 msgid "posted"
 msgstr ""
 
 #. Default: "Read more..."
 #: ../layout/browser/templates/news-tile.pt:19
-#: ../library/browser/templates/library.html:147
+#: ../library/browser/templates/library.html:148
 msgid "read-more"
 msgstr ""
 

--- a/src/ploneintranet/core/locales/en/LC_MESSAGES/ploneintranet.po
+++ b/src/ploneintranet/core/locales/en/LC_MESSAGES/ploneintranet.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-08-27 12:45+0000\n"
+"POT-Creation-Date: 2015-08-28 08:33+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -958,7 +958,7 @@ msgstr ""
 msgid "Post"
 msgstr ""
 
-msgid "PowerPoint 2007 slide"
+msgid "PowerPoint 2007 presentation"
 msgstr ""
 
 #: ../userprofile/content/userprofile.py:85

--- a/src/ploneintranet/core/locales/es/LC_MESSAGES/ploneintranet.po
+++ b/src/ploneintranet/core/locales/es/LC_MESSAGES/ploneintranet.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone Intranet\n"
-"POT-Creation-Date: 2015-08-27 12:45+0000\n"
+"POT-Creation-Date: 2015-08-28 08:33+0000\n"
 "PO-Revision-Date: 2015-05-23 00:20+0000\n"
 "Last-Translator: Leonardo J. Caballero G. <leonardocaballero@gmail.com>\n"
 "Language-Team: Spanish (http://www.transifex.com/projects/p/plone-intranet/language/es/)\n"
@@ -962,7 +962,7 @@ msgstr ""
 msgid "Post"
 msgstr "Envio"
 
-msgid "PowerPoint 2007 slide"
+msgid "PowerPoint 2007 presentation"
 msgstr ""
 
 #: ../userprofile/content/userprofile.py:85

--- a/src/ploneintranet/core/locales/es/LC_MESSAGES/ploneintranet.po
+++ b/src/ploneintranet/core/locales/es/LC_MESSAGES/ploneintranet.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone Intranet\n"
-"POT-Creation-Date: 2015-08-19 14:20+0000\n"
+"POT-Creation-Date: 2015-08-27 12:45+0000\n"
 "PO-Revision-Date: 2015-05-23 00:20+0000\n"
 "Last-Translator: Leonardo J. Caballero G. <leonardocaballero@gmail.com>\n"
 "Language-Team: Spanish (http://www.transifex.com/projects/p/plone-intranet/language/es/)\n"
@@ -93,7 +93,7 @@ msgstr "Gestionado por el Administador"
 
 #: ../workspace/browser/templates/roster-edit.pt:167
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:116
-#: ../workspace/browser/tiles/templates/sidebar.pt:480
+#: ../workspace/browser/tiles/templates/sidebar.pt:481
 msgid "Advanced"
 msgstr "Avanzado"
 
@@ -132,6 +132,10 @@ msgstr "Toda la hora"
 msgid "All Types"
 msgstr "Todos los tipos"
 
+#: ../workspace/browser/tiles/events.py:49
+msgid "All day"
+msgstr ""
+
 #: ../workspace/browser/templates/content_macros.pt:95
 msgid "All day event"
 msgstr ""
@@ -140,7 +144,7 @@ msgstr ""
 msgid "All notifications"
 msgstr "Todos las notificaciones"
 
-#: ../library/browser/views.py:97
+#: ../library/browser/views.py:100
 msgid "All topics"
 msgstr ""
 
@@ -219,6 +223,9 @@ msgstr ""
 msgid "Bulk import users"
 msgstr ""
 
+msgid "CSV document"
+msgstr ""
+
 #: ../messaging/browser/send-message.pt:63
 #: ../workspace/basecontent/document.py:77
 #: ../workspace/browser/templates/add_content.pt:36
@@ -227,6 +234,9 @@ msgstr "Cancelar"
 
 #: ../workspace/browser/templates/workspace-add.pt:27
 msgid "Case"
+msgstr ""
+
+msgid "Case Workspace"
 msgstr ""
 
 #: ../workspace/browser/templates/edit_folder.pt:7
@@ -251,6 +261,10 @@ msgstr ""
 msgid "Changes applied"
 msgstr "Cambios aplicados."
 
+#: ../workspace/browser/tiles/templates/sidebar.pt:357
+msgid "Close milestone"
+msgstr ""
+
 #: ../workspace/browser/templates/content_macros.pt:157
 msgid "Confirmed"
 msgstr ""
@@ -266,6 +280,10 @@ msgstr "Consumir"
 
 #: ../userprofile/browser/templates/userprofile.pt:35
 msgid "Contact"
+msgstr ""
+
+#: ../userprofile/browser/tiles/templates/contacts_search.pt:9
+msgid "Contacts"
 msgstr ""
 
 #: ../search/browser/templates/all_results.pt:27
@@ -300,10 +318,15 @@ msgstr ""
 msgid "Create folder"
 msgstr "Crear carpeta"
 
+#: ../workspace/browser/tiles/templates/sidebar.pt:289
+msgid "Create new task"
+msgstr ""
+
 #: ../workspace/browser/templates/add_task.pt:2
 msgid "Create task"
 msgstr ""
 
+#: ../theme/browser/templates/workspaces.pt:25
 #: ../workspace/browser/templates/workspace-add.pt:11
 #: ../workspace/browser/templates/workspaces.pt:24
 msgid "Create workspace"
@@ -375,7 +398,7 @@ msgstr "Documentos"
 msgid "Done"
 msgstr ""
 
-#: ../workspace/basecontent/templates/document_view.pt:108
+#: ../workspace/basecontent/templates/document_view.pt:109
 msgid "Download as"
 msgstr ""
 
@@ -404,7 +427,7 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:421
+#: ../workspace/browser/tiles/templates/sidebar.pt:422
 msgid "Ended"
 msgstr ""
 
@@ -420,6 +443,9 @@ msgstr ""
 msgid "Error while pasting items"
 msgstr ""
 
+msgid "Event"
+msgstr ""
+
 #: ../workspace/browser/templates/add_event.pt:17
 msgid "Event title"
 msgstr ""
@@ -427,6 +453,9 @@ msgstr ""
 #: ../workspace/browser/tiles/templates/workspace-tabs-tile.pt:20
 msgid "Events"
 msgstr "Eventos"
+
+msgid "Excel 2007 spreadsheet"
+msgstr ""
 
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:24
 #: ../workspace/browser/tiles/templates/sidebar.pt:50
@@ -436,6 +465,9 @@ msgstr ""
 #: ../core/browser/stream.py:56
 msgid "Explore"
 msgstr "Explorar"
+
+msgid "File"
+msgstr ""
 
 #: ../userprofile/browser/user_import.py:97
 msgid "File incorrectly formatted."
@@ -447,6 +479,9 @@ msgstr ""
 
 #: ../userprofile/content/userprofile.py:35
 msgid "First name"
+msgstr ""
+
+msgid "Folder"
 msgstr ""
 
 #: ../workspace/browser/templates/add_folder.pt:14
@@ -495,11 +530,11 @@ msgstr ""
 msgid "Functions"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:468
+#: ../workspace/browser/tiles/templates/sidebar.pt:469
 msgid "General"
 msgstr "General"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:295
+#: ../workspace/browser/tiles/templates/sidebar.pt:296
 msgid "General tasks"
 msgstr ""
 
@@ -602,6 +637,9 @@ msgstr "Elementos modificados hoy"
 msgid "Items since ever"
 msgstr "Elementos desde entonces"
 
+msgid "JPEG image"
+msgstr ""
+
 #: ../userprofile/content/userprofile.py:60
 msgid "Job title"
 msgstr ""
@@ -646,6 +684,7 @@ msgstr "Últimas noticias"
 msgid "Leave a comment"
 msgstr "Dejar un comentario"
 
+#: ../core/browser/tiles/templates/my_documents.pt:8
 #: ../library/profiles/default/actions.xml
 msgid "Library"
 msgstr ""
@@ -665,6 +704,9 @@ msgstr ""
 #: ../network/browser/likes.py:56
 msgid "Like"
 msgstr "Gustar"
+
+msgid "Link"
+msgstr ""
 
 #: ../workspace/browser/templates/content_macros.pt:79
 msgid "Location"
@@ -699,7 +741,7 @@ msgid "Member(s) removed"
 msgstr ""
 
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:20
-#: ../workspace/browser/tiles/templates/sidebar.pt:472
+#: ../workspace/browser/tiles/templates/sidebar.pt:473
 msgid "Members"
 msgstr "Miembros"
 
@@ -775,6 +817,9 @@ msgstr "Nuevo mensaje"
 msgid "News"
 msgstr ""
 
+msgid "News Item"
+msgstr ""
+
 #: ../messaging/browser/send-message.pt:42
 #: ../messaging/browser/your-inbox.pt:130
 msgid "No attachments selected."
@@ -797,7 +842,7 @@ msgstr "Sin notificaciones pendientes"
 msgid "No such user ${userid}."
 msgstr "No existe usuario ${userid}."
 
-#: ../layout/browser/templates/tasks-tile.pt:10
+#: ../layout/browser/templates/tasks-tile.pt:9
 msgid "No tasks available"
 msgstr ""
 
@@ -838,7 +883,7 @@ msgstr "Oh, muchacho, madre mía, que ya es un miembro"
 msgid "Ok"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:450
+#: ../workspace/browser/tiles/templates/sidebar.pt:451
 msgid "Older events"
 msgstr "Antiguos eventos"
 
@@ -863,9 +908,15 @@ msgstr ""
 msgid "Outsiders can self-join becoming a workspace member."
 msgstr "Los forasteros pueden auto-unirse a convertirse en un miembro del espacio de trabajo."
 
+msgid "PDF document"
+msgstr ""
+
 #: ../docconv/client/templates/pdf_not_available.pt:5
 msgid "PDF not generated yet"
 msgstr "PDF no ha sido generado aun"
+
+msgid "Page"
+msgstr ""
 
 #: ../workspace/browser/tiles/templates/sidebar.pt:102
 msgid "Paste"
@@ -877,6 +928,9 @@ msgstr ""
 
 #: ../search/browser/templates/search_template.pt:28
 msgid "People"
+msgstr ""
+
+msgid "Person"
 msgstr ""
 
 #: ../userprofile/content/userprofile.py:30
@@ -907,6 +961,9 @@ msgstr ""
 #: ../messaging/browser/your-inbox.pt:140
 msgid "Post"
 msgstr "Envio"
+
+msgid "PowerPoint 2007 slide"
+msgstr ""
 
 #: ../userprofile/content/userprofile.py:85
 msgid "Primary location"
@@ -952,6 +1009,10 @@ msgstr ""
 msgid "Remove role"
 msgstr ""
 
+#: ../workspace/browser/tiles/templates/sidebar.pt:360
+msgid "Reopen milestone"
+msgstr ""
+
 #: ../workspace/browser/templates/add_content.pt:15
 msgid "Rich text"
 msgstr "Texto enriquecido"
@@ -964,9 +1025,9 @@ msgstr ""
 msgid "Roster updated."
 msgstr "Lista de miembros actualizada."
 
+#: ../todo/browser/templates/todo_view.pt:56
 #: ../userprofile/browser/templates/userprofile-edit.pt:47
 #: ../workspace/basecontent/document.py:73
-#: ../workspace/basecontent/templates/event_view.pt:86
 msgid "Save"
 msgstr "Guardar"
 
@@ -996,7 +1057,7 @@ msgstr ""
 msgid "Secret"
 msgstr "Secreto"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:476
+#: ../workspace/browser/tiles/templates/sidebar.pt:477
 msgid "Security"
 msgstr "Seguridad"
 
@@ -1069,7 +1130,7 @@ msgstr ""
 msgid "Start date should be lower than end date"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:416
+#: ../workspace/browser/tiles/templates/sidebar.pt:417
 msgid "Starts"
 msgstr "Inicio"
 
@@ -1085,7 +1146,6 @@ msgstr ""
 msgid "Task title"
 msgstr ""
 
-#: ../layout/browser/templates/tasks-tile.pt:9
 #: ../workspace/browser/tiles/templates/workspace-tabs-tile.pt:22
 msgid "Tasks"
 msgstr "Tareas"
@@ -1222,7 +1282,7 @@ msgstr ""
 msgid "There was a problem updating the content: %s."
 msgstr ""
 
-#: ../workspace/basecontent/baseviews.py:75
+#: ../workspace/basecontent/baseviews.py:76
 msgid "There was a problem: %s"
 msgstr ""
 
@@ -1268,6 +1328,9 @@ msgstr ""
 msgid "Today"
 msgstr "Hoy"
 
+msgid "Todo"
+msgstr ""
+
 #: ../todo/browser/templates/todo_view.pt:43
 #: ../workspace/basecontent/templates/document_view.pt:38
 #: ../workspace/basecontent/templates/event_view.pt:63
@@ -1282,6 +1345,10 @@ msgstr "Token no mas valido"
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:124
 msgid "Transfer members to another workspace."
 msgstr "Transferir miembros a otro espacio de trabajo."
+
+#: ../workspace/browser/tiles/templates/sidebar.pt:367
+msgid "Unassigned"
+msgstr ""
 
 #: ../workspace/browser/templates/content_macros.pt:156
 msgid "Undecided"
@@ -1299,7 +1366,8 @@ msgstr ""
 msgid "Unlike"
 msgstr "No gustar"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:399
+#: ../workspace/browser/tiles/templates/events.pt:9
+#: ../workspace/browser/tiles/templates/sidebar.pt:400
 msgid "Upcoming events"
 msgstr "Próximos eventos"
 
@@ -1330,6 +1398,9 @@ msgstr "Bienvenido a nuestra familia, Extraño"
 
 #: ../workspace/browser/templates/confirmation-remove-special-role.pt:21
 msgid "When you remove the special role from this member, this member will inherit the default role for this workspace. Are you sure?"
+msgstr ""
+
+msgid "Word 2007 document"
 msgstr ""
 
 #: ../workspace/profiles/default/types/ploneintranet.workspace.workspacefolder.xml
@@ -1381,7 +1452,6 @@ msgid "Workspace security policy changes saved"
 msgstr "Las cambios de las políticas de seguridad del espacio de trabajo se guardadas."
 
 #: ../layout/profiles/default/actions.xml
-#: ../workspace/browser/tiles/templates/workspaces.pt:9
 msgid "Workspaces"
 msgstr "Espacios de trabajo"
 
@@ -1426,6 +1496,9 @@ msgstr "Sus cambios han sido guardados."
 msgid "Your message here!"
 msgstr "¡Su mensaje aquí!"
 
+msgid "Zip archive"
+msgstr ""
+
 #. Default: "What are you doing?"
 #: ../microblog/browser/tiles/newpostbox.py:234
 #: ../microblog/interfaces.py:14
@@ -1436,6 +1509,9 @@ msgstr "¿Qué esta haciendo?"
 #: ../workspace/browser/tiles/templates/sidebar.pt:39
 msgid "author"
 msgstr "autor"
+
+msgid "cases"
+msgstr ""
 
 #: ../workspace/browser/tiles/templates/navigation.pt:25
 #: ../workspace/browser/tiles/templates/sidebar.pt:41
@@ -1448,7 +1524,7 @@ msgid "document type"
 msgstr "tipo de documento"
 
 #. Default: "Download"
-#: ../library/browser/templates/library.html:150
+#: ../library/browser/templates/library.html:151
 msgid "download"
 msgstr ""
 
@@ -1548,7 +1624,7 @@ msgid "label_news"
 msgstr ""
 
 #. Default: "No events available"
-#: ../workspace/browser/tiles/templates/sidebar.pt:459
+#: ../workspace/browser/tiles/templates/sidebar.pt:460
 msgid "label_no_events_available"
 msgstr ""
 
@@ -1597,13 +1673,13 @@ msgstr ""
 msgid "leave_a_comment"
 msgstr "Dejar un comentario..."
 
-#. Default: "More sharing options coming soon…"
-#: ../workspace/basecontent/templates/document_view.pt:110
+#. Default: "More sharing options coming soon"
+#: ../workspace/basecontent/templates/document_view.pt:111
 msgid "more_sharing_soon"
 msgstr ""
 
 #. Default: "No tasks created yet"
-#: ../workspace/browser/tiles/templates/sidebar.pt:297
+#: ../workspace/browser/tiles/templates/sidebar.pt:298
 msgid "no-task-found"
 msgstr "Sin tareas creadas aun"
 
@@ -1618,17 +1694,17 @@ msgid "participant_policy_label"
 msgstr "Política de participantes"
 
 #. Default: "Description"
-#: ../workspace/basecontent/templates/event_view.pt:100
+#: ../workspace/basecontent/templates/event_view.pt:101
 msgid "placeholder"
 msgstr ""
 
-#: ../workspace/browser/tiles/workspaces.py:97
+#: ../workspace/browser/tiles/workspaces.py:109
 msgid "posted"
 msgstr "enviado"
 
 #. Default: "Read more..."
 #: ../layout/browser/templates/news-tile.pt:19
-#: ../library/browser/templates/library.html:147
+#: ../library/browser/templates/library.html:148
 msgid "read-more"
 msgstr ""
 
@@ -1693,6 +1769,9 @@ msgstr "Configuración de espacio de trabajo"
 #, fuzzy
 msgid "workspace_title"
 msgstr "Título del espacio de trabajo"
+
+msgid "workspacefolders"
+msgstr ""
 
 #: ../layout/browser/apps.py:43
 msgid "{0} Application"

--- a/src/ploneintranet/core/locales/fr/LC_MESSAGES/ploneintranet.po
+++ b/src/ploneintranet/core/locales/fr/LC_MESSAGES/ploneintranet.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone Intranet\n"
-"POT-Creation-Date: 2015-08-19 14:20+0000\n"
+"POT-Creation-Date: 2015-08-27 12:45+0000\n"
 "PO-Revision-Date: 2015-05-22 10:54+0000\n"
 "Last-Translator: gnafou <fmgre-fboi@yahoo.fr>\n"
 "Language-Team: French (http://www.transifex.com/projects/p/plone-intranet/language/fr/)\n"
@@ -94,7 +94,7 @@ msgstr "Géré par les administrateurs"
 
 #: ../workspace/browser/templates/roster-edit.pt:167
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:116
-#: ../workspace/browser/tiles/templates/sidebar.pt:480
+#: ../workspace/browser/tiles/templates/sidebar.pt:481
 msgid "Advanced"
 msgstr "Avancé"
 
@@ -133,6 +133,10 @@ msgstr ""
 msgid "All Types"
 msgstr ""
 
+#: ../workspace/browser/tiles/events.py:49
+msgid "All day"
+msgstr ""
+
 #: ../workspace/browser/templates/content_macros.pt:95
 msgid "All day event"
 msgstr ""
@@ -141,7 +145,7 @@ msgstr ""
 msgid "All notifications"
 msgstr "Toutes les notifications"
 
-#: ../library/browser/views.py:97
+#: ../library/browser/views.py:100
 msgid "All topics"
 msgstr ""
 
@@ -220,6 +224,9 @@ msgstr ""
 msgid "Bulk import users"
 msgstr ""
 
+msgid "CSV document"
+msgstr ""
+
 #: ../messaging/browser/send-message.pt:63
 #: ../workspace/basecontent/document.py:77
 #: ../workspace/browser/templates/add_content.pt:36
@@ -228,6 +235,9 @@ msgstr "Annuler"
 
 #: ../workspace/browser/templates/workspace-add.pt:27
 msgid "Case"
+msgstr ""
+
+msgid "Case Workspace"
 msgstr ""
 
 #: ../workspace/browser/templates/edit_folder.pt:7
@@ -252,6 +262,10 @@ msgstr ""
 msgid "Changes applied"
 msgstr "Les modifications ont été appliquées"
 
+#: ../workspace/browser/tiles/templates/sidebar.pt:357
+msgid "Close milestone"
+msgstr ""
+
 #: ../workspace/browser/templates/content_macros.pt:157
 msgid "Confirmed"
 msgstr ""
@@ -267,6 +281,10 @@ msgstr ""
 
 #: ../userprofile/browser/templates/userprofile.pt:35
 msgid "Contact"
+msgstr ""
+
+#: ../userprofile/browser/tiles/templates/contacts_search.pt:9
+msgid "Contacts"
 msgstr ""
 
 #: ../search/browser/templates/all_results.pt:27
@@ -301,10 +319,15 @@ msgstr ""
 msgid "Create folder"
 msgstr "Créer un dossier"
 
+#: ../workspace/browser/tiles/templates/sidebar.pt:289
+msgid "Create new task"
+msgstr ""
+
 #: ../workspace/browser/templates/add_task.pt:2
 msgid "Create task"
 msgstr ""
 
+#: ../theme/browser/templates/workspaces.pt:25
 #: ../workspace/browser/templates/workspace-add.pt:11
 #: ../workspace/browser/templates/workspaces.pt:24
 msgid "Create workspace"
@@ -376,7 +399,7 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#: ../workspace/basecontent/templates/document_view.pt:108
+#: ../workspace/basecontent/templates/document_view.pt:109
 msgid "Download as"
 msgstr ""
 
@@ -405,7 +428,7 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:421
+#: ../workspace/browser/tiles/templates/sidebar.pt:422
 msgid "Ended"
 msgstr ""
 
@@ -421,6 +444,9 @@ msgstr ""
 msgid "Error while pasting items"
 msgstr ""
 
+msgid "Event"
+msgstr ""
+
 #: ../workspace/browser/templates/add_event.pt:17
 msgid "Event title"
 msgstr ""
@@ -429,6 +455,9 @@ msgstr ""
 msgid "Events"
 msgstr "Événements"
 
+msgid "Excel 2007 spreadsheet"
+msgstr ""
+
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:24
 #: ../workspace/browser/tiles/templates/sidebar.pt:50
 msgid "Expand sidebar"
@@ -436,6 +465,9 @@ msgstr ""
 
 #: ../core/browser/stream.py:56
 msgid "Explore"
+msgstr ""
+
+msgid "File"
 msgstr ""
 
 #: ../userprofile/browser/user_import.py:97
@@ -448,6 +480,9 @@ msgstr ""
 
 #: ../userprofile/content/userprofile.py:35
 msgid "First name"
+msgstr ""
+
+msgid "Folder"
 msgstr ""
 
 #: ../workspace/browser/templates/add_folder.pt:14
@@ -496,11 +531,11 @@ msgstr ""
 msgid "Functions"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:468
+#: ../workspace/browser/tiles/templates/sidebar.pt:469
 msgid "General"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:295
+#: ../workspace/browser/tiles/templates/sidebar.pt:296
 msgid "General tasks"
 msgstr ""
 
@@ -603,6 +638,9 @@ msgstr ""
 msgid "Items since ever"
 msgstr ""
 
+msgid "JPEG image"
+msgstr ""
+
 #: ../userprofile/content/userprofile.py:60
 msgid "Job title"
 msgstr ""
@@ -647,6 +685,7 @@ msgstr "nouvelles récentes"
 msgid "Leave a comment"
 msgstr "laisser un commentaire"
 
+#: ../core/browser/tiles/templates/my_documents.pt:8
 #: ../library/profiles/default/actions.xml
 msgid "Library"
 msgstr ""
@@ -665,6 +704,9 @@ msgstr ""
 
 #: ../network/browser/likes.py:56
 msgid "Like"
+msgstr ""
+
+msgid "Link"
 msgstr ""
 
 #: ../workspace/browser/templates/content_macros.pt:79
@@ -700,7 +742,7 @@ msgid "Member(s) removed"
 msgstr ""
 
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:20
-#: ../workspace/browser/tiles/templates/sidebar.pt:472
+#: ../workspace/browser/tiles/templates/sidebar.pt:473
 msgid "Members"
 msgstr "Membres"
 
@@ -776,6 +818,9 @@ msgstr ""
 msgid "News"
 msgstr ""
 
+msgid "News Item"
+msgstr ""
+
 #: ../messaging/browser/send-message.pt:42
 #: ../messaging/browser/your-inbox.pt:130
 msgid "No attachments selected."
@@ -798,7 +843,7 @@ msgstr ""
 msgid "No such user ${userid}."
 msgstr ""
 
-#: ../layout/browser/templates/tasks-tile.pt:10
+#: ../layout/browser/templates/tasks-tile.pt:9
 msgid "No tasks available"
 msgstr ""
 
@@ -839,7 +884,7 @@ msgstr ""
 msgid "Ok"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:450
+#: ../workspace/browser/tiles/templates/sidebar.pt:451
 msgid "Older events"
 msgstr ""
 
@@ -864,8 +909,14 @@ msgstr ""
 msgid "Outsiders can self-join becoming a workspace member."
 msgstr ""
 
+msgid "PDF document"
+msgstr ""
+
 #: ../docconv/client/templates/pdf_not_available.pt:5
 msgid "PDF not generated yet"
+msgstr ""
+
+msgid "Page"
 msgstr ""
 
 #: ../workspace/browser/tiles/templates/sidebar.pt:102
@@ -878,6 +929,9 @@ msgstr ""
 
 #: ../search/browser/templates/search_template.pt:28
 msgid "People"
+msgstr ""
+
+msgid "Person"
 msgstr ""
 
 #: ../userprofile/content/userprofile.py:30
@@ -907,6 +961,9 @@ msgstr ""
 #: ../messaging/browser/send-message.pt:58
 #: ../messaging/browser/your-inbox.pt:140
 msgid "Post"
+msgstr ""
+
+msgid "PowerPoint 2007 slide"
 msgstr ""
 
 #: ../userprofile/content/userprofile.py:85
@@ -953,6 +1010,10 @@ msgstr ""
 msgid "Remove role"
 msgstr ""
 
+#: ../workspace/browser/tiles/templates/sidebar.pt:360
+msgid "Reopen milestone"
+msgstr ""
+
 #: ../workspace/browser/templates/add_content.pt:15
 msgid "Rich text"
 msgstr ""
@@ -965,9 +1026,9 @@ msgstr ""
 msgid "Roster updated."
 msgstr ""
 
+#: ../todo/browser/templates/todo_view.pt:56
 #: ../userprofile/browser/templates/userprofile-edit.pt:47
 #: ../workspace/basecontent/document.py:73
-#: ../workspace/basecontent/templates/event_view.pt:86
 msgid "Save"
 msgstr "Enregistrer"
 
@@ -997,7 +1058,7 @@ msgstr ""
 msgid "Secret"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:476
+#: ../workspace/browser/tiles/templates/sidebar.pt:477
 msgid "Security"
 msgstr "Sécurité"
 
@@ -1070,7 +1131,7 @@ msgstr ""
 msgid "Start date should be lower than end date"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:416
+#: ../workspace/browser/tiles/templates/sidebar.pt:417
 msgid "Starts"
 msgstr ""
 
@@ -1086,7 +1147,6 @@ msgstr ""
 msgid "Task title"
 msgstr ""
 
-#: ../layout/browser/templates/tasks-tile.pt:9
 #: ../workspace/browser/tiles/templates/workspace-tabs-tile.pt:22
 msgid "Tasks"
 msgstr ""
@@ -1223,7 +1283,7 @@ msgstr ""
 msgid "There was a problem updating the content: %s."
 msgstr ""
 
-#: ../workspace/basecontent/baseviews.py:75
+#: ../workspace/basecontent/baseviews.py:76
 msgid "There was a problem: %s"
 msgstr ""
 
@@ -1269,6 +1329,9 @@ msgstr ""
 msgid "Today"
 msgstr "Aujourd'hui"
 
+msgid "Todo"
+msgstr ""
+
 #: ../todo/browser/templates/todo_view.pt:43
 #: ../workspace/basecontent/templates/document_view.pt:38
 #: ../workspace/basecontent/templates/event_view.pt:63
@@ -1282,6 +1345,10 @@ msgstr ""
 #: ../workspace/browser/templates/roster-edit.pt:176
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:124
 msgid "Transfer members to another workspace."
+msgstr ""
+
+#: ../workspace/browser/tiles/templates/sidebar.pt:367
+msgid "Unassigned"
 msgstr ""
 
 #: ../workspace/browser/templates/content_macros.pt:156
@@ -1300,7 +1367,8 @@ msgstr ""
 msgid "Unlike"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:399
+#: ../workspace/browser/tiles/templates/events.pt:9
+#: ../workspace/browser/tiles/templates/sidebar.pt:400
 msgid "Upcoming events"
 msgstr ""
 
@@ -1331,6 +1399,9 @@ msgstr ""
 
 #: ../workspace/browser/templates/confirmation-remove-special-role.pt:21
 msgid "When you remove the special role from this member, this member will inherit the default role for this workspace. Are you sure?"
+msgstr ""
+
+msgid "Word 2007 document"
 msgstr ""
 
 #: ../workspace/profiles/default/types/ploneintranet.workspace.workspacefolder.xml
@@ -1382,7 +1453,6 @@ msgid "Workspace security policy changes saved"
 msgstr ""
 
 #: ../layout/profiles/default/actions.xml
-#: ../workspace/browser/tiles/templates/workspaces.pt:9
 msgid "Workspaces"
 msgstr ""
 
@@ -1427,6 +1497,9 @@ msgstr "Vos modification sont été enregistrées"
 msgid "Your message here!"
 msgstr ""
 
+msgid "Zip archive"
+msgstr ""
+
 #. Default: "What are you doing?"
 #: ../microblog/browser/tiles/newpostbox.py:234
 #: ../microblog/interfaces.py:14
@@ -1437,6 +1510,9 @@ msgstr ""
 #: ../workspace/browser/tiles/templates/sidebar.pt:39
 msgid "author"
 msgstr "auteur"
+
+msgid "cases"
+msgstr ""
 
 #: ../workspace/browser/tiles/templates/navigation.pt:25
 #: ../workspace/browser/tiles/templates/sidebar.pt:41
@@ -1449,7 +1525,7 @@ msgid "document type"
 msgstr "type de document"
 
 #. Default: "Download"
-#: ../library/browser/templates/library.html:150
+#: ../library/browser/templates/library.html:151
 msgid "download"
 msgstr ""
 
@@ -1547,7 +1623,7 @@ msgid "label_news"
 msgstr ""
 
 #. Default: "No events available"
-#: ../workspace/browser/tiles/templates/sidebar.pt:459
+#: ../workspace/browser/tiles/templates/sidebar.pt:460
 msgid "label_no_events_available"
 msgstr ""
 
@@ -1596,13 +1672,13 @@ msgstr ""
 msgid "leave_a_comment"
 msgstr ""
 
-#. Default: "More sharing options coming soon…"
-#: ../workspace/basecontent/templates/document_view.pt:110
+#. Default: "More sharing options coming soon"
+#: ../workspace/basecontent/templates/document_view.pt:111
 msgid "more_sharing_soon"
 msgstr ""
 
 #. Default: "No tasks created yet"
-#: ../workspace/browser/tiles/templates/sidebar.pt:297
+#: ../workspace/browser/tiles/templates/sidebar.pt:298
 msgid "no-task-found"
 msgstr ""
 
@@ -1617,17 +1693,17 @@ msgid "participant_policy_label"
 msgstr ""
 
 #. Default: "Description"
-#: ../workspace/basecontent/templates/event_view.pt:100
+#: ../workspace/basecontent/templates/event_view.pt:101
 msgid "placeholder"
 msgstr ""
 
-#: ../workspace/browser/tiles/workspaces.py:97
+#: ../workspace/browser/tiles/workspaces.py:109
 msgid "posted"
 msgstr ""
 
 #. Default: "Read more..."
 #: ../layout/browser/templates/news-tile.pt:19
-#: ../library/browser/templates/library.html:147
+#: ../library/browser/templates/library.html:148
 msgid "read-more"
 msgstr ""
 
@@ -1690,6 +1766,9 @@ msgstr ""
 #. Default: "Workspace title"
 #: ../workspace/browser/tiles/templates/sidebar-settings-general.pt:18
 msgid "workspace_title"
+msgstr ""
+
+msgid "workspacefolders"
 msgstr ""
 
 #: ../layout/browser/apps.py:43

--- a/src/ploneintranet/core/locales/fr/LC_MESSAGES/ploneintranet.po
+++ b/src/ploneintranet/core/locales/fr/LC_MESSAGES/ploneintranet.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone Intranet\n"
-"POT-Creation-Date: 2015-08-27 12:45+0000\n"
+"POT-Creation-Date: 2015-08-28 08:33+0000\n"
 "PO-Revision-Date: 2015-05-22 10:54+0000\n"
 "Last-Translator: gnafou <fmgre-fboi@yahoo.fr>\n"
 "Language-Team: French (http://www.transifex.com/projects/p/plone-intranet/language/fr/)\n"
@@ -963,7 +963,7 @@ msgstr ""
 msgid "Post"
 msgstr ""
 
-msgid "PowerPoint 2007 slide"
+msgid "PowerPoint 2007 presentation"
 msgstr ""
 
 #: ../userprofile/content/userprofile.py:85

--- a/src/ploneintranet/core/locales/it/LC_MESSAGES/ploneintranet.po
+++ b/src/ploneintranet/core/locales/it/LC_MESSAGES/ploneintranet.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone Intranet\n"
-"POT-Creation-Date: 2015-08-19 14:20+0000\n"
+"POT-Creation-Date: 2015-08-27 12:45+0000\n"
 "PO-Revision-Date: 2015-05-22 10:12+0000\n"
 "Last-Translator: Giacomo <giacomo.spettoli@gmail.com>\n"
 "Language-Team: Italian (http://www.transifex.com/projects/p/plone-intranet/language/it/)\n"
@@ -93,7 +93,7 @@ msgstr "Gestito dal amministratore"
 
 #: ../workspace/browser/templates/roster-edit.pt:167
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:116
-#: ../workspace/browser/tiles/templates/sidebar.pt:480
+#: ../workspace/browser/tiles/templates/sidebar.pt:481
 msgid "Advanced"
 msgstr "Avanzate"
 
@@ -132,6 +132,10 @@ msgstr "Tutti i tempi"
 msgid "All Types"
 msgstr "Tutti i tipi"
 
+#: ../workspace/browser/tiles/events.py:49
+msgid "All day"
+msgstr ""
+
 #: ../workspace/browser/templates/content_macros.pt:95
 msgid "All day event"
 msgstr ""
@@ -140,7 +144,7 @@ msgstr ""
 msgid "All notifications"
 msgstr "Tutte le notifiche"
 
-#: ../library/browser/views.py:97
+#: ../library/browser/views.py:100
 msgid "All topics"
 msgstr ""
 
@@ -219,6 +223,9 @@ msgstr ""
 msgid "Bulk import users"
 msgstr ""
 
+msgid "CSV document"
+msgstr ""
+
 #: ../messaging/browser/send-message.pt:63
 #: ../workspace/basecontent/document.py:77
 #: ../workspace/browser/templates/add_content.pt:36
@@ -227,6 +234,9 @@ msgstr "Annulla"
 
 #: ../workspace/browser/templates/workspace-add.pt:27
 msgid "Case"
+msgstr ""
+
+msgid "Case Workspace"
 msgstr ""
 
 #: ../workspace/browser/templates/edit_folder.pt:7
@@ -251,6 +261,10 @@ msgstr ""
 msgid "Changes applied"
 msgstr "Modifiche applicate"
 
+#: ../workspace/browser/tiles/templates/sidebar.pt:357
+msgid "Close milestone"
+msgstr ""
+
 #: ../workspace/browser/templates/content_macros.pt:157
 msgid "Confirmed"
 msgstr ""
@@ -266,6 +280,10 @@ msgstr "Consuma"
 
 #: ../userprofile/browser/templates/userprofile.pt:35
 msgid "Contact"
+msgstr ""
+
+#: ../userprofile/browser/tiles/templates/contacts_search.pt:9
+msgid "Contacts"
 msgstr ""
 
 #: ../search/browser/templates/all_results.pt:27
@@ -300,10 +318,15 @@ msgstr ""
 msgid "Create folder"
 msgstr "Crea cartella"
 
+#: ../workspace/browser/tiles/templates/sidebar.pt:289
+msgid "Create new task"
+msgstr ""
+
 #: ../workspace/browser/templates/add_task.pt:2
 msgid "Create task"
 msgstr ""
 
+#: ../theme/browser/templates/workspaces.pt:25
 #: ../workspace/browser/templates/workspace-add.pt:11
 #: ../workspace/browser/templates/workspaces.pt:24
 msgid "Create workspace"
@@ -375,7 +398,7 @@ msgstr "Pagine"
 msgid "Done"
 msgstr ""
 
-#: ../workspace/basecontent/templates/document_view.pt:108
+#: ../workspace/basecontent/templates/document_view.pt:109
 msgid "Download as"
 msgstr ""
 
@@ -404,7 +427,7 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:421
+#: ../workspace/browser/tiles/templates/sidebar.pt:422
 msgid "Ended"
 msgstr ""
 
@@ -420,6 +443,9 @@ msgstr ""
 msgid "Error while pasting items"
 msgstr ""
 
+msgid "Event"
+msgstr ""
+
 #: ../workspace/browser/templates/add_event.pt:17
 msgid "Event title"
 msgstr ""
@@ -427,6 +453,9 @@ msgstr ""
 #: ../workspace/browser/tiles/templates/workspace-tabs-tile.pt:20
 msgid "Events"
 msgstr "Eventi"
+
+msgid "Excel 2007 spreadsheet"
+msgstr ""
 
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:24
 #: ../workspace/browser/tiles/templates/sidebar.pt:50
@@ -436,6 +465,9 @@ msgstr ""
 #: ../core/browser/stream.py:56
 msgid "Explore"
 msgstr "Esplora"
+
+msgid "File"
+msgstr ""
 
 #: ../userprofile/browser/user_import.py:97
 msgid "File incorrectly formatted."
@@ -447,6 +479,9 @@ msgstr ""
 
 #: ../userprofile/content/userprofile.py:35
 msgid "First name"
+msgstr ""
+
+msgid "Folder"
 msgstr ""
 
 #: ../workspace/browser/templates/add_folder.pt:14
@@ -495,11 +530,11 @@ msgstr ""
 msgid "Functions"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:468
+#: ../workspace/browser/tiles/templates/sidebar.pt:469
 msgid "General"
 msgstr "Generale"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:295
+#: ../workspace/browser/tiles/templates/sidebar.pt:296
 msgid "General tasks"
 msgstr ""
 
@@ -602,6 +637,9 @@ msgstr "Contenuti modificati oggi"
 msgid "Items since ever"
 msgstr "Tutti i contenuti"
 
+msgid "JPEG image"
+msgstr ""
+
 #: ../userprofile/content/userprofile.py:60
 msgid "Job title"
 msgstr ""
@@ -646,6 +684,7 @@ msgstr "Ultime notizie"
 msgid "Leave a comment"
 msgstr "Lascia un commento"
 
+#: ../core/browser/tiles/templates/my_documents.pt:8
 #: ../library/profiles/default/actions.xml
 msgid "Library"
 msgstr ""
@@ -665,6 +704,9 @@ msgstr ""
 #: ../network/browser/likes.py:56
 msgid "Like"
 msgstr "Mi piace"
+
+msgid "Link"
+msgstr ""
 
 #: ../workspace/browser/templates/content_macros.pt:79
 msgid "Location"
@@ -699,7 +741,7 @@ msgid "Member(s) removed"
 msgstr ""
 
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:20
-#: ../workspace/browser/tiles/templates/sidebar.pt:472
+#: ../workspace/browser/tiles/templates/sidebar.pt:473
 msgid "Members"
 msgstr "Membri"
 
@@ -775,6 +817,9 @@ msgstr "Nuovo messaggio"
 msgid "News"
 msgstr ""
 
+msgid "News Item"
+msgstr ""
+
 #: ../messaging/browser/send-message.pt:42
 #: ../messaging/browser/your-inbox.pt:130
 msgid "No attachments selected."
@@ -797,7 +842,7 @@ msgstr "Nessuna notifica in sospeso"
 msgid "No such user ${userid}."
 msgstr "Nessun utente trovato con id ${userid}"
 
-#: ../layout/browser/templates/tasks-tile.pt:10
+#: ../layout/browser/templates/tasks-tile.pt:9
 msgid "No tasks available"
 msgstr ""
 
@@ -838,7 +883,7 @@ msgstr "Sei già un membro"
 msgid "Ok"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:450
+#: ../workspace/browser/tiles/templates/sidebar.pt:451
 msgid "Older events"
 msgstr "Eventi passati"
 
@@ -863,9 +908,15 @@ msgstr ""
 msgid "Outsiders can self-join becoming a workspace member."
 msgstr "Gli esterni possono auto-aggiungersi come membri dell'area di lavoro"
 
+msgid "PDF document"
+msgstr ""
+
 #: ../docconv/client/templates/pdf_not_available.pt:5
 msgid "PDF not generated yet"
 msgstr "Il file PDF non è stato ancora generato"
+
+msgid "Page"
+msgstr ""
 
 #: ../workspace/browser/tiles/templates/sidebar.pt:102
 msgid "Paste"
@@ -877,6 +928,9 @@ msgstr ""
 
 #: ../search/browser/templates/search_template.pt:28
 msgid "People"
+msgstr ""
+
+msgid "Person"
 msgstr ""
 
 #: ../userprofile/content/userprofile.py:30
@@ -907,6 +961,9 @@ msgstr ""
 #: ../messaging/browser/your-inbox.pt:140
 msgid "Post"
 msgstr "Invia"
+
+msgid "PowerPoint 2007 slide"
+msgstr ""
 
 #: ../userprofile/content/userprofile.py:85
 msgid "Primary location"
@@ -952,6 +1009,10 @@ msgstr ""
 msgid "Remove role"
 msgstr ""
 
+#: ../workspace/browser/tiles/templates/sidebar.pt:360
+msgid "Reopen milestone"
+msgstr ""
+
 #: ../workspace/browser/templates/add_content.pt:15
 msgid "Rich text"
 msgstr "Testo"
@@ -964,9 +1025,9 @@ msgstr ""
 msgid "Roster updated."
 msgstr "Lista aggiornata"
 
+#: ../todo/browser/templates/todo_view.pt:56
 #: ../userprofile/browser/templates/userprofile-edit.pt:47
 #: ../workspace/basecontent/document.py:73
-#: ../workspace/basecontent/templates/event_view.pt:86
 msgid "Save"
 msgstr "Salva"
 
@@ -996,7 +1057,7 @@ msgstr ""
 msgid "Secret"
 msgstr "Nascosto"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:476
+#: ../workspace/browser/tiles/templates/sidebar.pt:477
 msgid "Security"
 msgstr "Sicurezza"
 
@@ -1069,7 +1130,7 @@ msgstr ""
 msgid "Start date should be lower than end date"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:416
+#: ../workspace/browser/tiles/templates/sidebar.pt:417
 msgid "Starts"
 msgstr "Inizio"
 
@@ -1085,7 +1146,6 @@ msgstr ""
 msgid "Task title"
 msgstr ""
 
-#: ../layout/browser/templates/tasks-tile.pt:9
 #: ../workspace/browser/tiles/templates/workspace-tabs-tile.pt:22
 msgid "Tasks"
 msgstr "Attività"
@@ -1222,7 +1282,7 @@ msgstr ""
 msgid "There was a problem updating the content: %s."
 msgstr ""
 
-#: ../workspace/basecontent/baseviews.py:75
+#: ../workspace/basecontent/baseviews.py:76
 msgid "There was a problem: %s"
 msgstr ""
 
@@ -1268,6 +1328,9 @@ msgstr ""
 msgid "Today"
 msgstr "Oggi"
 
+msgid "Todo"
+msgstr ""
+
 #: ../todo/browser/templates/todo_view.pt:43
 #: ../workspace/basecontent/templates/document_view.pt:38
 #: ../workspace/basecontent/templates/event_view.pt:63
@@ -1282,6 +1345,10 @@ msgstr "Il token non è più valido"
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:124
 msgid "Transfer members to another workspace."
 msgstr "Sposta i membri in un'altra area di lavoro"
+
+#: ../workspace/browser/tiles/templates/sidebar.pt:367
+msgid "Unassigned"
+msgstr ""
 
 #: ../workspace/browser/templates/content_macros.pt:156
 msgid "Undecided"
@@ -1299,7 +1366,8 @@ msgstr ""
 msgid "Unlike"
 msgstr "Togli mi piace"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:399
+#: ../workspace/browser/tiles/templates/events.pt:9
+#: ../workspace/browser/tiles/templates/sidebar.pt:400
 msgid "Upcoming events"
 msgstr "Prossimi eventi"
 
@@ -1330,6 +1398,9 @@ msgstr "Benvenuto nella nostra famiglia, straniero"
 
 #: ../workspace/browser/templates/confirmation-remove-special-role.pt:21
 msgid "When you remove the special role from this member, this member will inherit the default role for this workspace. Are you sure?"
+msgstr ""
+
+msgid "Word 2007 document"
 msgstr ""
 
 #: ../workspace/profiles/default/types/ploneintranet.workspace.workspacefolder.xml
@@ -1381,7 +1452,6 @@ msgid "Workspace security policy changes saved"
 msgstr "Le modifiche alla policy di sicurezza dell'area di lavoro sono state salvate."
 
 #: ../layout/profiles/default/actions.xml
-#: ../workspace/browser/tiles/templates/workspaces.pt:9
 msgid "Workspaces"
 msgstr "Aree di lavoro"
 
@@ -1426,6 +1496,9 @@ msgstr "Le tue modifiche sono state salvate."
 msgid "Your message here!"
 msgstr "Il tuo messaggio qui!"
 
+msgid "Zip archive"
+msgstr ""
+
 #. Default: "What are you doing?"
 #: ../microblog/browser/tiles/newpostbox.py:234
 #: ../microblog/interfaces.py:14
@@ -1436,6 +1509,9 @@ msgstr "Di cosa ti stai occupando?"
 #: ../workspace/browser/tiles/templates/sidebar.pt:39
 msgid "author"
 msgstr "autore"
+
+msgid "cases"
+msgstr ""
 
 #: ../workspace/browser/tiles/templates/navigation.pt:25
 #: ../workspace/browser/tiles/templates/sidebar.pt:41
@@ -1448,7 +1524,7 @@ msgid "document type"
 msgstr "tipo di documento"
 
 #. Default: "Download"
-#: ../library/browser/templates/library.html:150
+#: ../library/browser/templates/library.html:151
 msgid "download"
 msgstr ""
 
@@ -1548,7 +1624,7 @@ msgid "label_news"
 msgstr ""
 
 #. Default: "No events available"
-#: ../workspace/browser/tiles/templates/sidebar.pt:459
+#: ../workspace/browser/tiles/templates/sidebar.pt:460
 msgid "label_no_events_available"
 msgstr ""
 
@@ -1597,13 +1673,13 @@ msgstr ""
 msgid "leave_a_comment"
 msgstr "Lascia un commento"
 
-#. Default: "More sharing options coming soon…"
-#: ../workspace/basecontent/templates/document_view.pt:110
+#. Default: "More sharing options coming soon"
+#: ../workspace/basecontent/templates/document_view.pt:111
 msgid "more_sharing_soon"
 msgstr ""
 
 #. Default: "No tasks created yet"
-#: ../workspace/browser/tiles/templates/sidebar.pt:297
+#: ../workspace/browser/tiles/templates/sidebar.pt:298
 msgid "no-task-found"
 msgstr "Nessuna attività è stata ancora creata"
 
@@ -1618,17 +1694,17 @@ msgid "participant_policy_label"
 msgstr "Policy di partecipazione"
 
 #. Default: "Description"
-#: ../workspace/basecontent/templates/event_view.pt:100
+#: ../workspace/basecontent/templates/event_view.pt:101
 msgid "placeholder"
 msgstr ""
 
-#: ../workspace/browser/tiles/workspaces.py:97
+#: ../workspace/browser/tiles/workspaces.py:109
 msgid "posted"
 msgstr "ha scritto"
 
 #. Default: "Read more..."
 #: ../layout/browser/templates/news-tile.pt:19
-#: ../library/browser/templates/library.html:147
+#: ../library/browser/templates/library.html:148
 msgid "read-more"
 msgstr ""
 
@@ -1693,6 +1769,9 @@ msgstr "Impostazioni dell'area di lavoro"
 #, fuzzy
 msgid "workspace_title"
 msgstr "Titolo dell'area di lavoro"
+
+msgid "workspacefolders"
+msgstr ""
 
 #: ../layout/browser/apps.py:43
 msgid "{0} Application"

--- a/src/ploneintranet/core/locales/it/LC_MESSAGES/ploneintranet.po
+++ b/src/ploneintranet/core/locales/it/LC_MESSAGES/ploneintranet.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone Intranet\n"
-"POT-Creation-Date: 2015-08-27 12:45+0000\n"
+"POT-Creation-Date: 2015-08-28 08:33+0000\n"
 "PO-Revision-Date: 2015-05-22 10:12+0000\n"
 "Last-Translator: Giacomo <giacomo.spettoli@gmail.com>\n"
 "Language-Team: Italian (http://www.transifex.com/projects/p/plone-intranet/language/it/)\n"
@@ -962,7 +962,7 @@ msgstr ""
 msgid "Post"
 msgstr "Invia"
 
-msgid "PowerPoint 2007 slide"
+msgid "PowerPoint 2007 presentation"
 msgstr ""
 
 #: ../userprofile/content/userprofile.py:85

--- a/src/ploneintranet/core/locales/manual.pot
+++ b/src/ploneintranet/core/locales/manual.pot
@@ -29,7 +29,7 @@ msgstr ""
 msgid "Word 2007 document"
 msgstr ""
 
-msgid "PowerPoint 2007 slide"
+msgid "PowerPoint 2007 presentation"
 msgstr ""
 
 msgid "Zip archive"
@@ -66,15 +66,6 @@ msgid "Todo"
 msgstr ""
 
 msgid "Case Workspace"
-msgstr ""
-
-msgid "Library App"
-msgstr ""
-
-msgid "Library Section"
-msgstr ""
-
-msgid "Library Folder"
 msgstr ""
 
 msgid "Person"

--- a/src/ploneintranet/core/locales/manual.pot
+++ b/src/ploneintranet/core/locales/manual.pot
@@ -22,3 +22,60 @@ msgstr ""
 
 msgid "cases"
 msgstr ""
+
+msgid "PDF document"
+msgstr ""
+
+msgid "Word 2007 document"
+msgstr ""
+
+msgid "PowerPoint 2007 slide"
+msgstr ""
+
+msgid "Zip archive"
+msgstr ""
+
+msgid "JPEG image"
+msgstr ""
+
+msgid "CSV document"
+msgstr ""
+
+msgid "Excel 2007 spreadsheet"
+msgstr ""
+
+msgid "Page"
+msgstr ""
+
+msgid "Folder"
+msgstr ""
+
+msgid "Link"
+msgstr ""
+
+msgid "File"
+msgstr ""
+
+msgid "News Item"
+msgstr ""
+
+msgid "Event"
+msgstr ""
+
+msgid "Todo"
+msgstr ""
+
+msgid "Case Workspace"
+msgstr ""
+
+msgid "Library App"
+msgstr ""
+
+msgid "Library Section"
+msgstr ""
+
+msgid "Library Folder"
+msgstr ""
+
+msgid "Person"
+msgstr ""

--- a/src/ploneintranet/core/locales/nl/LC_MESSAGES/ploneintranet.po
+++ b/src/ploneintranet/core/locales/nl/LC_MESSAGES/ploneintranet.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone Intranet\n"
-"POT-Creation-Date: 2015-08-27 12:45+0000\n"
+"POT-Creation-Date: 2015-08-28 08:33+0000\n"
 "PO-Revision-Date: 2015-05-22 10:00+0000\n"
 "Last-Translator: Coen van der Kamp <cvanderkamp@gmail.com>\n"
 "Language-Team: Dutch (http://www.transifex.com/projects/p/plone-intranet/language/nl/)\n"
@@ -962,7 +962,7 @@ msgstr ""
 msgid "Post"
 msgstr "Verzenden"
 
-msgid "PowerPoint 2007 slide"
+msgid "PowerPoint 2007 presentation"
 msgstr ""
 
 #: ../userprofile/content/userprofile.py:85

--- a/src/ploneintranet/core/locales/nl/LC_MESSAGES/ploneintranet.po
+++ b/src/ploneintranet/core/locales/nl/LC_MESSAGES/ploneintranet.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone Intranet\n"
-"POT-Creation-Date: 2015-08-19 14:20+0000\n"
+"POT-Creation-Date: 2015-08-27 12:45+0000\n"
 "PO-Revision-Date: 2015-05-22 10:00+0000\n"
 "Last-Translator: Coen van der Kamp <cvanderkamp@gmail.com>\n"
 "Language-Team: Dutch (http://www.transifex.com/projects/p/plone-intranet/language/nl/)\n"
@@ -93,7 +93,7 @@ msgstr "Beheerd door beheerder"
 
 #: ../workspace/browser/templates/roster-edit.pt:167
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:116
-#: ../workspace/browser/tiles/templates/sidebar.pt:480
+#: ../workspace/browser/tiles/templates/sidebar.pt:481
 msgid "Advanced"
 msgstr "Geavanceerd"
 
@@ -132,6 +132,10 @@ msgstr "Alle Tijden"
 msgid "All Types"
 msgstr "Alle Type"
 
+#: ../workspace/browser/tiles/events.py:49
+msgid "All day"
+msgstr ""
+
 #: ../workspace/browser/templates/content_macros.pt:95
 msgid "All day event"
 msgstr ""
@@ -140,7 +144,7 @@ msgstr ""
 msgid "All notifications"
 msgstr "Alle notificaties"
 
-#: ../library/browser/views.py:97
+#: ../library/browser/views.py:100
 msgid "All topics"
 msgstr ""
 
@@ -219,6 +223,9 @@ msgstr ""
 msgid "Bulk import users"
 msgstr ""
 
+msgid "CSV document"
+msgstr ""
+
 #: ../messaging/browser/send-message.pt:63
 #: ../workspace/basecontent/document.py:77
 #: ../workspace/browser/templates/add_content.pt:36
@@ -227,6 +234,9 @@ msgstr "Annuleren "
 
 #: ../workspace/browser/templates/workspace-add.pt:27
 msgid "Case"
+msgstr ""
+
+msgid "Case Workspace"
 msgstr ""
 
 #: ../workspace/browser/templates/edit_folder.pt:7
@@ -251,6 +261,10 @@ msgstr ""
 msgid "Changes applied"
 msgstr "Wijzigingen toegepast"
 
+#: ../workspace/browser/tiles/templates/sidebar.pt:357
+msgid "Close milestone"
+msgstr ""
+
 #: ../workspace/browser/templates/content_macros.pt:157
 msgid "Confirmed"
 msgstr ""
@@ -266,6 +280,10 @@ msgstr "Consumeren"
 
 #: ../userprofile/browser/templates/userprofile.pt:35
 msgid "Contact"
+msgstr ""
+
+#: ../userprofile/browser/tiles/templates/contacts_search.pt:9
+msgid "Contacts"
 msgstr ""
 
 #: ../search/browser/templates/all_results.pt:27
@@ -300,10 +318,15 @@ msgstr ""
 msgid "Create folder"
 msgstr "Folder aanmaken"
 
+#: ../workspace/browser/tiles/templates/sidebar.pt:289
+msgid "Create new task"
+msgstr ""
+
 #: ../workspace/browser/templates/add_task.pt:2
 msgid "Create task"
 msgstr ""
 
+#: ../theme/browser/templates/workspaces.pt:25
 #: ../workspace/browser/templates/workspace-add.pt:11
 #: ../workspace/browser/templates/workspaces.pt:24
 msgid "Create workspace"
@@ -375,7 +398,7 @@ msgstr "Documenten"
 msgid "Done"
 msgstr ""
 
-#: ../workspace/basecontent/templates/document_view.pt:108
+#: ../workspace/basecontent/templates/document_view.pt:109
 msgid "Download as"
 msgstr ""
 
@@ -404,7 +427,7 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:421
+#: ../workspace/browser/tiles/templates/sidebar.pt:422
 msgid "Ended"
 msgstr ""
 
@@ -420,6 +443,9 @@ msgstr ""
 msgid "Error while pasting items"
 msgstr ""
 
+msgid "Event"
+msgstr ""
+
 #: ../workspace/browser/templates/add_event.pt:17
 msgid "Event title"
 msgstr ""
@@ -427,6 +453,9 @@ msgstr ""
 #: ../workspace/browser/tiles/templates/workspace-tabs-tile.pt:20
 msgid "Events"
 msgstr "Evenementen"
+
+msgid "Excel 2007 spreadsheet"
+msgstr ""
 
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:24
 #: ../workspace/browser/tiles/templates/sidebar.pt:50
@@ -436,6 +465,9 @@ msgstr ""
 #: ../core/browser/stream.py:56
 msgid "Explore"
 msgstr "Ontdekken"
+
+msgid "File"
+msgstr ""
 
 #: ../userprofile/browser/user_import.py:97
 msgid "File incorrectly formatted."
@@ -447,6 +479,9 @@ msgstr ""
 
 #: ../userprofile/content/userprofile.py:35
 msgid "First name"
+msgstr ""
+
+msgid "Folder"
 msgstr ""
 
 #: ../workspace/browser/templates/add_folder.pt:14
@@ -495,11 +530,11 @@ msgstr ""
 msgid "Functions"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:468
+#: ../workspace/browser/tiles/templates/sidebar.pt:469
 msgid "General"
 msgstr "Algemeen"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:295
+#: ../workspace/browser/tiles/templates/sidebar.pt:296
 msgid "General tasks"
 msgstr ""
 
@@ -602,6 +637,9 @@ msgstr "Vandaag bewerkte items "
 msgid "Items since ever"
 msgstr "Alle items ooit"
 
+msgid "JPEG image"
+msgstr ""
+
 #: ../userprofile/content/userprofile.py:60
 msgid "Job title"
 msgstr ""
@@ -646,6 +684,7 @@ msgstr "Laatste nieuws"
 msgid "Leave a comment"
 msgstr "Plaats een reactie"
 
+#: ../core/browser/tiles/templates/my_documents.pt:8
 #: ../library/profiles/default/actions.xml
 msgid "Library"
 msgstr ""
@@ -665,6 +704,9 @@ msgstr ""
 #: ../network/browser/likes.py:56
 msgid "Like"
 msgstr "Vind ik leuk"
+
+msgid "Link"
+msgstr ""
 
 #: ../workspace/browser/templates/content_macros.pt:79
 msgid "Location"
@@ -699,7 +741,7 @@ msgid "Member(s) removed"
 msgstr ""
 
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:20
-#: ../workspace/browser/tiles/templates/sidebar.pt:472
+#: ../workspace/browser/tiles/templates/sidebar.pt:473
 msgid "Members"
 msgstr "Leden"
 
@@ -775,6 +817,9 @@ msgstr "Nieuw bericht"
 msgid "News"
 msgstr ""
 
+msgid "News Item"
+msgstr ""
+
 #: ../messaging/browser/send-message.pt:42
 #: ../messaging/browser/your-inbox.pt:130
 msgid "No attachments selected."
@@ -797,7 +842,7 @@ msgstr "Geen openstaande notificaties"
 msgid "No such user ${userid}."
 msgstr "Gebruiker ${userid} onbekend."
 
-#: ../layout/browser/templates/tasks-tile.pt:10
+#: ../layout/browser/templates/tasks-tile.pt:9
 msgid "No tasks available"
 msgstr ""
 
@@ -838,7 +883,7 @@ msgstr "Hela, hola! Je bent al lid"
 msgid "Ok"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:450
+#: ../workspace/browser/tiles/templates/sidebar.pt:451
 msgid "Older events"
 msgstr "Oudere evenementen"
 
@@ -863,9 +908,15 @@ msgstr ""
 msgid "Outsiders can self-join becoming a workspace member."
 msgstr "Buitenstaanders kunnen zichzelf werkruimte-deelnemer maken."
 
+msgid "PDF document"
+msgstr ""
+
 #: ../docconv/client/templates/pdf_not_available.pt:5
 msgid "PDF not generated yet"
 msgstr "PDF is nog niet gegenereerd"
+
+msgid "Page"
+msgstr ""
 
 #: ../workspace/browser/tiles/templates/sidebar.pt:102
 msgid "Paste"
@@ -877,6 +928,9 @@ msgstr ""
 
 #: ../search/browser/templates/search_template.pt:28
 msgid "People"
+msgstr ""
+
+msgid "Person"
 msgstr ""
 
 #: ../userprofile/content/userprofile.py:30
@@ -907,6 +961,9 @@ msgstr ""
 #: ../messaging/browser/your-inbox.pt:140
 msgid "Post"
 msgstr "Verzenden"
+
+msgid "PowerPoint 2007 slide"
+msgstr ""
 
 #: ../userprofile/content/userprofile.py:85
 msgid "Primary location"
@@ -952,6 +1009,10 @@ msgstr ""
 msgid "Remove role"
 msgstr ""
 
+#: ../workspace/browser/tiles/templates/sidebar.pt:360
+msgid "Reopen milestone"
+msgstr ""
+
 #: ../workspace/browser/templates/add_content.pt:15
 msgid "Rich text"
 msgstr "Text met opmaak"
@@ -964,9 +1025,9 @@ msgstr ""
 msgid "Roster updated."
 msgstr "Rooster geüpdatet"
 
+#: ../todo/browser/templates/todo_view.pt:56
 #: ../userprofile/browser/templates/userprofile-edit.pt:47
 #: ../workspace/basecontent/document.py:73
-#: ../workspace/basecontent/templates/event_view.pt:86
 msgid "Save"
 msgstr "Opslaan"
 
@@ -996,7 +1057,7 @@ msgstr ""
 msgid "Secret"
 msgstr "Geheim"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:476
+#: ../workspace/browser/tiles/templates/sidebar.pt:477
 msgid "Security"
 msgstr "Beveiliging"
 
@@ -1069,7 +1130,7 @@ msgstr ""
 msgid "Start date should be lower than end date"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:416
+#: ../workspace/browser/tiles/templates/sidebar.pt:417
 msgid "Starts"
 msgstr "Begint"
 
@@ -1085,7 +1146,6 @@ msgstr ""
 msgid "Task title"
 msgstr ""
 
-#: ../layout/browser/templates/tasks-tile.pt:9
 #: ../workspace/browser/tiles/templates/workspace-tabs-tile.pt:22
 msgid "Tasks"
 msgstr "Taken"
@@ -1222,7 +1282,7 @@ msgstr ""
 msgid "There was a problem updating the content: %s."
 msgstr ""
 
-#: ../workspace/basecontent/baseviews.py:75
+#: ../workspace/basecontent/baseviews.py:76
 msgid "There was a problem: %s"
 msgstr ""
 
@@ -1268,6 +1328,9 @@ msgstr ""
 msgid "Today"
 msgstr "Vandaag"
 
+msgid "Todo"
+msgstr ""
+
 #: ../todo/browser/templates/todo_view.pt:43
 #: ../workspace/basecontent/templates/document_view.pt:38
 #: ../workspace/basecontent/templates/event_view.pt:63
@@ -1282,6 +1345,10 @@ msgstr "Token is niet langer geldig"
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:124
 msgid "Transfer members to another workspace."
 msgstr "Verplaats deelnemer naar een andere werkruimte."
+
+#: ../workspace/browser/tiles/templates/sidebar.pt:367
+msgid "Unassigned"
+msgstr ""
 
 #: ../workspace/browser/templates/content_macros.pt:156
 msgid "Undecided"
@@ -1299,7 +1366,8 @@ msgstr ""
 msgid "Unlike"
 msgstr "Vind ik niet meer leuk"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:399
+#: ../workspace/browser/tiles/templates/events.pt:9
+#: ../workspace/browser/tiles/templates/sidebar.pt:400
 msgid "Upcoming events"
 msgstr "Aanstaande evenementen"
 
@@ -1330,6 +1398,9 @@ msgstr "Van harte welkom"
 
 #: ../workspace/browser/templates/confirmation-remove-special-role.pt:21
 msgid "When you remove the special role from this member, this member will inherit the default role for this workspace. Are you sure?"
+msgstr ""
+
+msgid "Word 2007 document"
 msgstr ""
 
 #: ../workspace/profiles/default/types/ploneintranet.workspace.workspacefolder.xml
@@ -1381,7 +1452,6 @@ msgid "Workspace security policy changes saved"
 msgstr "Wijzigingen aan het werkplaatsbeleid zijn opgeslagen"
 
 #: ../layout/profiles/default/actions.xml
-#: ../workspace/browser/tiles/templates/workspaces.pt:9
 msgid "Workspaces"
 msgstr "Werkplaatsen"
 
@@ -1426,6 +1496,9 @@ msgstr "Je wijzigingen zijn opgeslagen."
 msgid "Your message here!"
 msgstr "Jou bericht hier!"
 
+msgid "Zip archive"
+msgstr ""
+
 #. Default: "What are you doing?"
 #: ../microblog/browser/tiles/newpostbox.py:234
 #: ../microblog/interfaces.py:14
@@ -1436,6 +1509,9 @@ msgstr "Plaatsen"
 #: ../workspace/browser/tiles/templates/sidebar.pt:39
 msgid "author"
 msgstr "auteur"
+
+msgid "cases"
+msgstr ""
 
 #: ../workspace/browser/tiles/templates/navigation.pt:25
 #: ../workspace/browser/tiles/templates/sidebar.pt:41
@@ -1448,7 +1524,7 @@ msgid "document type"
 msgstr "docmenttype"
 
 #. Default: "Download"
-#: ../library/browser/templates/library.html:150
+#: ../library/browser/templates/library.html:151
 msgid "download"
 msgstr ""
 
@@ -1548,7 +1624,7 @@ msgid "label_news"
 msgstr ""
 
 #. Default: "No events available"
-#: ../workspace/browser/tiles/templates/sidebar.pt:459
+#: ../workspace/browser/tiles/templates/sidebar.pt:460
 msgid "label_no_events_available"
 msgstr ""
 
@@ -1597,13 +1673,13 @@ msgstr ""
 msgid "leave_a_comment"
 msgstr "Plaats een reactie"
 
-#. Default: "More sharing options coming soon…"
-#: ../workspace/basecontent/templates/document_view.pt:110
+#. Default: "More sharing options coming soon"
+#: ../workspace/basecontent/templates/document_view.pt:111
 msgid "more_sharing_soon"
 msgstr ""
 
 #. Default: "No tasks created yet"
-#: ../workspace/browser/tiles/templates/sidebar.pt:297
+#: ../workspace/browser/tiles/templates/sidebar.pt:298
 msgid "no-task-found"
 msgstr "Geen taak gevonden"
 
@@ -1618,17 +1694,17 @@ msgid "participant_policy_label"
 msgstr "Deelnemersbeleid"
 
 #. Default: "Description"
-#: ../workspace/basecontent/templates/event_view.pt:100
+#: ../workspace/basecontent/templates/event_view.pt:101
 msgid "placeholder"
 msgstr ""
 
-#: ../workspace/browser/tiles/workspaces.py:97
+#: ../workspace/browser/tiles/workspaces.py:109
 msgid "posted"
 msgstr "Verzonden"
 
 #. Default: "Read more..."
 #: ../layout/browser/templates/news-tile.pt:19
-#: ../library/browser/templates/library.html:147
+#: ../library/browser/templates/library.html:148
 msgid "read-more"
 msgstr ""
 
@@ -1693,6 +1769,9 @@ msgstr "Werkruimte-instellingen"
 #, fuzzy
 msgid "workspace_title"
 msgstr "Werkruimte-titel"
+
+msgid "workspacefolders"
+msgstr ""
 
 #: ../layout/browser/apps.py:43
 msgid "{0} Application"

--- a/src/ploneintranet/core/locales/ploneintranet.pot
+++ b/src/ploneintranet/core/locales/ploneintranet.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-08-27 12:45+0000\n"
+"POT-Creation-Date: 2015-08-28 08:33+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -961,7 +961,7 @@ msgstr ""
 msgid "Post"
 msgstr ""
 
-msgid "PowerPoint 2007 slide"
+msgid "PowerPoint 2007 presentation"
 msgstr ""
 
 #: ../userprofile/content/userprofile.py:85

--- a/src/ploneintranet/core/locales/ploneintranet.pot
+++ b/src/ploneintranet/core/locales/ploneintranet.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-08-19 14:20+0000\n"
+"POT-Creation-Date: 2015-08-27 12:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -92,7 +92,7 @@ msgstr ""
 
 #: ../workspace/browser/templates/roster-edit.pt:167
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:116
-#: ../workspace/browser/tiles/templates/sidebar.pt:480
+#: ../workspace/browser/tiles/templates/sidebar.pt:481
 msgid "Advanced"
 msgstr ""
 
@@ -131,6 +131,10 @@ msgstr ""
 msgid "All Types"
 msgstr ""
 
+#: ../workspace/browser/tiles/events.py:49
+msgid "All day"
+msgstr ""
+
 #: ../workspace/browser/templates/content_macros.pt:95
 msgid "All day event"
 msgstr ""
@@ -139,7 +143,7 @@ msgstr ""
 msgid "All notifications"
 msgstr ""
 
-#: ../library/browser/views.py:97
+#: ../library/browser/views.py:100
 msgid "All topics"
 msgstr ""
 
@@ -218,6 +222,9 @@ msgstr ""
 msgid "Bulk import users"
 msgstr ""
 
+msgid "CSV document"
+msgstr ""
+
 #: ../messaging/browser/send-message.pt:63
 #: ../workspace/basecontent/document.py:77
 #: ../workspace/browser/templates/add_content.pt:36
@@ -226,6 +233,9 @@ msgstr ""
 
 #: ../workspace/browser/templates/workspace-add.pt:27
 msgid "Case"
+msgstr ""
+
+msgid "Case Workspace"
 msgstr ""
 
 #: ../workspace/browser/templates/edit_folder.pt:7
@@ -250,6 +260,10 @@ msgstr ""
 msgid "Changes applied"
 msgstr ""
 
+#: ../workspace/browser/tiles/templates/sidebar.pt:357
+msgid "Close milestone"
+msgstr ""
+
 #: ../workspace/browser/templates/content_macros.pt:157
 msgid "Confirmed"
 msgstr ""
@@ -265,6 +279,10 @@ msgstr ""
 
 #: ../userprofile/browser/templates/userprofile.pt:35
 msgid "Contact"
+msgstr ""
+
+#: ../userprofile/browser/tiles/templates/contacts_search.pt:9
+msgid "Contacts"
 msgstr ""
 
 #: ../search/browser/templates/all_results.pt:27
@@ -299,10 +317,15 @@ msgstr ""
 msgid "Create folder"
 msgstr ""
 
+#: ../workspace/browser/tiles/templates/sidebar.pt:289
+msgid "Create new task"
+msgstr ""
+
 #: ../workspace/browser/templates/add_task.pt:2
 msgid "Create task"
 msgstr ""
 
+#: ../theme/browser/templates/workspaces.pt:25
 #: ../workspace/browser/templates/workspace-add.pt:11
 #: ../workspace/browser/templates/workspaces.pt:24
 msgid "Create workspace"
@@ -374,7 +397,7 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#: ../workspace/basecontent/templates/document_view.pt:108
+#: ../workspace/basecontent/templates/document_view.pt:109
 msgid "Download as"
 msgstr ""
 
@@ -403,7 +426,7 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:421
+#: ../workspace/browser/tiles/templates/sidebar.pt:422
 msgid "Ended"
 msgstr ""
 
@@ -419,12 +442,18 @@ msgstr ""
 msgid "Error while pasting items"
 msgstr ""
 
+msgid "Event"
+msgstr ""
+
 #: ../workspace/browser/templates/add_event.pt:17
 msgid "Event title"
 msgstr ""
 
 #: ../workspace/browser/tiles/templates/workspace-tabs-tile.pt:20
 msgid "Events"
+msgstr ""
+
+msgid "Excel 2007 spreadsheet"
 msgstr ""
 
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:24
@@ -434,6 +463,9 @@ msgstr ""
 
 #: ../core/browser/stream.py:56
 msgid "Explore"
+msgstr ""
+
+msgid "File"
 msgstr ""
 
 #: ../userprofile/browser/user_import.py:97
@@ -446,6 +478,9 @@ msgstr ""
 
 #: ../userprofile/content/userprofile.py:35
 msgid "First name"
+msgstr ""
+
+msgid "Folder"
 msgstr ""
 
 #: ../workspace/browser/templates/add_folder.pt:14
@@ -494,11 +529,11 @@ msgstr ""
 msgid "Functions"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:468
+#: ../workspace/browser/tiles/templates/sidebar.pt:469
 msgid "General"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:295
+#: ../workspace/browser/tiles/templates/sidebar.pt:296
 msgid "General tasks"
 msgstr ""
 
@@ -601,6 +636,9 @@ msgstr ""
 msgid "Items since ever"
 msgstr ""
 
+msgid "JPEG image"
+msgstr ""
+
 #: ../userprofile/content/userprofile.py:60
 msgid "Job title"
 msgstr ""
@@ -645,6 +683,7 @@ msgstr ""
 msgid "Leave a comment"
 msgstr ""
 
+#: ../core/browser/tiles/templates/my_documents.pt:8
 #: ../library/profiles/default/actions.xml
 msgid "Library"
 msgstr ""
@@ -663,6 +702,9 @@ msgstr ""
 
 #: ../network/browser/likes.py:56
 msgid "Like"
+msgstr ""
+
+msgid "Link"
 msgstr ""
 
 #: ../workspace/browser/templates/content_macros.pt:79
@@ -698,7 +740,7 @@ msgid "Member(s) removed"
 msgstr ""
 
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:20
-#: ../workspace/browser/tiles/templates/sidebar.pt:472
+#: ../workspace/browser/tiles/templates/sidebar.pt:473
 msgid "Members"
 msgstr ""
 
@@ -774,6 +816,9 @@ msgstr ""
 msgid "News"
 msgstr ""
 
+msgid "News Item"
+msgstr ""
+
 #: ../messaging/browser/send-message.pt:42
 #: ../messaging/browser/your-inbox.pt:130
 msgid "No attachments selected."
@@ -796,7 +841,7 @@ msgstr ""
 msgid "No such user ${userid}."
 msgstr ""
 
-#: ../layout/browser/templates/tasks-tile.pt:10
+#: ../layout/browser/templates/tasks-tile.pt:9
 msgid "No tasks available"
 msgstr ""
 
@@ -837,7 +882,7 @@ msgstr ""
 msgid "Ok"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:450
+#: ../workspace/browser/tiles/templates/sidebar.pt:451
 msgid "Older events"
 msgstr ""
 
@@ -862,8 +907,14 @@ msgstr ""
 msgid "Outsiders can self-join becoming a workspace member."
 msgstr ""
 
+msgid "PDF document"
+msgstr ""
+
 #: ../docconv/client/templates/pdf_not_available.pt:5
 msgid "PDF not generated yet"
+msgstr ""
+
+msgid "Page"
 msgstr ""
 
 #: ../workspace/browser/tiles/templates/sidebar.pt:102
@@ -876,6 +927,9 @@ msgstr ""
 
 #: ../search/browser/templates/search_template.pt:28
 msgid "People"
+msgstr ""
+
+msgid "Person"
 msgstr ""
 
 #: ../userprofile/content/userprofile.py:30
@@ -905,6 +959,9 @@ msgstr ""
 #: ../messaging/browser/send-message.pt:58
 #: ../messaging/browser/your-inbox.pt:140
 msgid "Post"
+msgstr ""
+
+msgid "PowerPoint 2007 slide"
 msgstr ""
 
 #: ../userprofile/content/userprofile.py:85
@@ -951,6 +1008,10 @@ msgstr ""
 msgid "Remove role"
 msgstr ""
 
+#: ../workspace/browser/tiles/templates/sidebar.pt:360
+msgid "Reopen milestone"
+msgstr ""
+
 #: ../workspace/browser/templates/add_content.pt:15
 msgid "Rich text"
 msgstr ""
@@ -963,9 +1024,9 @@ msgstr ""
 msgid "Roster updated."
 msgstr ""
 
+#: ../todo/browser/templates/todo_view.pt:56
 #: ../userprofile/browser/templates/userprofile-edit.pt:47
 #: ../workspace/basecontent/document.py:73
-#: ../workspace/basecontent/templates/event_view.pt:86
 msgid "Save"
 msgstr ""
 
@@ -995,7 +1056,7 @@ msgstr ""
 msgid "Secret"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:476
+#: ../workspace/browser/tiles/templates/sidebar.pt:477
 msgid "Security"
 msgstr ""
 
@@ -1068,7 +1129,7 @@ msgstr ""
 msgid "Start date should be lower than end date"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:416
+#: ../workspace/browser/tiles/templates/sidebar.pt:417
 msgid "Starts"
 msgstr ""
 
@@ -1084,7 +1145,6 @@ msgstr ""
 msgid "Task title"
 msgstr ""
 
-#: ../layout/browser/templates/tasks-tile.pt:9
 #: ../workspace/browser/tiles/templates/workspace-tabs-tile.pt:22
 msgid "Tasks"
 msgstr ""
@@ -1221,7 +1281,7 @@ msgstr ""
 msgid "There was a problem updating the content: %s."
 msgstr ""
 
-#: ../workspace/basecontent/baseviews.py:75
+#: ../workspace/basecontent/baseviews.py:76
 msgid "There was a problem: %s"
 msgstr ""
 
@@ -1267,6 +1327,9 @@ msgstr ""
 msgid "Today"
 msgstr ""
 
+msgid "Todo"
+msgstr ""
+
 #: ../todo/browser/templates/todo_view.pt:43
 #: ../workspace/basecontent/templates/document_view.pt:38
 #: ../workspace/basecontent/templates/event_view.pt:63
@@ -1280,6 +1343,10 @@ msgstr ""
 #: ../workspace/browser/templates/roster-edit.pt:176
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:124
 msgid "Transfer members to another workspace."
+msgstr ""
+
+#: ../workspace/browser/tiles/templates/sidebar.pt:367
+msgid "Unassigned"
 msgstr ""
 
 #: ../workspace/browser/templates/content_macros.pt:156
@@ -1298,7 +1365,8 @@ msgstr ""
 msgid "Unlike"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:399
+#: ../workspace/browser/tiles/templates/events.pt:9
+#: ../workspace/browser/tiles/templates/sidebar.pt:400
 msgid "Upcoming events"
 msgstr ""
 
@@ -1329,6 +1397,9 @@ msgstr ""
 
 #: ../workspace/browser/templates/confirmation-remove-special-role.pt:21
 msgid "When you remove the special role from this member, this member will inherit the default role for this workspace. Are you sure?"
+msgstr ""
+
+msgid "Word 2007 document"
 msgstr ""
 
 #: ../workspace/profiles/default/types/ploneintranet.workspace.workspacefolder.xml
@@ -1380,7 +1451,6 @@ msgid "Workspace security policy changes saved"
 msgstr ""
 
 #: ../layout/profiles/default/actions.xml
-#: ../workspace/browser/tiles/templates/workspaces.pt:9
 msgid "Workspaces"
 msgstr ""
 
@@ -1425,6 +1495,9 @@ msgstr ""
 msgid "Your message here!"
 msgstr ""
 
+msgid "Zip archive"
+msgstr ""
+
 #. Default: "What are you doing?"
 #: ../microblog/browser/tiles/newpostbox.py:234
 #: ../microblog/interfaces.py:14
@@ -1434,6 +1507,9 @@ msgstr ""
 #: ../workspace/browser/tiles/templates/navigation.pt:23
 #: ../workspace/browser/tiles/templates/sidebar.pt:39
 msgid "author"
+msgstr ""
+
+msgid "cases"
 msgstr ""
 
 #: ../workspace/browser/tiles/templates/navigation.pt:25
@@ -1447,7 +1523,7 @@ msgid "document type"
 msgstr ""
 
 #. Default: "Download"
-#: ../library/browser/templates/library.html:150
+#: ../library/browser/templates/library.html:151
 msgid "download"
 msgstr ""
 
@@ -1542,7 +1618,7 @@ msgid "label_news"
 msgstr ""
 
 #. Default: "No events available"
-#: ../workspace/browser/tiles/templates/sidebar.pt:459
+#: ../workspace/browser/tiles/templates/sidebar.pt:460
 msgid "label_no_events_available"
 msgstr ""
 
@@ -1591,13 +1667,13 @@ msgstr ""
 msgid "leave_a_comment"
 msgstr ""
 
-#. Default: "More sharing options coming soon…"
-#: ../workspace/basecontent/templates/document_view.pt:110
+#. Default: "More sharing options coming soon"
+#: ../workspace/basecontent/templates/document_view.pt:111
 msgid "more_sharing_soon"
 msgstr ""
 
 #. Default: "No tasks created yet"
-#: ../workspace/browser/tiles/templates/sidebar.pt:297
+#: ../workspace/browser/tiles/templates/sidebar.pt:298
 msgid "no-task-found"
 msgstr ""
 
@@ -1612,17 +1688,17 @@ msgid "participant_policy_label"
 msgstr ""
 
 #. Default: "Description"
-#: ../workspace/basecontent/templates/event_view.pt:100
+#: ../workspace/basecontent/templates/event_view.pt:101
 msgid "placeholder"
 msgstr ""
 
-#: ../workspace/browser/tiles/workspaces.py:97
+#: ../workspace/browser/tiles/workspaces.py:109
 msgid "posted"
 msgstr ""
 
 #. Default: "Read more..."
 #: ../layout/browser/templates/news-tile.pt:19
-#: ../library/browser/templates/library.html:147
+#: ../library/browser/templates/library.html:148
 msgid "read-more"
 msgstr ""
 
@@ -1685,6 +1761,9 @@ msgstr ""
 #. Default: "Workspace title"
 #: ../workspace/browser/tiles/templates/sidebar-settings-general.pt:18
 msgid "workspace_title"
+msgstr ""
+
+msgid "workspacefolders"
 msgstr ""
 
 #: ../layout/browser/apps.py:43

--- a/src/ploneintranet/core/locales/pt_BR/LC_MESSAGES/ploneintranet.po
+++ b/src/ploneintranet/core/locales/pt_BR/LC_MESSAGES/ploneintranet.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-08-19 14:20+0000\n"
+"POT-Creation-Date: 2015-08-27 12:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -89,7 +89,7 @@ msgstr ""
 
 #: ../workspace/browser/templates/roster-edit.pt:167
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:116
-#: ../workspace/browser/tiles/templates/sidebar.pt:480
+#: ../workspace/browser/tiles/templates/sidebar.pt:481
 msgid "Advanced"
 msgstr ""
 
@@ -128,6 +128,10 @@ msgstr ""
 msgid "All Types"
 msgstr ""
 
+#: ../workspace/browser/tiles/events.py:49
+msgid "All day"
+msgstr ""
+
 #: ../workspace/browser/templates/content_macros.pt:95
 msgid "All day event"
 msgstr ""
@@ -136,7 +140,7 @@ msgstr ""
 msgid "All notifications"
 msgstr ""
 
-#: ../library/browser/views.py:97
+#: ../library/browser/views.py:100
 msgid "All topics"
 msgstr ""
 
@@ -215,6 +219,9 @@ msgstr ""
 msgid "Bulk import users"
 msgstr ""
 
+msgid "CSV document"
+msgstr ""
+
 #: ../messaging/browser/send-message.pt:63
 #: ../workspace/basecontent/document.py:77
 #: ../workspace/browser/templates/add_content.pt:36
@@ -223,6 +230,9 @@ msgstr ""
 
 #: ../workspace/browser/templates/workspace-add.pt:27
 msgid "Case"
+msgstr ""
+
+msgid "Case Workspace"
 msgstr ""
 
 #: ../workspace/browser/templates/edit_folder.pt:7
@@ -247,6 +257,10 @@ msgstr ""
 msgid "Changes applied"
 msgstr ""
 
+#: ../workspace/browser/tiles/templates/sidebar.pt:357
+msgid "Close milestone"
+msgstr ""
+
 #: ../workspace/browser/templates/content_macros.pt:157
 msgid "Confirmed"
 msgstr ""
@@ -262,6 +276,10 @@ msgstr ""
 
 #: ../userprofile/browser/templates/userprofile.pt:35
 msgid "Contact"
+msgstr ""
+
+#: ../userprofile/browser/tiles/templates/contacts_search.pt:9
+msgid "Contacts"
 msgstr ""
 
 #: ../search/browser/templates/all_results.pt:27
@@ -296,10 +314,15 @@ msgstr ""
 msgid "Create folder"
 msgstr ""
 
+#: ../workspace/browser/tiles/templates/sidebar.pt:289
+msgid "Create new task"
+msgstr ""
+
 #: ../workspace/browser/templates/add_task.pt:2
 msgid "Create task"
 msgstr ""
 
+#: ../theme/browser/templates/workspaces.pt:25
 #: ../workspace/browser/templates/workspace-add.pt:11
 #: ../workspace/browser/templates/workspaces.pt:24
 msgid "Create workspace"
@@ -371,7 +394,7 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#: ../workspace/basecontent/templates/document_view.pt:108
+#: ../workspace/basecontent/templates/document_view.pt:109
 msgid "Download as"
 msgstr ""
 
@@ -400,7 +423,7 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:421
+#: ../workspace/browser/tiles/templates/sidebar.pt:422
 msgid "Ended"
 msgstr ""
 
@@ -416,12 +439,18 @@ msgstr ""
 msgid "Error while pasting items"
 msgstr ""
 
+msgid "Event"
+msgstr ""
+
 #: ../workspace/browser/templates/add_event.pt:17
 msgid "Event title"
 msgstr ""
 
 #: ../workspace/browser/tiles/templates/workspace-tabs-tile.pt:20
 msgid "Events"
+msgstr ""
+
+msgid "Excel 2007 spreadsheet"
 msgstr ""
 
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:24
@@ -431,6 +460,9 @@ msgstr ""
 
 #: ../core/browser/stream.py:56
 msgid "Explore"
+msgstr ""
+
+msgid "File"
 msgstr ""
 
 #: ../userprofile/browser/user_import.py:97
@@ -443,6 +475,9 @@ msgstr ""
 
 #: ../userprofile/content/userprofile.py:35
 msgid "First name"
+msgstr ""
+
+msgid "Folder"
 msgstr ""
 
 #: ../workspace/browser/templates/add_folder.pt:14
@@ -491,11 +526,11 @@ msgstr ""
 msgid "Functions"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:468
+#: ../workspace/browser/tiles/templates/sidebar.pt:469
 msgid "General"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:295
+#: ../workspace/browser/tiles/templates/sidebar.pt:296
 msgid "General tasks"
 msgstr ""
 
@@ -598,6 +633,9 @@ msgstr ""
 msgid "Items since ever"
 msgstr ""
 
+msgid "JPEG image"
+msgstr ""
+
 #: ../userprofile/content/userprofile.py:60
 msgid "Job title"
 msgstr ""
@@ -642,6 +680,7 @@ msgstr ""
 msgid "Leave a comment"
 msgstr ""
 
+#: ../core/browser/tiles/templates/my_documents.pt:8
 #: ../library/profiles/default/actions.xml
 msgid "Library"
 msgstr ""
@@ -660,6 +699,9 @@ msgstr ""
 
 #: ../network/browser/likes.py:56
 msgid "Like"
+msgstr ""
+
+msgid "Link"
 msgstr ""
 
 #: ../workspace/browser/templates/content_macros.pt:79
@@ -695,7 +737,7 @@ msgid "Member(s) removed"
 msgstr ""
 
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:20
-#: ../workspace/browser/tiles/templates/sidebar.pt:472
+#: ../workspace/browser/tiles/templates/sidebar.pt:473
 msgid "Members"
 msgstr ""
 
@@ -771,6 +813,9 @@ msgstr ""
 msgid "News"
 msgstr ""
 
+msgid "News Item"
+msgstr ""
+
 #: ../messaging/browser/send-message.pt:42
 #: ../messaging/browser/your-inbox.pt:130
 msgid "No attachments selected."
@@ -793,7 +838,7 @@ msgstr ""
 msgid "No such user ${userid}."
 msgstr ""
 
-#: ../layout/browser/templates/tasks-tile.pt:10
+#: ../layout/browser/templates/tasks-tile.pt:9
 msgid "No tasks available"
 msgstr ""
 
@@ -834,7 +879,7 @@ msgstr ""
 msgid "Ok"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:450
+#: ../workspace/browser/tiles/templates/sidebar.pt:451
 msgid "Older events"
 msgstr ""
 
@@ -859,8 +904,14 @@ msgstr ""
 msgid "Outsiders can self-join becoming a workspace member."
 msgstr ""
 
+msgid "PDF document"
+msgstr ""
+
 #: ../docconv/client/templates/pdf_not_available.pt:5
 msgid "PDF not generated yet"
+msgstr ""
+
+msgid "Page"
 msgstr ""
 
 #: ../workspace/browser/tiles/templates/sidebar.pt:102
@@ -873,6 +924,9 @@ msgstr ""
 
 #: ../search/browser/templates/search_template.pt:28
 msgid "People"
+msgstr ""
+
+msgid "Person"
 msgstr ""
 
 #: ../userprofile/content/userprofile.py:30
@@ -902,6 +956,9 @@ msgstr ""
 #: ../messaging/browser/send-message.pt:58
 #: ../messaging/browser/your-inbox.pt:140
 msgid "Post"
+msgstr ""
+
+msgid "PowerPoint 2007 slide"
 msgstr ""
 
 #: ../userprofile/content/userprofile.py:85
@@ -948,6 +1005,10 @@ msgstr ""
 msgid "Remove role"
 msgstr ""
 
+#: ../workspace/browser/tiles/templates/sidebar.pt:360
+msgid "Reopen milestone"
+msgstr ""
+
 #: ../workspace/browser/templates/add_content.pt:15
 msgid "Rich text"
 msgstr ""
@@ -960,9 +1021,9 @@ msgstr ""
 msgid "Roster updated."
 msgstr ""
 
+#: ../todo/browser/templates/todo_view.pt:56
 #: ../userprofile/browser/templates/userprofile-edit.pt:47
 #: ../workspace/basecontent/document.py:73
-#: ../workspace/basecontent/templates/event_view.pt:86
 msgid "Save"
 msgstr ""
 
@@ -992,7 +1053,7 @@ msgstr ""
 msgid "Secret"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:476
+#: ../workspace/browser/tiles/templates/sidebar.pt:477
 msgid "Security"
 msgstr ""
 
@@ -1065,7 +1126,7 @@ msgstr ""
 msgid "Start date should be lower than end date"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:416
+#: ../workspace/browser/tiles/templates/sidebar.pt:417
 msgid "Starts"
 msgstr ""
 
@@ -1081,7 +1142,6 @@ msgstr ""
 msgid "Task title"
 msgstr ""
 
-#: ../layout/browser/templates/tasks-tile.pt:9
 #: ../workspace/browser/tiles/templates/workspace-tabs-tile.pt:22
 msgid "Tasks"
 msgstr ""
@@ -1218,7 +1278,7 @@ msgstr ""
 msgid "There was a problem updating the content: %s."
 msgstr ""
 
-#: ../workspace/basecontent/baseviews.py:75
+#: ../workspace/basecontent/baseviews.py:76
 msgid "There was a problem: %s"
 msgstr ""
 
@@ -1264,6 +1324,9 @@ msgstr ""
 msgid "Today"
 msgstr ""
 
+msgid "Todo"
+msgstr ""
+
 #: ../todo/browser/templates/todo_view.pt:43
 #: ../workspace/basecontent/templates/document_view.pt:38
 #: ../workspace/basecontent/templates/event_view.pt:63
@@ -1277,6 +1340,10 @@ msgstr ""
 #: ../workspace/browser/templates/roster-edit.pt:176
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:124
 msgid "Transfer members to another workspace."
+msgstr ""
+
+#: ../workspace/browser/tiles/templates/sidebar.pt:367
+msgid "Unassigned"
 msgstr ""
 
 #: ../workspace/browser/templates/content_macros.pt:156
@@ -1295,7 +1362,8 @@ msgstr ""
 msgid "Unlike"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:399
+#: ../workspace/browser/tiles/templates/events.pt:9
+#: ../workspace/browser/tiles/templates/sidebar.pt:400
 msgid "Upcoming events"
 msgstr ""
 
@@ -1326,6 +1394,9 @@ msgstr ""
 
 #: ../workspace/browser/templates/confirmation-remove-special-role.pt:21
 msgid "When you remove the special role from this member, this member will inherit the default role for this workspace. Are you sure?"
+msgstr ""
+
+msgid "Word 2007 document"
 msgstr ""
 
 #: ../workspace/profiles/default/types/ploneintranet.workspace.workspacefolder.xml
@@ -1377,7 +1448,6 @@ msgid "Workspace security policy changes saved"
 msgstr ""
 
 #: ../layout/profiles/default/actions.xml
-#: ../workspace/browser/tiles/templates/workspaces.pt:9
 msgid "Workspaces"
 msgstr ""
 
@@ -1422,6 +1492,9 @@ msgstr ""
 msgid "Your message here!"
 msgstr ""
 
+msgid "Zip archive"
+msgstr ""
+
 #. Default: "What are you doing?"
 #: ../microblog/browser/tiles/newpostbox.py:234
 #: ../microblog/interfaces.py:14
@@ -1431,6 +1504,9 @@ msgstr ""
 #: ../workspace/browser/tiles/templates/navigation.pt:23
 #: ../workspace/browser/tiles/templates/sidebar.pt:39
 msgid "author"
+msgstr ""
+
+msgid "cases"
 msgstr ""
 
 #: ../workspace/browser/tiles/templates/navigation.pt:25
@@ -1444,7 +1520,7 @@ msgid "document type"
 msgstr ""
 
 #. Default: "Download"
-#: ../library/browser/templates/library.html:150
+#: ../library/browser/templates/library.html:151
 msgid "download"
 msgstr ""
 
@@ -1539,7 +1615,7 @@ msgid "label_news"
 msgstr ""
 
 #. Default: "No events available"
-#: ../workspace/browser/tiles/templates/sidebar.pt:459
+#: ../workspace/browser/tiles/templates/sidebar.pt:460
 msgid "label_no_events_available"
 msgstr ""
 
@@ -1588,13 +1664,13 @@ msgstr ""
 msgid "leave_a_comment"
 msgstr ""
 
-#. Default: "More sharing options coming soon…"
-#: ../workspace/basecontent/templates/document_view.pt:110
+#. Default: "More sharing options coming soon"
+#: ../workspace/basecontent/templates/document_view.pt:111
 msgid "more_sharing_soon"
 msgstr ""
 
 #. Default: "No tasks created yet"
-#: ../workspace/browser/tiles/templates/sidebar.pt:297
+#: ../workspace/browser/tiles/templates/sidebar.pt:298
 msgid "no-task-found"
 msgstr ""
 
@@ -1609,17 +1685,17 @@ msgid "participant_policy_label"
 msgstr ""
 
 #. Default: "Description"
-#: ../workspace/basecontent/templates/event_view.pt:100
+#: ../workspace/basecontent/templates/event_view.pt:101
 msgid "placeholder"
 msgstr ""
 
-#: ../workspace/browser/tiles/workspaces.py:97
+#: ../workspace/browser/tiles/workspaces.py:109
 msgid "posted"
 msgstr ""
 
 #. Default: "Read more..."
 #: ../layout/browser/templates/news-tile.pt:19
-#: ../library/browser/templates/library.html:147
+#: ../library/browser/templates/library.html:148
 msgid "read-more"
 msgstr ""
 
@@ -1682,6 +1758,9 @@ msgstr ""
 #. Default: "Workspace title"
 #: ../workspace/browser/tiles/templates/sidebar-settings-general.pt:18
 msgid "workspace_title"
+msgstr ""
+
+msgid "workspacefolders"
 msgstr ""
 
 #: ../layout/browser/apps.py:43

--- a/src/ploneintranet/core/locales/pt_BR/LC_MESSAGES/ploneintranet.po
+++ b/src/ploneintranet/core/locales/pt_BR/LC_MESSAGES/ploneintranet.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-08-27 12:45+0000\n"
+"POT-Creation-Date: 2015-08-28 08:33+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -958,7 +958,7 @@ msgstr ""
 msgid "Post"
 msgstr ""
 
-msgid "PowerPoint 2007 slide"
+msgid "PowerPoint 2007 presentation"
 msgstr ""
 
 #: ../userprofile/content/userprofile.py:85

--- a/src/ploneintranet/search/browser/templates/all_results.pt
+++ b/src/ploneintranet/search/browser/templates/all_results.pt
@@ -31,7 +31,7 @@
                         <input checked type="checkbox"
                                name="friendly_type_name:list"
                                tal:attributes="value ctype">
-                        <tal:type i18n:translate="" i18n:domain="plone" tal:replace="ctype"></tal:type>
+                        <tal:type i18n:translate="" i18n:domain="ploneintranet" tal:replace="ctype"></tal:type>
                     </label>
                 </fieldset>
                 <label>

--- a/src/ploneintranet/workspace/basecontent/templates/document_view.pt
+++ b/src/ploneintranet/workspace/basecontent/templates/document_view.pt
@@ -108,7 +108,7 @@
           <li tal:condition="python:context.portal_type in ('File', 'Image')">
             <a href="${context/absolute_url}/download" class="icon-file-word" tal:attributes="class view/icon_class"><tal:label i18n:translate="">Download as</tal:label> <tal:type replace="view/content_type_name"/></a>
           </li>
-          <li><em i18n:translate="more_sharing_soon">More sharing options coming soon</em></li>
+          <li><em><tal:more_options i18n:translate="more_sharing_soon">More sharing options coming soon</tal:more_options>…</em></li>
         </ul>
       </div>
 

--- a/src/ploneintranet/workspace/basecontent/templates/document_view.pt
+++ b/src/ploneintranet/workspace/basecontent/templates/document_view.pt
@@ -108,7 +108,7 @@
           <li tal:condition="python:context.portal_type in ('File', 'Image')">
             <a href="${context/absolute_url}/download" class="icon-file-word" tal:attributes="class view/icon_class"><tal:label i18n:translate="">Download as</tal:label> <tal:type replace="view/content_type_name"/></a>
           </li>
-          <li><em i18n:translate="more_sharing_soon">More sharing options coming soon…</em></li>
+          <li><em i18n:translate="more_sharing_soon">More sharing options coming soon</em></li>
         </ul>
       </div>
 


### PR DESCRIPTION
We index the mime type name for files e.g. "Word 2007 document" and
for plone content types we use the name of the content type. Although
Products.Mimetypes has a registry where we can look up the relevant
translation for each file type it's tricky to do that for the search
facets since we don't index the id.

As a work-around, this uses the ploneintranet i18n domain and adds
msgids for the various content types and file types.
