### PR TITLE
Make sure to use an absolute path for calling bin/celery.

### DIFF
--- a/src/ploneintranet/async/browser/status.py
+++ b/src/ploneintranet/async/browser/status.py
@@ -2,6 +2,7 @@ import datetime
 import random
 import socket
 import subprocess
+import sys
 import time
 import redis.exceptions
 import logging
@@ -57,11 +58,12 @@ class StatusView(BrowserView):
             return self.fail('redis', 'not available')
 
     def celery_running(self):
-        cmd = 'bin/celery -A ploneintranet.async.celerytasks status'
+        cmd = '{0}/bin/celery -A ploneintranet.async.celerytasks status'.format(  # noqa
+            sys.prefix)
         try:
             res = subprocess.check_output(cmd.split(' '))
             # drop terminal prompt from output
-            res = res.strip().split('\n')[-1]
+            res = [line for line in res.strip().split('\n') if line][-1]
             return self.ok('celery', res)
 
         except subprocess.CalledProcessError:


### PR DESCRIPTION
Reason: when run in fg, cwd is the buildout-directory, so `bin/celery` will work.
But when run in bg or via supervisor, cwd is $buildout-directory/var/instance, leading to a "No such file" error.

Follows #741 
