### PR TITLE
Add the missing type filter and search box

### DIFF
--- a/src/ploneintranet/layout/browser/templates/dashboard.pt
+++ b/src/ploneintranet/layout/browser/templates/dashboard.pt
@@ -46,8 +46,8 @@
           <div data-tile="./@@contacts_search.tile"/>
           <div data-tile="./@@news.tile"/>
           <div data-tile="./@@my_documents.tile"/>
-          <div data-tile="./@@workspaces.tile?workspace_type=workspacefolders"/>
-          <div data-tile="./@@workspaces.tile?workspace_type=cases"/>
+          <div data-tile="./@@workspaces.tile?workspace_type=ploneintranet.workspace.workspacefolder"/>
+          <div data-tile="./@@workspaces.tile?workspace_type=ploneintranet.workspace.case"/>
           <div data-tile="./@@events.tile"/>
           <div data-tile="./@@tasks.tile"/>
         </div>

--- a/src/ploneintranet/workspace/browser/templates/workspace-add.pt
+++ b/src/ploneintranet/workspace/browser/templates/workspace-add.pt
@@ -7,7 +7,7 @@
 <head>
 </head>
 <body class="diazo-off sidebar-normal gh-collapsed sidebar-left-open focus-listing  generic application-workspace">
-  <div id="content">
+  <div id="workspaces">
       <h1 i18n:translate="">Create workspace</h1>
 
       <form action="/workspaces.html#workspaces" method="post" enctype="multipart/form-data" class="wizard-box pat-validation" data-pat-validation="disable-selector:#form-buttons-create" data-pat-inject="" name="workspace-add" id="workspace-add" novalidate

--- a/src/ploneintranet/workspace/browser/templates/workspaces.pt
+++ b/src/ploneintranet/workspace/browser/templates/workspaces.pt
@@ -9,21 +9,28 @@
   <body class="view-secure">
     <metal:content fill-slot="content">
 
-    <div class="container" tal:define="ploneview here/@@plone">
+    <div class="container" id="workspace-search" tal:define="ploneview here/@@plone">
         <!--form class="canvas-toolbar pat-inject pat-autosubmit" action="/workspaces.html#workspaces" -->
-        <form class="canvas-toolbar pat-inject pat-autosubmit" action="./workspaces.html" data-pat-inject="source: #content; target: #content" method="POST">
+        <form  class="canvas-toolbar pat-inject pat-autosubmit" action="./workspaces.html" data-pat-inject="source: #workspace-search; target: #workspace-search" method="POST">
             <label class="bare pat-select">
-
                 <select name="sort">
                     <tal:r repeat="o view/sort_options">
-                        <option tal:attributes="value o/value" tal:content="o/content" i18n:translate="">Option</option>
+                        <option tal:attributes="value o/value; selected python:request.get('sort')==o['value'] and 'selected' or None" tal:content="o/content" i18n:translate="">Option</option>
                     </tal:r>
                  </select>
-             </label>
-             <div class="icons">
+            </label>
+            <label class="bare pat-select">
+                <select name="workspace_type">
+                  <tal:r repeat="o view/workspace_types">
+                    <option tal:attributes="value o/value; selected python:request.get('workspace_type')==o['value'] and 'selected' or None" tal:content="o/content" i18n:translate="">Option</option>
+                  </tal:r>
+                </select>
+            </label>
+            <div class="icons">
                <a href="${view/target/absolute_url}/@@workspace-add#content" data-pat-modal="class: large" title="Create a new workspace" class="icon create pat-modal" tal:condition="view/can_add" i18n:translate="" i18n:attributes="title">Create workspace</a>
                <span tal:replace="structure context/@@authenticator/authenticator"/>
-             </div>
+            </div>
+             <input type="search" placeholder="Search workspaces" focus name="SearchableText" tal:attributes="value request/SearchableText | nothing">
          </form>
 
         <div class="tiles row workspaces pat-masonry" data-pat-masonry="column-width: .grid-sizer; gutter: 0; item-selector: .tile;">

--- a/src/ploneintranet/workspace/browser/templates/workspaces.pt
+++ b/src/ploneintranet/workspace/browser/templates/workspaces.pt
@@ -9,9 +9,9 @@
   <body class="view-secure">
     <metal:content fill-slot="content">
 
-    <div class="container" id="workspace-search" tal:define="ploneview here/@@plone">
+    <div class="container" id="workspaces" tal:define="ploneview here/@@plone">
         <!--form class="canvas-toolbar pat-inject pat-autosubmit" action="/workspaces.html#workspaces" -->
-        <form  class="canvas-toolbar pat-inject pat-autosubmit" action="./workspaces.html" data-pat-inject="source: #workspace-search; target: #workspace-search" method="POST">
+        <form  class="canvas-toolbar pat-inject pat-autosubmit" action="./workspaces.html" data-pat-inject="source: #workspaces; target: #workspaces" method="POST">
             <label class="bare pat-select">
                 <select name="sort">
                     <tal:r repeat="o view/sort_options">

--- a/src/ploneintranet/workspace/browser/tiles/workspaces.py
+++ b/src/ploneintranet/workspace/browser/tiles/workspaces.py
@@ -24,7 +24,10 @@ class WorkspacesTile(Tile):
         """
         A tile should show either Workspacefolders or Cases, not both.
         """
-        return self.request.form.get('workspace_type', 'workspacefolders')
+        return self.request.form.get(
+            'workspace_type',
+            ['ploneintranet.workspace.workspacefolder',
+             'ploneintranet.workspace.case'])
 
     def shorten(self, text):
         return shorten(text, length=60)
