### PR TITLE
build complete stack by default

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,5 +1,5 @@
 [buildout]
-extends = base.cfg
+extends = complete.cfg
 
 parts +=
     omelette


### PR DESCRIPTION
Our stack requires celery and solr. Build that by default, and ZEO as well.
