### PR TITLE
Jenkins should depend on the complete config

### DIFF
--- a/jenkins.cfg
+++ b/jenkins.cfg
@@ -1,6 +1,6 @@
 [buildout]
 extends =
-    solr.cfg
+    complete.cfg
 
 parts += 
     jenkins-test


### PR DESCRIPTION
Fixes the recursive dependencies introduced by https://github.com/ploneintranet/ploneintranet/pull/768
