### PR TITLE
Save an empty tag field as () not (u'',)

### DIFF
--- a/src/ploneintranet/workspace/basecontent/widgets.py
+++ b/src/ploneintranet/workspace/basecontent/widgets.py
@@ -41,8 +41,8 @@ class CommaSeparatedWidget(Widget):
 
         :rtype tuple of strings: """
         value = self.request.get(self.name, default)
-        if value == default:
-            return default
+        if value == u'':
+            return (u'',)
         if isinstance(value, basestring):
             values = value.split(',')
             return tuple(values)

--- a/src/ploneintranet/workspace/basecontent/widgets.py
+++ b/src/ploneintranet/workspace/basecontent/widgets.py
@@ -42,7 +42,7 @@ class CommaSeparatedWidget(Widget):
         :rtype tuple of strings: """
         value = self.request.get(self.name, default)
         if value == u'':
-            return (u'',)
+            return ()
         if isinstance(value, basestring):
             values = value.split(',')
             return tuple(values)

--- a/src/ploneintranet/workspace/profiles/default/metadata.xml
+++ b/src/ploneintranet/workspace/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>0003</version>
+  <version>0004</version>
   <dependencies>
     <dependency>profile-collective.workspace:default</dependency>
     <dependency>profile-Products.CMFPlacefulWorkflow:base</dependency>

--- a/src/ploneintranet/workspace/upgrades.py
+++ b/src/ploneintranet/workspace/upgrades.py
@@ -1,3 +1,5 @@
+from plone import api
+
 import logging
 
 default_profile = 'profile-ploneintranet.workspace:default'
@@ -7,3 +9,14 @@ logger = logging.getLogger(__file__)
 def import_portal_types(context):
     logger.info('Import Types Tool')
     context.runImportStepFromProfile(default_profile, 'typeinfo')
+
+
+def reset_empty_tags(context):
+    logger.info('Resetting empty tags')
+    pc = api.portal.get_tool('portal_catalog')
+    empties = pc.searchResults({'Subject': ''})
+    for empty in empties:
+        obj = empty.getObject()
+        obj.subject = ()
+        obj.reindexObject()
+        logger.info('Reset tags for {}'.format(obj.absolute_url()))

--- a/src/ploneintranet/workspace/upgrades.zcml
+++ b/src/ploneintranet/workspace/upgrades.zcml
@@ -11,4 +11,12 @@
         handler=".upgrades.import_portal_types"
         profile="ploneintranet.workspace:default" />
 
+    <genericsetup:upgradeStep
+        title="Reset empty tags"
+        description="Empty tags were saved as (u'',) rather than ()"
+        source="*"
+        destination="0004"
+        handler=".upgrades.reset_empty_tags"
+        profile="ploneintranet.workspace:default" />
+
 </configure>


### PR DESCRIPTION
Includes an upgrade step to fix existing items.

To see the problem:
- Create a new Document in workspace
- Save the Document (without tags)
- Expand the sidebar

You will see an empty tag in the listing for the object.
