### PR TITLE
Event add date validation: support a fallback time zone

### DIFF
--- a/src/ploneintranet/workspace/browser/add_content.py
+++ b/src/ploneintranet/workspace/browser/add_content.py
@@ -3,6 +3,7 @@ from DateTime import DateTime
 from Products.Five import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from plone import api
+from plone.app.event.base import default_timezone
 from plone.i18n.normalizer import idnormalizer
 from ploneintranet.core import ploneintranetCoreMessageFactory as _  # noqa
 from ploneintranet.workspace.basecontent.utils import dexterity_update
@@ -146,7 +147,7 @@ class AddEvent(AddContent):
         localized_start = DateTime(
             '%s %s' % (
                 ' '.join(self.request.get('start')),
-                self.request.get('timezone')
+                self.request.get('timezone', default_timezone())
             )
         )
         localized_end = localized_start + 1. / 24


### PR DESCRIPTION
The content_macros.pt supports omitting the timezone, so we should support it for the validation too.

Refs SLC #12314
