### PR TITLE
Small ui fixes

### DIFF
--- a/src/ploneintranet/core/browser/tiles/templates/my_documents.pt
+++ b/src/ploneintranet/core/browser/tiles/templates/my_documents.pt
@@ -10,7 +10,7 @@
         <ul class="menu links">
           <tal:my_document repeat="my_document my_documents">
             <li class="my_document" tal:attributes="title my_document/Title">
-              <a class="icon-doc-text" href="${my_document/getURL}">
+              <a class="icon-doc-text" href="${my_document/getURL}/view">
                 <h4 class="title">${my_document/Title}</h4>
               </a>
             </li>

--- a/src/ploneintranet/userprofile/browser/configure.zcml
+++ b/src/ploneintranet/userprofile/browser/configure.zcml
@@ -106,4 +106,13 @@
       layer="ploneintranet.userprofile.interfaces.IPloneintranetUserprofileLayer"
      />
 
+  <browser:page
+      name="workspace-group-view"
+      for="*"
+      class=".groups.WorkspaceGroupView"
+      permission="zope2.View"
+      template="templates/group.pt"
+      layer="ploneintranet.userprofile.interfaces.IPloneintranetUserprofileLayer"
+      />
+
 </configure>

--- a/src/ploneintranet/userprofile/browser/groups.py
+++ b/src/ploneintranet/userprofile/browser/groups.py
@@ -1,0 +1,23 @@
+from plone import api
+from Products.Five import BrowserView
+
+
+class WorkspaceGroupView(BrowserView):
+    """Helper view to show the members of a group when clicked in workspace"""
+
+    def group(self):
+        """ Get group data """
+        gid = self.request.get('id')
+        if not gid:
+            return dict(id='',
+                        title="No Group",
+                        description="",
+                        members=[])
+
+        g = api.group.get(groupname=gid)
+        m = api.user.get_users(groupname=gid)
+
+        return dict(id=gid,
+                    title=g.title or gid,
+                    description=g.description,
+                    members=m)

--- a/src/ploneintranet/userprofile/browser/templates/group.pt
+++ b/src/ploneintranet/userprofile/browser/templates/group.pt
@@ -1,0 +1,48 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      lang="en"
+      metal:use-macro="context/main_template/macros/master"
+      i18n:domain="ploneintranet">
+
+    <body class="view-secure sidebar-normal gh-collapsed sidebar-left-open focus-listing  generic application-contacts patterns-loaded">
+        <metal:content fill-slot="content">
+        <div class="application page-type- workspace-type-" id="content">
+            <h1 id="workspace-name">
+                <!-- Next link is to lead to landing state of current workspace -->
+                <a href="/open-market-committee"></a>
+            </h1>
+
+            <div class="ws-baggage-handling-regulations dark-theme" id="application-body">
+
+                <div id="document-body" class="" tal:define="group view/group">
+                    <div id="document-content">
+                        <article class="document rich person">
+                            <h1 tal:content="group/title | group/id">The board</h1>
+                            <p tal:content="group/description">The board is concerned with lorem ipsum dolor sit amet.</p>
+
+                            <div class="row user-table pat-equaliser">
+                                    
+                                <!-- The last anchor tag in this list should always get a class 'last' to avoid that the item will float to the right. -->
+                                <tal:repeat repeat="member group/members">
+                                    <a href="/liz-baker" class="two columns equalised"  tal:attributes="href string:${here/portal_url}/profiles/${member/id}; class string:two columns equalised ${lastcls}" tal:define="fullname python:member.getProperty('fullname'); last repeat/member/end; lastcls python:last == 1 and 'last' or ''">
+                                        <figure>
+                                            <img src="/media/avatar-liz-baker.jpg" class="pat-avatar" alt="Image of Liz Baker" tal:attributes="src string:${here/portal_url}/@@avatars/${member/id}; alt string:Image of ${fullname}">
+
+                                            <figcaption tal:content="fullname">
+                                            Liz Baker
+                                            </figcaption>
+                                        </figure>
+                                    </a>
+                                </tal:repeat>
+
+                            </div>
+                        </article>
+                    </div>
+                </div>
+            </div>
+        </div>
+        </metal:content>
+    </body>
+</html>

--- a/src/ploneintranet/workspace/browser/tiles/events.py
+++ b/src/ploneintranet/workspace/browser/tiles/events.py
@@ -34,6 +34,8 @@ class EventsTile(Tile):
         upcoming_events = catalog.searchResults(
             object_provides=IEvent.__identifier__,
             end={'query': now, 'range': 'min'},
+            sort_on='start',
+            sort_order='ascending',
         )
         return upcoming_events
 

--- a/src/ploneintranet/workspace/browser/tiles/templates/sidebar-settings-members.pt
+++ b/src/ploneintranet/workspace/browser/tiles/templates/sidebar-settings-members.pt
@@ -65,19 +65,21 @@
                 <label class="item user has-no-description"
                        tal:repeat="user view/users"
                        tal:attributes="class string:item user ${user/cls}">