@@ -60,14 +63,13 @@ def my_workspaces(context,
                 order = "reverse"
         if 'SearchableText' in request:
             searchable_text = request['SearchableText']
+        if 'workspace_type' in request and request.get('workspace_type'):
+            workspace_types = request['workspace_type']
 
     pc = api.portal.get_tool('portal_catalog')
     portal = api.portal.get()
     ws_folder = portal.get("workspaces")
     ws_path = "/".join(ws_folder.getPhysicalPath())
-
-    if 'workspace_type' in request and request.get('workspace_type'):
-        workspace_types = request['workspace_type']
 
     query = dict(object_provides=(
         'ploneintranet.workspace.workspacefolder.IWorkspaceFolder'),
@@ -75,11 +77,6 @@ def my_workspaces(context,
         sort_on=sort_by,
         sort_order=order,
         path=ws_path)
-
-    if 'cases' in workspace_types:
-        query['portal_types'] = "ploneintranet.workspace.case"
-    if 'workspacefolders' in workspace_types:
-        query['portal_types'] = "ploneintranet.workspace.workspacefolder"
 
     if searchable_text:
         query['SearchableText'] = searchable_text + '*'

--- a/src/ploneintranet/workspace/browser/tiles/workspaces.py
+++ b/src/ploneintranet/workspace/browser/tiles/workspaces.py
@@ -36,8 +36,10 @@ class WorkspacesTile(Tile):
         return my_workspaces(self.context, workspace_types=self.workspace_type)
 
 
-def my_workspaces(
-        context, request=None, workspace_types=['workspacefolders', 'cases']):
+def my_workspaces(context,
+                  request=None,
+                  workspace_types=['ploneintranet.workspace.workspacefolder',
+                                   'ploneintranet.workspace.case']):
     """ The list of my workspaces
     Is also used in theme/browser/workspace.py view.
     """
@@ -45,8 +47,10 @@ def my_workspaces(
     # determine sorting order (default: alphabetical)
     sort_by = "sortable_title"
     order = "ascending"
+    searchable_text = None
+
     if request:
-        if hasattr(request, "sort"):
+        if 'sort' in request:
             if request.sort == "activity":
                 raise NotImplementedError(
                     "Sorting by activity"
@@ -54,24 +58,34 @@ def my_workspaces(
             elif request.sort == "newest":
                 sort_by = "modified"
                 order = "reverse"
+        if 'SearchableText' in request:
+            searchable_text = request['SearchableText']
 
     pc = api.portal.get_tool('portal_catalog')
     portal = api.portal.get()
     ws_folder = portal.get("workspaces")
     ws_path = "/".join(ws_folder.getPhysicalPath())
-    portal_types = []
-    if 'cases' in workspace_types:
-        portal_types.append("ploneintranet.workspace.case")
-    if 'workspacefolders' in workspace_types:
-        portal_types.append("ploneintranet.workspace.workspacefolder")
-    brains = pc(
-        object_provides=(
-            'ploneintranet.workspace.workspacefolder.IWorkspaceFolder'),
-        portal_type=portal_types,
+
+    if 'workspace_type' in request and request.get('workspace_type'):
+        workspace_types = request['workspace_type']
+
+    query = dict(object_provides=(
+        'ploneintranet.workspace.workspacefolder.IWorkspaceFolder'),
+        portal_type=workspace_types,
         sort_on=sort_by,
         sort_order=order,
-        path=ws_path,
-    )
+        path=ws_path)
+
+    if 'cases' in workspace_types:
+        query['portal_types'] = "ploneintranet.workspace.case"
+    if 'workspacefolders' in workspace_types:
+        query['portal_types'] = "ploneintranet.workspace.workspacefolder"
+
+    if searchable_text:
+        query['SearchableText'] = searchable_text + '*'
+
+    brains = pc(query)
+
     workspaces = []
     for brain in brains:
         css_class = escape_id_to_class(brain.getId)

--- a/src/ploneintranet/workspace/browser/workspacecontainer.py
+++ b/src/ploneintranet/workspace/browser/workspacecontainer.py
@@ -43,12 +43,16 @@ class Workspaces(BrowserView):
                    # {'value': 'activity',
                    #  'content': 'Most active workspaces on top'}
                    ]
-        # put currently selected sort order at the beginning of the list
-        if hasattr(self.request, "sort"):
-            for o in options:
-                if o['value'] == self.request.sort:
-                    options.remove(o)
-                    options.insert(0, o)
+        return options
+
+    def workspace_types(self):
+        options = [{'value': '',
+                    'content': 'All workspace types'},
+                   {'value': 'ploneintranet.workspace.workspacefolder',
+                    'content': 'Generic workspaces'},
+                   {'value': 'ploneintranet.workspace.case',
+                    'content': 'Cases'}
+                   ]
         return options
 
     @memoize

--- a/src/ploneintranet/workspace/tests/test_workspace_sort.py
+++ b/src/ploneintranet/workspace/tests/test_workspace_sort.py
@@ -20,7 +20,8 @@ class TestWorkspaceSort(BaseTestCase):
                 context=self.portal.workspaces,
                 request=request)
             self.assertEqual(len(ws_container.sort_options()), 2)
-            self.assertEqual(ws_container.sort_options()[0]['value'], sort_by)
+            self.assertEqual(ws_container.sort_options()[0]['value'],
+                             'alphabet')
 
     def test_my_workspaces(self):
         ws_before = my_workspaces(self.portal.workspaces)


### PR DESCRIPTION
As soon as you get a notable amount of workspaces or cases, it becomes annoying to scroll through the boxes trying to locate the right title. Especially if you know what you want, you need the search or the type filter to drill down quicker. This is a low hanging fruit as the search is already coded and designed. This ties the threads together.
