### PR TITLE
Revert "Update metromap from task sidebar"

### DIFF
--- a/src/ploneintranet/todo/utils.py
+++ b/src/ploneintranet/todo/utils.py
@@ -6,7 +6,7 @@ from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 def update_task_status(self, return_status_message=False):
     """
     opens or closes tasks
-    is used by workspace view/sidebar and dashboard
+    is used by workspace sidebar and dashboard
     """
     current_tasks = self.request.form.get('current-tasks', [])
     active_tasks = self.request.form.get('active-tasks', [])

--- a/src/ploneintranet/workspace/browser/templates/add_task.pt
+++ b/src/ploneintranet/workspace/browser/templates/add_task.pt
@@ -2,7 +2,7 @@
   <h1 i18n:translate="">
     Create task
   </h1>
-  <form method="POST" action="#" tal:attributes="action request/URL" class="pat-inject wizard-box pat-validate" data-pat-inject="source: #workspace-tickets; target: #workspace-tickets${python:context.is_case and ' && source: .timeline; target: .timeline' or ''}" data-pat-validate="disable-selector:#form-buttons-create">
+  <form method="POST" action="#" tal:attributes="action request/URL" class="pat-inject wizard-box pat-validate" data-pat-inject="source: #workspace-tickets; target: #workspace-tickets" data-pat-validate="disable-selector:#form-buttons-create">
     <div class="panel-body">
 
       <fieldset class="vertical">

--- a/src/ploneintranet/workspace/browser/tiles/templates/sidebar.pt
+++ b/src/ploneintranet/workspace/browser/tiles/templates/sidebar.pt
@@ -304,8 +304,8 @@ Supported types include (class names):
           <tal:tasks condition="python:ws.is_case or tasks">
             <form method="post" class="pat-autosubmit pat-inject"
                   tal:define="ws view/workspace"
-                  data-pat-inject="source: #workspace-tickets; target: #workspace-tickets${python:ws.is_case and ' && source: .timeline; target: .timeline' or ''}"
-                  tal:attributes="action string:${ws/absolute_url}">
+                  data-pat-inject="source: #workspace-tickets; target: #workspace-tickets"
+                  tal:attributes="action string:${ws/absolute_url}/@@sidebar.default">
 
               <tal:workspace_tasks tal:condition="not: ws/is_case">
                 <fieldset class="object-list tasks pat-checklist">

--- a/src/ploneintranet/workspace/browser/workspace.py
+++ b/src/ploneintranet/workspace/browser/workspace.py
@@ -4,7 +4,6 @@ from plone import api
 from plone.memoize.view import memoize
 from zope.interface import implements
 from plone.app.blocks.interfaces import IBlocksTransformEnabled
-from ploneintranet.todo.utils import update_task_status
 from ploneintranet.workspace.interfaces import IWorkspaceState
 from ploneintranet.workspace.utils import parent_workspace
 from json import dumps
@@ -14,12 +13,6 @@ class BaseWorkspaceView(BrowserView):
     """
     Base view class for workspace related view
     """
-    def __call__(self):
-        section = self.request.form.get('section', None)
-        if section == 'task':
-            update_task_status(self)
-        return super(BaseWorkspaceView, self).__call__()
-
     @memoize
     def workspace(self):
         """Acquire the root workspace of the current context"""


### PR DESCRIPTION
Reverts ploneintranet/ploneintranet#742

There is a problem with the modal which creates a new task from within a milestone fieldset in the sidebar. The appearance of the modal is wrong, and it is submitted twice (via event listeners) which creates duplicate Tasks. It needs to be debugged further.