-                  <input name="user_id:list" type="checkbox" tal:attributes="value user/id" />
-                  <a class="follow pat-inject" href="${here/portal_url}/profiles/${user/id}" data-pat-inject="source: #document-body; target: #document-body">
-                    <img src="/media/avatar-adrian-white.jpg" alt="" class="avatar" tal:attributes="src user/portrait" tal:condition="user/portrait" />
-                    <strong class="title" tal:content="user/title">Adrian White</strong>
-                    <tal:block condition="user/description"><br />
-                    <dfn class="byline" tal:content="user/description">Lorem ipsum dolor sit amet</dfn></tal:block>
-                  </a>
-                  <tal:manager condition="view/can_manage_roster">
-                      <a tal:condition="user/role" href="${ws/absolute_url}/panel-member-role-actions?user_id=${user/id}&user_role=${user/role}#content" class="label pat-tooltip inactive" data-pat-tooltip="source: ajax">${user/role}</a>
-                  </tal:manager>
-                  <tal:non_manager condition="not:view/can_manage_roster">
-                      <a tal:condition="user/role" href="/adrian-white" class="label inactive follow pat-inject">${user/role}</a>
-                  </tal:non_manager>
+                  <tal:d define="purl here/portal_url; url python:user['typ']=='user' and '%s/profiles/%s' % (purl, user['id']) or '%s/@@workspace-group-view?id=%s' % (purl, user['id'])">
+                    <input name="user_id:list" type="checkbox" tal:attributes="value user/id" />
+                    <a class="follow pat-inject" href="${url}" data-pat-inject="source: #document-body; target: #document-body">
+                      <img src="/media/avatar-adrian-white.jpg" alt="" class="avatar" tal:attributes="src user/portrait" tal:condition="user/portrait" />
+                      <strong class="title" tal:content="user/title">Adrian White</strong>
+                      <tal:block condition="user/description"><br />
+                      <dfn class="byline" tal:content="user/description">Lorem ipsum dolor sit amet</dfn></tal:block>
+                    </a>
+                    <tal:manager condition="view/can_manage_roster">
+                        <a tal:condition="user/role" href="${ws/absolute_url}/panel-member-role-actions?user_id=${user/id}&user_role=${user/role}#content" class="label pat-tooltip inactive" data-pat-tooltip="source: ajax">${user/role}</a>
+                    </tal:manager>
+                    <tal:non_manager condition="not:view/can_manage_roster">
+                        <a tal:condition="user/role" href="/adrian-white" class="label inactive follow pat-inject">${user/role}</a>
+                    </tal:non_manager>
+                  </tal:d>
                 </label>
 
               </fieldset>

--- a/src/ploneintranet/workspace/browser/tiles/templates/sidebar-settings-members.pt
+++ b/src/ploneintranet/workspace/browser/tiles/templates/sidebar-settings-members.pt
@@ -77,7 +77,8 @@
                         <a tal:condition="user/role" href="${ws/absolute_url}/panel-member-role-actions?user_id=${user/id}&user_role=${user/role}#content" class="label pat-tooltip inactive" data-pat-tooltip="source: ajax">${user/role}</a>
                     </tal:manager>
                     <tal:non_manager condition="not:view/can_manage_roster">
-                        <a tal:condition="user/role" href="/adrian-white" class="label inactive follow pat-inject">${user/role}</a>
+                        <a tal:condition="user/role" href="${url}" class="label inactive follow pat-inject"
+                           data-pat-inject="source: #document-body; target: #document-body">${user/role}</a>
                     </tal:non_manager>
                   </tal:d>
                 </label>

--- a/src/ploneintranet/workspace/workspacefolder.py
+++ b/src/ploneintranet/workspace/workspacefolder.py
@@ -153,6 +153,7 @@ class WorkspaceFolder(Container):
         for user_or_group_id, details in members.items():
             user = api.user.get(user_or_group_id)
             if user is not None:
+                typ = 'user'
                 user = user.getUser()
                 title = (user.getProperty('fullname') or user.getId() or
                          user_or_group_id)
@@ -162,6 +163,7 @@ class WorkspaceFolder(Container):
                                      or 'has-no-description')
                 portrait = pi_api.userprofile.avatar_url(user_or_group_id)
             else:
+                typ = 'group'
                 group = api.group.get(user_or_group_id)
                 if group is None:
                     continue
@@ -204,6 +206,7 @@ class WorkspaceFolder(Container):
                     member=True,
                     admin='Admins' in details['groups'],
                     role=role,
+                    typ=typ
                 )
             )
 


### PR DESCRIPTION
Found during demonstrations and fixed right away.
- Clicking groups in the Members sidebar errors, there is no group view, however it is designed. Added.
- The events portlet on the dashboard ordered wrongly - or better said: not. Does now.
- The links in the library portlet linked directly to files and images, which resulted in download or direct display. Links to /view now.
