### PR TITLE
re-add the injection for bulk actions

### DIFF
--- a/src/ploneintranet/core/browser/panel_tags.pt
+++ b/src/ploneintranet/core/browser/panel_tags.pt
@@ -31,7 +31,7 @@
               class="search-result tags pat-inject pat-autosubmit"
 
               tal:attributes="action string:${here/absolute_url}/@@newpostbox.tile;
-              data-pat-inject string:source: #${form_id}-selected-tags;; target:#${form_id}-selected-tags && source: #selected-tags-data;; target: #selected-tags-data">
+              data-pat-inject string:source: #${form_id}-selected-tags;; target:#${form_id}-selected-tags &amp;&amp; source: #selected-tags-data;; target: #selected-tags-data">
           <fieldset class="checklist pat-checklist tags unchecked" tal:define="tags view/tags" id="tag-entries"
             tal:attributes="class string:${attrs/class} ${request/search_active|nothing} ">
             <tal:tags repeat="tag tags">

--- a/src/ploneintranet/core/browser/panel_users.pt
+++ b/src/ploneintranet/core/browser/panel_users.pt
@@ -30,7 +30,7 @@
         <form id="postbox-users"
               class="search-result users pat-inject pat-autosubmit"
               tal:attributes="action string:${here/absolute_url}/@@newpostbox.tile;
-                              data-pat-inject string:source: #${form_id}-selected-users;; target:#${form_id}-selected-users && source: #selected-users-data;; target: #selected-users-data">
+                              data-pat-inject string:source: #${form_id}-selected-users;; target:#${form_id}-selected-users &amp;&amp; source: #selected-users-data;; target: #selected-users-data">
           <fieldset class="checklist pat-checklist users" tal:define="users view/users" id="user-entries"
               tal:attributes="class string:${attrs/class} ${request/search_active|nothing}">
             <label tal:define="status python:user.getProperty('status', '');

--- a/src/ploneintranet/search/browser/templates/search_template.pt
+++ b/src/ploneintranet/search/browser/templates/search_template.pt
@@ -10,7 +10,7 @@
     <metal:content fill-slot="content">
 
     <form action="${view/__name__}" id="global-search" class="pat-autosubmit pat-inject"
-          data-pat-inject="source: #results; target: #results; && source: #tabs-nav; target: #tabs-nav; history: record;">
+          data-pat-inject="source: #results; target: #results; &amp;&amp; source: #tabs-nav; target: #tabs-nav; history: record;">
 
         <div class="container input">
         <fieldset class="search">

