### PR TITLE
sort upcoming events ascendingly

### DIFF
--- a/src/ploneintranet/workspace/browser/tiles/sidebar.py
+++ b/src/ploneintranet/workspace/browser/tiles/sidebar.py
@@ -931,7 +931,7 @@ class Sidebar(BaseTile):
             path=workspace_path,
             end={'query': now, 'range': 'min'},
             sort_on='start',
-            sort_order='descending',
+            sort_order='ascending',
         )
 
         # Events which have finished


### PR DESCRIPTION
The next upcoming event in a workspace is the most relevant one and should be displayed at the top. This is achieved by changing the sort order to ascending.
