### PR TITLE
shorten titles to 80 chars to cater for crazy germans

### DIFF
--- a/src/ploneintranet/layout/browser/overrides/plone.app.layout.viewlets.path_bar.pt
+++ b/src/ploneintranet/layout/browser/overrides/plone.app.layout.viewlets.path_bar.pt
@@ -1,6 +1,6 @@
 <nav id="breadcrumbs" class="breadcrumbs" role="navigation"
          i18n:domain="plone"
-         tal:define="breadcrumbs view/breadcrumbs">
+         tal:define="breadcrumbs view/breadcrumbs; ploneview here/@@plone">
 
         <!--a i18n:translate="tabs_home"
             tal:attributes="href view/navigation_root_url">Home</a-->
@@ -21,7 +21,7 @@
              tal:condition="is_last"
              tal:attributes="href url;
                              id string:breadcrumbs-${repeat/crumb/number};"
-             tal:content="title">crumb</a>
+             tal:content="python:ploneview.cropText(title, 80)">crumb</a>
         </tal:item>
       </tal:block>
 </nav>

--- a/src/ploneintranet/workspace/browser/templates/workspaces.pt
+++ b/src/ploneintranet/workspace/browser/templates/workspaces.pt
@@ -9,7 +9,7 @@
   <body class="view-secure">
     <metal:content fill-slot="content">
 
-    <div class="container">
+    <div class="container" tal:define="ploneview here/@@plone">
         <!--form class="canvas-toolbar pat-inject pat-autosubmit" action="/workspaces.html#workspaces" -->
         <form class="canvas-toolbar pat-inject pat-autosubmit" action="./workspaces.html" data-pat-inject="source: #content; target: #content" method="POST">
             <label class="bare pat-select">
@@ -34,7 +34,7 @@
                  tal:attributes="class string:tile workspace four columns ${w/class}">
               <a href="/open-market-committee" class="link"
                  tal:attributes="href w/url">
-                <h3 tal:content="w/title">Open Market Committee</h3>
+                <h3 tal:content="python:ploneview.cropText(w['title'], 80)">Open Market Committee</h3>
                 <p class="description" tal:content="w/description">
                     The OMC holds eight regularly scheduled meetings during the year and other meetings as needed.
                 </p>


### PR DESCRIPTION
If somebody adds insanely long titles (like germans love to do), the title first hides the searchbar and then , when even longer, breaks and is totally hidden. This crops it to decent 80 chars.
Also the workspace overview constrains on 80 in display, however if users like, they can still add as many chars as they want in the edit form. We don't want to be so picky, do we?