--- a/src/ploneintranet/suite/tests/acceptance/test_copy_paste.robot
+++ b/src/ploneintranet/suite/tests/acceptance/test_copy_paste.robot
@@ -54,19 +54,17 @@ I toggle the bulk action controls
 I can copy the Minutes word document
     Click Element  xpath=(//input[@id='cart-minutes'])
     Click Element  xpath=//div[@class='batch-functions']//button[@value='copy']
-    Wait Until Page Contains  1 item(s) copied
 
 I can paste the Minutes word document
     Wait Until Element is Visible  xpath=//div[@class='batch-functions']//button[@value='paste']
     Click Element  xpath=//div[@class='batch-functions']//button[@value='paste']
-    Wait Until Page Contains  Item(s) pasted
+    Wait Until Page Contains Element   xpath=//label[contains(@class,'type-word')]/a/strong[text()='Minutes']
 
 I can delete the Minutes word document
     Click Element  xpath=//input[@id='cart-minutes']
     Click Element  xpath=//div[@class='batch-functions']//button[@value='delete']
-    Wait Until Page Contains  The following items have been deleted
+    Page should not contain  Minutes
 
 I can cut the Minutes word document
     Click Element  xpath=(//input[@id='cart-minutes'])
     Click Element  xpath=//div[@class='batch-functions']//button[@value='cut']
-    Wait Until Page Contains  1 item(s) cut

--- a/src/ploneintranet/suite/tests/acceptance/test_copy_paste.robot
+++ b/src/ploneintranet/suite/tests/acceptance/test_copy_paste.robot
@@ -54,16 +54,17 @@ I toggle the bulk action controls
 I can copy the Minutes word document
     Click Element  xpath=(//input[@id='cart-minutes'])
     Click Element  xpath=//div[@class='batch-functions']//button[@value='copy']
+    Wait Until Page Contains  1 item(s) copied
 
 I can paste the Minutes word document
     Wait Until Element is Visible  xpath=//div[@class='batch-functions']//button[@value='paste']
     Click Element  xpath=//div[@class='batch-functions']//button[@value='paste']
-    Wait Until Page Contains Element   xpath=//label[contains(@class,'type-word')]/a/strong[text()='Minutes']
+    Wait Until Page Contains   Item(s) pasted
 
 I can delete the Minutes word document
     Click Element  xpath=//input[@id='cart-minutes']
     Click Element  xpath=//div[@class='batch-functions']//button[@value='delete']
-    Page should not contain  Minutes
+    Wait Until Page Contains  The following items have been deleted
 
 I can cut the Minutes word document
     Click Element  xpath=(//input[@id='cart-minutes'])

--- a/src/ploneintranet/suite/tests/acceptance/test_copy_paste.robot
+++ b/src/ploneintranet/suite/tests/acceptance/test_copy_paste.robot
@@ -59,7 +59,7 @@ I can copy the Minutes word document
 I can paste the Minutes word document
     Wait Until Element is Visible  xpath=//div[@class='batch-functions']//button[@value='paste']
     Click Element  xpath=//div[@class='batch-functions']//button[@value='paste']
-    Wait Until Page Contains   Item(s) pasted
+    Wait Until Page Contains  Item(s) pasted
 
 I can delete the Minutes word document
     Click Element  xpath=//input[@id='cart-minutes']
@@ -69,3 +69,4 @@ I can delete the Minutes word document
 I can cut the Minutes word document
     Click Element  xpath=(//input[@id='cart-minutes'])
     Click Element  xpath=//div[@class='batch-functions']//button[@value='cut']
+    Wait Until Page Contains  1 item(s) cut

--- a/src/ploneintranet/theme/browser/templates/main_template.pt
+++ b/src/ploneintranet/theme/browser/templates/main_template.pt
@@ -57,9 +57,13 @@
       The main navigation
     </div>
 
-    <aside id="global-statusmessage">
-      <tal:message tal:content="structure provider:plone.globalstatusmessage"/>
-    </aside>
+    <metal:statusmessage define-slot="statusmessage">
+      <metal:block define-macro="statusmessage">
+        <aside id="global-statusmessage">
+         <tal:message tal:content="structure provider:plone.globalstatusmessage"/>
+       </aside>
+      </metal:block>
+   </metal:statusmessage>
 
     <section id="viewlet-above-content" tal:content="structure provider:plone.abovecontent" />
 

--- a/src/ploneintranet/todo/browser/templates/todo_view.pt
+++ b/src/ploneintranet/todo/browser/templates/todo_view.pt
@@ -44,7 +44,7 @@
                       Toggle extra metadata
                     </a>
                     <fieldset tal:condition="view/has_workflow" id="workflow-menu" class="pat-subform pat-autosubmit pat-inject" data-pat-inject="target: #document-content::before; url: /feedback/banner-notifications.html; source: #workflow-state-changed::element;"
-                                tal:attributes="data-pat-inject string:target: #global-statusmessage;; url: ${context/absolute_url}/view;; source: #global-statusmessage && url: ${context/absolute_url}/view;; source: #workspace-tickets;; target: #workspace-tickets">
+                                tal:attributes="data-pat-inject string:target: #global-statusmessage;; url: ${context/absolute_url}/view;; source: #global-statusmessage &amp;&amp; url: ${context/absolute_url}/view;; source: #workspace-tickets;; target: #workspace-tickets">
                       <label class="pat-select bare" title="Change the workflow state" i18n:attributes="title">
                         <select name="task_action" id="workflow_action"
                                 tal:define="wf_state view/get_workflow_state">

--- a/src/ploneintranet/workspace/basecontent/templates/document_view.pt
+++ b/src/ploneintranet/workspace/basecontent/templates/document_view.pt
@@ -23,7 +23,7 @@
         <div class="${workspace_id} dark-theme" id="application-body" tal:define="read_only python:not view.can_edit">
           <div id="document-body">
             <form class="document pat-inject" method="POST" action="${context/absolute_url}/view" enctype="multipart/form-data"
-                  data-pat-inject="source:#global-statusmessage; target:#global-statusmessage; hooks: raptor && source: #application-body; target: #application-body">
+                  data-pat-inject="source:#global-statusmessage; target:#global-statusmessage; hooks: raptor &amp;&amp; source: #application-body; target: #application-body">
               <div class="metadata pat-bumper" id="meta">
                 <div class="meta-bar">
                   <h1 class="doc-title" id="document-title">${context/title}</h1>
@@ -37,7 +37,7 @@
                     <a href="#share-panel" class="icon-export iconified pat-tooltip" data-pat-tooltip="source: ajax" title="Share this document" i18n:attributes="title" i18n:translate="">Share</a>
                     <a class="icon-info-circle meta-data-toggle iconified" title="Show extra metadata fields" i18n:attributes="title" i18n:translate="">Toggle extra metadata</a>
                     <fieldset tal:condition="view/has_workflow" id="workflow-menu" class="pat-subform pat-autosubmit pat-inject"
-                              tal:attributes="data-pat-inject string:target: #global-statusmessage;; url: ${here_url}/view;; source: #global-statusmessage && url: ${here_url}/view;; source: #application-body;; target: #application-body">
+                              tal:attributes="data-pat-inject string:target: #global-statusmessage;; url: ${here_url}/view;; source: #global-statusmessage &amp;&amp; url: ${here_url}/view;; source: #application-body;; target: #application-body">
                       <label class="pat-select bare workflow" title="Change the workflow state" i18n:attributes="title">
                         <select name="workflow_action" id="workflow_action">
                           <option tal:repeat="state view/get_workflow_transitions"

--- a/src/ploneintranet/workspace/basecontent/templates/document_view.pt
+++ b/src/ploneintranet/workspace/basecontent/templates/document_view.pt
@@ -7,8 +7,8 @@
       i18n:domain="ploneintranet">
 
   <body>
-        <metal:statusmessage fill-slot="statusmessage">
-          <metal:macro tal:condition="not:request/suppress_message|nothing" use-macro="context/main_template/macros/statusmessage" />
+        <metal:statusmessage fill-slot="statusmessage" tal:define="suppress_message python:request.get('suppress_message', False)">
+          <metal:macro tal:condition="not:suppress_message" use-macro="context/main_template/macros/statusmessage" />
         </metal:statusmessage>
     <metal:content fill-slot="content"
                    tal:define="workspace python:view.workspace;

--- a/src/ploneintranet/workspace/basecontent/templates/document_view.pt
+++ b/src/ploneintranet/workspace/basecontent/templates/document_view.pt
@@ -7,6 +7,9 @@
       i18n:domain="ploneintranet">
 
   <body>
+        <metal:statusmessage fill-slot="statusmessage">
+          <metal:macro tal:condition="not:request/suppress_message|nothing" use-macro="context/main_template/macros/statusmessage" />
+        </metal:statusmessage>
     <metal:content fill-slot="content"
                    tal:define="workspace python:view.workspace;
                                here_url context/absolute_url;

--- a/src/ploneintranet/workspace/browser/cart.py
+++ b/src/ploneintranet/workspace/browser/cart.py
@@ -199,4 +199,5 @@ class Cart(BrowserView):
                     type="success")
 
         self.request.response.redirect(
-            self.context.absolute_url() + '/?{0}=1'.format(self.action))
+            '{0}/?{1}=1&suppress_message=1'.format(
+                self.context.absolute_url(), self.action))

--- a/src/ploneintranet/workspace/browser/templates/add_content.pt
+++ b/src/ploneintranet/workspace/browser/templates/add_content.pt
@@ -8,7 +8,7 @@
 <h1 i18n:translate="">
     Create document
 </h1>
-<form method="POST" action="#" tal:attributes="action request/URL" class="wizard-box pat-inject pat-validate" data-pat-inject="source: #document-body; target: #document-body && source: #workspace-documents; target: #workspace-documents" data-pat-validate="disable-selector:#form-buttons-create">
+<form method="POST" action="#" tal:attributes="action request/URL" class="wizard-box pat-inject pat-validate" data-pat-inject="source: #document-body; target: #document-body &amp;&amp; source: #workspace-documents; target: #workspace-documents" data-pat-validate="disable-selector:#form-buttons-create">
   <div class="panel-body">
     <fieldset class="icon-tabs">
         <label class="icon-doc-text">

--- a/src/ploneintranet/workspace/browser/templates/add_folder.pt
+++ b/src/ploneintranet/workspace/browser/templates/add_folder.pt
@@ -7,7 +7,7 @@
 <h1 i18n:translate="">
     Create folder
 </h1>
-<form method="POST" action="#" tal:attributes="action request/URL" class="wizard-box pat-inject pat-validate" data-pat-inject="source: #workspace-documents; target: #workspace-documents && source: nav.breadcrumbs; target: nav.breadcrumbs" data-pat-validate="disable-selector:#form-buttons-create">
+<form method="POST" action="#" tal:attributes="action request/URL" class="wizard-box pat-inject pat-validate" data-pat-inject="source: #workspace-documents; target: #workspace-documents &amp;&amp; source: nav.breadcrumbs; target: nav.breadcrumbs" data-pat-validate="disable-selector:#form-buttons-create">
   <div class="panel-body">
     <fieldset class="vertical">
         <input type="hidden" name="portal_type" value="Folder" />

--- a/src/ploneintranet/workspace/browser/templates/edit_folder.pt
+++ b/src/ploneintranet/workspace/browser/templates/edit_folder.pt
@@ -7,7 +7,7 @@
 <h1 i18n:translate="">
     Change folder title and description
 </h1>
-<form method="POST" action="#" tal:attributes="action request/URL" class="wizard-box pat-inject pat-validate" data-pat-inject="source: #workspace-documents; target: #workspace-documents && source: nav.breadcrumbs; target: nav.breadcrumbs" data-pat-validate="disable-selector:#form-buttons-edit">
+<form method="POST" action="#" tal:attributes="action request/URL" class="wizard-box pat-inject pat-validate" data-pat-inject="source: #workspace-documents; target: #workspace-documents &amp;&amp; source: nav.breadcrumbs; target: nav.breadcrumbs" data-pat-validate="disable-selector:#form-buttons-edit">
   <div class="panel-body">
     <fieldset class="vertical">
         <input type="text" name="title" required="required" autofocus tal:attributes="value context/Title|nothing"/>

--- a/src/ploneintranet/workspace/browser/templates/workspace.pt
+++ b/src/ploneintranet/workspace/browser/templates/workspace.pt
@@ -7,9 +7,14 @@
             i18n:domain="ploneintranet">
 
     <body class="view-secure">
+        <metal:statusmessage fill-slot="statusmessage">
+          <metal:macro tal:condition="not:request/suppress_message|nothing" use-macro="context/main_template/macros/statusmessage" />
+        </metal:statusmessage>
+
         <metal:content fill-slot="content"
                         tal:define="workspace view/workspace; workspace_url python:workspace.absolute_url()">
         <div  id="content" class="application page-type-workspace workspace-type-workspace">
+
 
             <h1 id="workspace-name">
                 <!-- Next link is to lead to landing state of current workspace! -->

--- a/src/ploneintranet/workspace/browser/templates/workspace.pt
+++ b/src/ploneintranet/workspace/browser/templates/workspace.pt
@@ -7,8 +7,8 @@
             i18n:domain="ploneintranet">
 
     <body class="view-secure">
-        <metal:statusmessage fill-slot="statusmessage">
-          <metal:macro tal:condition="not:request/suppress_message|nothing" use-macro="context/main_template/macros/statusmessage" />
+        <metal:statusmessage fill-slot="statusmessage" tal:define="suppress_message python:request.get('suppress_message', False)">
+          <metal:macro tal:condition="not:suppress_message" use-macro="context/main_template/macros/statusmessage" />
         </metal:statusmessage>
 
         <metal:content fill-slot="content"

--- a/src/ploneintranet/workspace/browser/tiles/templates/sidebar.pt
+++ b/src/ploneintranet/workspace/browser/tiles/templates/sidebar.pt
@@ -72,7 +72,7 @@
               </label>
             </form>
 
-            <form class="search-result docs" action="${here/absolute_url}/@@cart" id="items">
+            <form class="search-result docs pat-inject" action="${here/absolute_url}/@@cart" id="items" data-pat-inject="source: #items; target: #items">
               <fieldset class="checklist pat-checklist docs ">
 
                 <div class="batch-functions">
@@ -187,7 +187,7 @@ Supported types include (class names):
                     <a href="/event-traces-through-time#document-body"
                        class="pat-inject follow"
                        data-pat-inject="target: #document-body"
-                       data-pat-switch="body focus-* focus-document && body sidebar-large sidebar-normal"
+                       data-pat-switch="body focus-* focus-document &amp;&amp; body sidebar-large sidebar-normal"
                        tal:attributes="href string:${item/url};
                                        class python:item.get('dps', None) and (attrs['class'] + ' pat-switch') or attrs['class'];
                                        data-pat-inject item/dpi | nothing;
@@ -315,7 +315,7 @@ Supported types include (class names):
                              />
                       <a class="pat-inject follow pat-switch"
                          data-pat-inject="source: #document-body; target: #document-body"
-                         data-pat-switch="body focus-* focus-document && body sidebar-large sidebar-normal"
+                         data-pat-switch="body focus-* focus-document &amp;&amp; body sidebar-large sidebar-normal"
                          tal:attributes="title task/title;
                                          href task/url"
                          tal:content="task/title"/>
@@ -345,7 +345,7 @@ Supported types include (class names):
 
                         <a class="pat-inject follow pat-switch"
                            data-pat-inject="source: #document-body; target: #document-body"
-                           data-pat-switch="body focus-* focus-document && body sidebar-large sidebar-normal"
+                           data-pat-switch="body focus-* focus-document &amp;&amp; body sidebar-large sidebar-normal"
                            tal:attributes="title task/title; href task/url"
                            tal:content="task/title"/>
                       </label>
@@ -406,7 +406,7 @@ Supported types include (class names):
                       <h4 class="title">
                         <a class="pat-inject follow pat-switch"
                            data-pat-inject="source: #document-body; target: #document-body"
-                           data-pat-switch="body focus-* focus-document && body sidebar-large sidebar-normal"
+                           data-pat-switch="body focus-* focus-document &amp;&amp; body sidebar-large sidebar-normal"
                            tal:attributes="href string:${event/getURL}#document-body"
                            tal:content="event/Title"/>
                       </h4>

--- a/src/ploneintranet/workspace/browser/tiles/templates/sidebar.pt
+++ b/src/ploneintranet/workspace/browser/tiles/templates/sidebar.pt
@@ -72,7 +72,10 @@
               </label>
             </form>
 
-            <form class="search-result docs pat-inject" action="${here/absolute_url}/@@cart" id="items" data-pat-inject="source: #items; target: #items">
+            <form class="search-result docs pat-inject" action="${here/absolute_url}/@@cart#items" id="items">
+
+            <tal:message tal:content="structure provider:plone.globalstatusmessage"/>
+
               <fieldset class="checklist pat-checklist docs ">
 
                 <div class="batch-functions">

--- a/src/ploneintranet/workspace/browser/tiles/templates/sidebar.pt
+++ b/src/ploneintranet/workspace/browser/tiles/templates/sidebar.pt
@@ -73,8 +73,9 @@
             </form>
 
             <form class="search-result docs pat-inject" action="${here/absolute_url}/@@cart#items" id="items">
-
-            <tal:message tal:content="structure provider:plone.globalstatusmessage"/>
+              <aside id="local-statusmessage" tal:condition="request/suppress_message|python:0">
+                <tal:message tal:content="structure provider:plone.globalstatusmessage" />
+              </aside>
 
               <fieldset class="checklist pat-checklist docs ">
 

--- a/src/ploneintranet/workspace/browser/tiles/templates/workspace-tabs-tile.pt
+++ b/src/ploneintranet/workspace/browser/tiles/templates/workspace-tabs-tile.pt
@@ -8,7 +8,7 @@
 
 <nav class="navigation workspace-tabs" id="workspace-tabs" tal:define="ws view/workspace">
 
-    <a href="{{ workspace.url }}#document-body" title="Workspace landing page" i18n:attributes="title workspace_landing_page" class="pat-inject current landing pat-switch" data-pat-switch="selector: body; remove: sidebar-left-*; add: sidebar-left-closed && selector: body; remove: body focus-*; add: focus-document" tal:attributes="href string:${ws/absolute_url}#document-body" tal:content="ws/Title">ws name</a>
+    <a href="{{ workspace.url }}#document-body" title="Workspace landing page" i18n:attributes="title workspace_landing_page" class="pat-inject current landing pat-switch" data-pat-switch="selector: body; remove: sidebar-left-*; add: sidebar-left-closed &amp;&amp; selector: body; remove: body focus-*; add: focus-document" tal:attributes="href string:${ws/absolute_url}#document-body" tal:content="ws/Title">ws name</a>
 
     <a class="settings pat-switch" data-pat-switch="selector: body; remove: sidebar-left-*; add: sidebar-left-open" href="#workspace-settings"
        title="Workspace settings" i18n:attributes="title workspace_settings">Workspace settings and about</a>


### PR DESCRIPTION
EDIT:
To circumvent problems caused by double injection (see below), the status message after a cart action will now be shown locally (inside the single injection target), and the global status message will be suppressed (to prevent that the message gets consumed already.)

This: https://github.com/ploneintranet/ploneintranet/commit/f9bb239ffc407ae2645109cf87d7a8ebd9df20ed leads to this: http://jenkins.ploneintranet.net/job/Plone.Intranet.Pull.Request.Builder/699/robot/report/robot_log.html#s1-s10
