### PR TITLE
AllUsersJSONView: use the catalog to search for users

### DIFF
--- a/src/ploneintranet/api/tests/test_userprofile.py
+++ b/src/ploneintranet/api/tests/test_userprofile.py
@@ -40,6 +40,21 @@ class TestUserProfile(IntegrationTestCase):
                 email='foobar@doe.com',
             )
 
+    def test_get_users(self):
+        self.login_as_portal_owner()
+        profile1 = pi_api.userprofile.create(
+            username='janedoe',
+            email='janedoe@doe.com',
+        )
+        profile2 = pi_api.userprofile.create(
+            username='bobdoe',
+            email='bobdoe@doe.com',
+        )
+        found = [x for x in pi_api.userprofile.get_users()]
+        self.assertEqual(len(found), 2)
+        self.assertIn(profile1, found)
+        self.assertIn(profile2, found)
+
     def test_get(self):
         self.login_as_portal_owner()
         profile = pi_api.userprofile.create(

--- a/src/ploneintranet/workspace/browser/workspace.py
+++ b/src/ploneintranet/workspace/browser/workspace.py
@@ -4,6 +4,7 @@ from plone import api
 from plone.memoize.view import memoize
 from zope.interface import implements
 from plone.app.blocks.interfaces import IBlocksTransformEnabled
+import ploneintranet.api as pi_api
 from ploneintranet.workspace.interfaces import IWorkspaceState
 from ploneintranet.workspace.utils import parent_workspace
 from json import dumps
@@ -99,15 +100,9 @@ class AllUsersJSONView(BrowserView):
     Return a filtered list of users for pat-autosuggest
     """
     def __call__(self):
-        pc = api.portal.get_tool('portal_catalog')
         q = self.request.get('q', '')
-        users = pc.searchResults(
-            portal_type='ploneintranet.userprofile.userprofile',
-            SearchableText=q,
-        )
         user_details = []
-        for brain in users:
-            user = brain.getObject()
+        for user in pi_api.userprofile.get_users(SearchableText=q):
             fullname = user.Title()
             email = user.email
             user_details.append({

--- a/src/ploneintranet/workspace/browser/workspace.py
+++ b/src/ploneintranet/workspace/browser/workspace.py
@@ -96,12 +96,25 @@ class WorkspaceMembersJSONView(BrowserView):
 
 class AllUsersJSONView(BrowserView):
     """
-    Return all users in JSON for use with pat-autosuggest.
+    Return a filtered list of users for pat-autosuggest
     """
     def __call__(self):
-        users = api.user.get_users()
+        pc = api.portal.get_tool('portal_catalog')
         q = self.request.get('q', '')
-        return filter_users_json(q, users)
+        users = pc.searchResults(
+            portal_type='ploneintranet.userprofile.userprofile',
+            SearchableText=q,
+        )
+        user_details = []
+        for brain in users:
+            user = brain.getObject()
+            fullname = user.Title()
+            email = user.email
+            user_details.append({
+                'id': user.getId(),
+                'text': u'{} <{}>'.format(fullname, email),
+            })
+        return dumps(user_details)
 
 
 class AllGroupsJSONView(BrowserView):

--- a/src/ploneintranet/workspace/browser/workspace.py
+++ b/src/ploneintranet/workspace/browser/workspace.py
@@ -102,7 +102,8 @@ class AllUsersJSONView(BrowserView):
     def __call__(self):
         q = self.request.get('q', '')
         user_details = []
-        for user in pi_api.userprofile.get_users(SearchableText=q):
+        for user in pi_api.userprofile.get_users(
+                SearchableText=u'{}*'.format(q)):
             fullname = user.Title()
             email = user.email
             user_details.append({


### PR DESCRIPTION
Since we have userprofile objects, we can avoid expensive PAS/LDAP
lookups.  Even on a local instance without LDAP the time to query 50
users went from 1.5 seconds to 40ms.
