### PR TITLE
Case: fix case metromap avatars

### DIFF
--- a/src/ploneintranet/workspace/browser/templates/case.pt
+++ b/src/ploneintranet/workspace/browser/templates/case.pt
@@ -52,12 +52,13 @@
 					        </p>
 					        <p class="step-assignee"
                                tal:define="due_date task/due;
-                                           user_details python:existing_users_by_id.get(task.get('assignee'))"
-                               tal:condition="user_details">
+                                           assignee task/assignee;
+                                           assignee_id assignee/getId|nothing"
+                               tal:condition="assignee">
 	                          <a href="" class="pat-avatar "  id="">
-                                <img tal:attributes="src user_details/portrait;
-                                                     alt user_details/title;
-                                                     title user_details/description"/>
+                                <img src="${portal_url}/@@avatars/${assignee_id}/@@avatar_profile.jpg"
+                                     alt="${python:assignee.getProperty('fullname') or assignee_id}"
+                                     title="${assignee/Description}"/>
 	                          </a>
 					          <time class="date" tal:condition="due_date"
                                     tal:attributes="datetime due_date"


### PR DESCRIPTION
The workspacefolder.tasks() method was changed to return User objects,
for the sidebar metadata. This broke the avatar images in the
metromap. Since we already have the User objects, we don't need to call
existing_users_by_id to get the details (which is probably quite
expensive).

TODO: test both the metadata in the sidebar and the metromap to prevent
similar regressions in the future.

SLC Refs #12393
