### PR TITLE
Upgrade p.a.content to 3.0.8

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -31,3 +31,7 @@ funcsigs = 0.4
 pbr = 1.5.0
 responses = 0.4.0
 cookies = 2.2.1
+
+# Override http://dist.plone.org/release/5.0b3/versions.cfg
+# This allows files with umlauts to be deleted
+plone.app.content = 3.0.8


### PR DESCRIPTION
Fixes a bug which prevents us deleting a file with unicode chars in the
title.
