### PR TITLE
Fire an event when the workspace roster is changed

### DIFF
--- a/src/ploneintranet/workspace/browser/tiles/sidebar.py
+++ b/src/ploneintranet/workspace/browser/tiles/sidebar.py
@@ -9,6 +9,7 @@ from ...utils import map_content_type
 from ...utils import parent_workspace
 from ...utils import set_cookie
 from ...utils import month_name
+from ploneintranet.workspace.events import WorkspaceRosterChangedEvent
 from AccessControl import Unauthorized
 from collective.workspace.interfaces import IWorkspace
 from DateTime import DateTime
@@ -193,6 +194,7 @@ class SidebarSettingsMembers(BaseTile):
             msg_type = 'error'
 
         api.portal.show_message(msg, self.request, msg_type)
+        notify(WorkspaceRosterChangedEvent(self.context))
 
     def __call__(self):
         if self.request.method == 'POST':

--- a/src/ploneintranet/workspace/events.py
+++ b/src/ploneintranet/workspace/events.py
@@ -2,6 +2,7 @@ from zope.interface import implements
 from zope.component.interfaces import ObjectEvent
 
 from ploneintranet.workspace.interfaces import IParticipationPolicyChangedEvent
+from ploneintranet.workspace.interfaces import IWorkspaceRosterChangedEvent
 
 
 class ParticipationPolicyChangedEvent(ObjectEvent):
@@ -14,3 +15,13 @@ class ParticipationPolicyChangedEvent(ObjectEvent):
         super(ParticipationPolicyChangedEvent, self).__init__(ob)
         self.old_policy = old_policy
         self.new_policy = new_policy
+
+
+class WorkspaceRosterChangedEvent(ObjectEvent):
+    """
+    Event, which is fired once the roster of a workspace had changed
+    """
+    implements(IWorkspaceRosterChangedEvent)
+
+    def __init__(self, ob):
+        super(WorkspaceRosterChangedEvent, self).__init__(ob)

--- a/src/ploneintranet/workspace/interfaces.py
+++ b/src/ploneintranet/workspace/interfaces.py
@@ -26,6 +26,12 @@ class IParticipationPolicyChangedEvent(Interface):
     new_policy = Attribute(u"Policy we are moving to")
 
 
+class IWorkspaceRosterChangedEvent(Interface):
+    """
+    Event, which is fired once the roster of a workspace had changed
+    """
+
+
 class IWorkspaceState(Interface):
     """A view that gives access to the containing workspace
     """


### PR DESCRIPTION
This can be useful for clearing caches, related to #780.
