### PR TITLE
Fix arguments

### DIFF
--- a/src/ploneintranet/search/solr/indexers.py
+++ b/src/ploneintranet/search/solr/indexers.py
@@ -114,7 +114,7 @@ class ContentIndexer(object):
     def _get_schema(self):
         url = '{.url}/schema'.format(self._solr_conf)
         headers = {'Content-type': 'application/json'}
-        response = requests.get(url, headers)
+        response = requests.get(url, headers=headers)
         return response.json()['schema']
 
     def _add_mandatory_data(self, data):


### PR DESCRIPTION
When using the solr extra requires I have problems adding a Plone site.

```
------
2015-09-01T17:00:47 ERROR Zope.SiteErrorLog 1441119647.00.290384052201 http://localhost:9001/@@plone-addsite
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module Products.CMFPlone.browser.admin, line 257, in __call__
  Module Products.CMFPlone.factory, line 99, in addPloneSite
  Module Products.GenericSetup.tool, line 365, in runAllImportStepsFromProfile
   - __traceback_info__: profile-plone.app.contenttypes:plone-content
  Module Products.GenericSetup.tool, line 1184, in _runImportStepsFromContext
  Module Products.GenericSetup.tool, line 1095, in _doRunImportStep
   - __traceback_info__: plone.app.contenttypes--plone-content
  Module plone.app.contenttypes.setuphandlers, line 324, in step_import_content
  Module plone.app.contenttypes.setuphandlers, line 167, in create_frontpage
  Module plone.app.contenttypes.setuphandlers, line 91, in addContentToContainer
  Module OFS.ObjectManager, line 359, in _setObject
  Module zope.event, line 31, in notify
  Module zope.component.event, line 24, in dispatch
  Module zope.component._api, line 136, in subscribers
  Module zope.component.registry, line 321, in subscribers
  Module zope.interface.adapter, line 585, in subscribers
  Module zope.component.event, line 32, in objectEventNotify
  Module zope.component._api, line 136, in subscribers
  Module zope.component.registry, line 321, in subscribers
  Module zope.interface.adapter, line 585, in subscribers
  Module Products.CMFCore.CMFCatalogAware, line 262, in handleContentishEvent
  Module Products.CMFCore.CMFCatalogAware, line 188, in notifyWorkflowCreated
  Module Products.CMFCore.WorkflowTool, line 289, in notifyCreated
  Module Products.CMFCore.WorkflowTool, line 639, in _reindexWorkflowVariables
  Module Products.CMFCore.CMFCatalogAware, line 103, in reindexObjectSecurity
  Module collective.indexing.monkey, line 89, in unrestrictedSearchResults
  Module collective.indexing.queue, line 39, in processQueue
  Module collective.indexing.queue, line 165, in process
  Module ploneintranet.search.solr.indexers, line 278, in reindex
  Module ploneintranet.search.solr.indexers, line 269, in index
  Module ploneintranet.search.solr.indexers, line 228, in _get_data
  Module ploneintranet.search.solr.indexers, line 117, in _get_schema
TypeError: get() takes exactly 1 argument (2 given)
------
```

Apparently I am using the correct requests version, which indeed accepts only url as parameter.

```
[ale@kenobi plone]$ grep requests ./bin/zopepy 
  '/opt/ploneintranet/eggs/requests-2.7.0-py2.7.egg',
[ale@kenobi plone]$ ./bin/zopepy 

>>> import requests
>>> print requests.get.__doc__
Sends a GET request.

    :param url: URL for the new :class:`Request` object.
    :param params: (optional) Dictionary or bytes to be sent in the query string for the :class:`Request`.
    :param \*\*kwargs: Optional arguments that ``request`` takes.
    :return: :class:`Response <Response>` object
    :rtype: requests.Response
```

This PR fixes the issue passing the headers as a keyword argument.
