### PR TITLE
Solr connection caching

### DIFF
--- a/src/ploneintranet/search/solr/indexers.py
+++ b/src/ploneintranet/search/solr/indexers.py
@@ -88,6 +88,8 @@ class BinaryAdder(ContentAdder):
 class ContentIndexer(object):
     """Content indexing for Plone > SOLR."""
 
+    _connection = None
+
     _solr_to_plone_field_mapping = {
         'tags': 'Subject'
     }
@@ -248,7 +250,9 @@ class ContentIndexer(object):
 
     @property
     def _solr(self):
-        return IConnection(self._solr_conf)
+        if self._connection is None:
+            self._connection = IConnection(self._solr_conf)
+        return self._connection
 
     def abort(self):
         self._solr.rollback()

--- a/src/ploneintranet/search/solr/indexers.py
+++ b/src/ploneintranet/search/solr/indexers.py
@@ -155,6 +155,11 @@ class ContentIndexer(object):
         else:
             attr_names &= set(attributes)
 
+        # If no matching attributes found, bail out here
+        # (nothing to update in solr)
+        if not attr_names:
+            return []
+
         # The uniqueKey must be present in the payload sent to SOLR
         # Ensure the unique key is always supplied.
         unique_key = schema.get('uniqueKey')
@@ -223,6 +228,11 @@ class ContentIndexer(object):
         iobj = self._indexable_wrapper(obj)
         schema = self._solr.schema
         attr_names = self._data_attributes(schema, attributes)
+        if not attr_names:
+            # No attributes matched - nothing to do
+            logger.warn('No solr fields to update')
+            return None
+
         for attr_name in attr_names:
             val = self._get_value_for_indexable_object(iobj, attr_name)
             data[attr_name] = val
@@ -265,8 +275,8 @@ class ContentIndexer(object):
 
         """
         data = self._get_data(obj, attributes=attributes)
-        portal_type = data.get('portal_type', 'default')
         if data is not None:
+            portal_type = data.get('portal_type', 'default')
             adder = queryMultiAdapter((obj, self._solr), name=portal_type)
             if adder is None:
                 adder = ContentAdder(obj, self._solr)

--- a/src/ploneintranet/search/solr/indexers.py
+++ b/src/ploneintranet/search/solr/indexers.py
@@ -113,12 +113,6 @@ class ContentIndexer(object):
             return decode(val)
         return val
 
-    def _get_schema(self):
-        url = '{.url}/schema'.format(self._solr_conf)
-        headers = {'Content-type': 'application/json'}
-        response = requests.get(url, headers)
-        return response.json()['schema']
-
     def _add_mandatory_data(self, data):
         """Add `mandatory` data to the `data` to indexed by SOLR.
 
@@ -227,7 +221,7 @@ class ContentIndexer(object):
         """
         data = {}
         iobj = self._indexable_wrapper(obj)
-        schema = self._get_schema()
+        schema = self._solr.schema
         attr_names = self._data_attributes(schema, attributes)
         for attr_name in attr_names:
             val = self._get_value_for_indexable_object(iobj, attr_name)
@@ -284,7 +278,7 @@ class ContentIndexer(object):
     def unindex(self, obj):
         if hasattr(obj, 'context'):
             obj = obj.context
-        schema = self._get_schema()
+        schema = self._solr.schema
         unique_key = schema['uniqueKey']
         data = self._get_data(obj, attributes=[unique_key])
         if data is None:


### PR DESCRIPTION
Significantly reduces the number of times we talk to solr by using scorched's connection pooling during (re)indexing.
