### PR TITLE
Catch and log AttributeError when configuring hostname_switchlist.

### DIFF
--- a/src/ploneintranet/themeswitcher/dbconfig.py
+++ b/src/ploneintranet/themeswitcher/dbconfig.py
@@ -63,7 +63,12 @@ def dbconfig(event):
     registry = getUtility(IRegistry, context=plone)
     settings = registry.forInterface(IThemeSwitcherSettings, check=False)
     if conf.get('hostname_switchlist'):
-        settings.hostname_switchlist = [
-            unicode(conf.get('hostname_switchlist')), ]
-        log.info('hostname_switchlist configured')
+        try:
+            settings.hostname_switchlist = [
+                unicode(conf.get('hostname_switchlist')), ]
+            log.info('hostname_switchlist configured')
+        except AttributeError as e:
+            log.exception(e)
+            log.error('Could not configure hostname_switchlist. Is '
+                      'PloneIntranet installed?')
     transaction.commit()


### PR DESCRIPTION
If ploneintranet is not installed yet, configuring hostname_switchlist fails with an AttributeError and the instance doesn't start up. By catching and logging the error the user gets a chance to install PI and restart the instance.
