### PR TITLE
Fix dashboard workspace tile headings

### DIFF
--- a/src/ploneintranet/core/locales/de/LC_MESSAGES/ploneintranet.po
+++ b/src/ploneintranet/core/locales/de/LC_MESSAGES/ploneintranet.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone Intranet\n"
-"POT-Creation-Date: 2015-08-28 08:33+0000\n"
+"POT-Creation-Date: 2015-10-01 12:49+0000\n"
 "PO-Revision-Date: 2015-05-22 19:10+0000\n"
 "Last-Translator: Alexander Pilz <pilz@syslab.com>\n"
 "Language-Team: German (http://www.transifex.com/projects/p/plone-intranet/language/de/)\n"
@@ -54,11 +54,15 @@ msgstr "Ein Benutzer (oder eine Gruppe), dem diese Aufgabe zugewiesen wurde."
 msgid "A user with this username already exists"
 msgstr ""
 
+#: ../layout/browser/templates/dashboard.pt:18
+msgid "Activity centric view"
+msgstr ""
+
 #: ../messaging/browser/messaging.py:26
 msgid "Add a comment"
 msgstr "Füge einen Kommentar hinzu."
 
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:91
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:94
 msgid "Add group"
 msgstr ""
 
@@ -75,7 +79,7 @@ msgstr "Füge ein 'aktuelle Nachrichten' Portlet hinzu."
 msgid "Add tags"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:88
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:91
 msgid "Add user"
 msgstr ""
 
@@ -92,47 +96,46 @@ msgid "Admin-Managed"
 msgstr "Verwaltet durch Administrator"
 
 #: ../workspace/browser/templates/roster-edit.pt:167
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:116
-#: ../workspace/browser/tiles/templates/sidebar.pt:481
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:119
+#: ../workspace/browser/tiles/templates/sidebar.pt:506
 msgid "Advanced"
 msgstr "Erweitert"
 
 #: ../workspace/browser/templates/roster-edit.pt:183
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:130
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:133
 msgid "Advanced permissions"
 msgstr "Erweiterte Berechtigungen"
 
-#: ../search/browser/templates/all_results.pt:24
 #: ../search/browser/templates/search_template.pt:24
 #: ../workspace/browser/tiles/templates/navigation.pt:35
 msgid "All"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:385
+#: ../workspace/browser/tiles/sidebar.py:384
 msgid "All Authors"
 msgstr "Alle Authoren"
 
-#: ../workspace/browser/tiles/sidebar.py:381
+#: ../workspace/browser/tiles/sidebar.py:380
 msgid "All Dates"
 msgstr "Alle Zeitpunkte"
 
-#: ../workspace/browser/tiles/sidebar.py:389
+#: ../workspace/browser/tiles/sidebar.py:388
 msgid "All Letters"
 msgstr "Alle Buchstaben"
 
-#: ../workspace/browser/tiles/sidebar.py:383
+#: ../workspace/browser/tiles/sidebar.py:382
 msgid "All Tags"
 msgstr "Alle Tags"
 
-#: ../workspace/browser/tiles/sidebar.py:635
+#: ../workspace/browser/tiles/sidebar.py:634
 msgid "All Time"
 msgstr "Alle Zeiträume"
 
-#: ../workspace/browser/tiles/sidebar.py:387
+#: ../workspace/browser/tiles/sidebar.py:386
 msgid "All Types"
 msgstr "Alle Typen"
 
-#: ../workspace/browser/tiles/events.py:49
+#: ../workspace/browser/tiles/events.py:52
 msgid "All day"
 msgstr ""
 
@@ -156,7 +159,7 @@ msgstr ""
 msgid "Any logged-in user is allowed to join the group and participate. Anything in this group is visible for any logged-in user, even if they're not a member."
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:40
+#: ../search/browser/templates/all_results.pt:36
 msgid "Any modification date"
 msgstr ""
 
@@ -183,15 +186,15 @@ msgstr "Datei hinzufügen"
 msgid "Attach a file (or create a picture)"
 msgstr "Füge eine Datei hinzu (oder erstelle ein Bild)"
 
-#: ../workspace/basecontent/templates/event_view.pt:60
+#: ../workspace/basecontent/templates/event_view.pt:59
 msgid "Attach documents"
 msgstr ""
 
-#: ../workspace/basecontent/templates/event_view.pt:60
+#: ../workspace/basecontent/templates/event_view.pt:59
 msgid "Attachments"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:286
+#: ../workspace/browser/tiles/sidebar.py:285
 msgid "Attributes changed."
 msgstr ""
 
@@ -199,19 +202,19 @@ msgstr ""
 msgid "Author name (for display)"
 msgstr "Name des Authors (für die Anzeige)"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:200
+#: ../workspace/browser/tiles/templates/sidebar.pt:204
 msgid "Author of this document"
 msgstr ""
 
-#: ../userprofile/browser/templates/user_import_form.pt:39
+#: ../userprofile/browser/templates/user_import_form.pt:70
 msgid "Available fields/columns"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:391
+#: ../workspace/browser/tiles/sidebar.py:390
 msgid "Back"
 msgstr "Zurück"
 
-#: ../search/browser/templates/all_results.pt:52
+#: ../search/browser/templates/all_results.pt:48
 msgid "Before last month"
 msgstr ""
 
@@ -219,16 +222,12 @@ msgstr ""
 msgid "Biography"
 msgstr ""
 
-#: ../userprofile/browser/templates/user_import_form.pt:13
-msgid "Bulk import users"
-msgstr ""
-
 msgid "CSV document"
 msgstr "CSV"
 
 #: ../messaging/browser/send-message.pt:63
 #: ../workspace/basecontent/document.py:77
-#: ../workspace/browser/templates/add_content.pt:36
+#: ../workspace/browser/templates/add_content.pt:38
 msgid "Cancel"
 msgstr "Abbrechen"
 
@@ -253,7 +252,7 @@ msgid "Change role of member"
 msgstr ""
 
 #: ../todo/browser/templates/todo_view.pt:48
-#: ../workspace/basecontent/templates/document_view.pt:41
+#: ../workspace/basecontent/templates/document_view.pt:44
 msgid "Change the workflow state"
 msgstr ""
 
@@ -261,11 +260,11 @@ msgstr ""
 msgid "Changes applied"
 msgstr "Änderungen gespeichert"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:357
+#: ../workspace/browser/tiles/templates/sidebar.pt:380
 msgid "Close milestone"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:157
+#: ../workspace/browser/templates/content_macros.pt:163
 msgid "Confirmed"
 msgstr ""
 
@@ -282,25 +281,25 @@ msgstr "Verbrauchen"
 msgid "Contact"
 msgstr ""
 
-#: ../userprofile/browser/tiles/templates/contacts_search.pt:9
+#: ../userprofile/browser/tiles/templates/contacts_search.pt:10
 msgid "Contacts"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:27
+#: ../search/browser/templates/all_results.pt:23
 msgid "Content types"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:95
+#: ../workspace/browser/tiles/templates/sidebar.pt:99
 msgid "Copy"
 msgstr "Kopieren"
 
-#: ../workspace/browser/templates/add_content.pt:33
+#: ../workspace/browser/templates/add_content.pt:35
 #: ../workspace/browser/templates/add_folder.pt:20
 #: ../workspace/browser/templates/add_task.pt:24
 msgid "Create"
 msgstr "Erzeugen"
 
-#: ../workspace/browser/templates/workspaces.pt:24
+#: ../workspace/browser/templates/workspaces.pt:30
 msgid "Create a new workspace"
 msgstr ""
 
@@ -314,11 +313,11 @@ msgid "Create event"
 msgstr ""
 
 #: ../workspace/browser/templates/add_folder.pt:7
-#: ../workspace/browser/tiles/templates/sidebar.pt:221
+#: ../workspace/browser/tiles/templates/sidebar.pt:225
 msgid "Create folder"
 msgstr "Verzeichnis erstellen"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:289
+#: ../workspace/browser/tiles/templates/sidebar.pt:293
 msgid "Create new task"
 msgstr ""
 
@@ -328,7 +327,7 @@ msgstr ""
 
 #: ../theme/browser/templates/workspaces.pt:25
 #: ../workspace/browser/templates/workspace-add.pt:11
-#: ../workspace/browser/templates/workspaces.pt:24
+#: ../workspace/browser/templates/workspaces.pt:30
 msgid "Create workspace"
 msgstr ""
 
@@ -336,30 +335,30 @@ msgstr ""
 msgid "Creation date"
 msgstr "Erstellungsdatum"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:88
+#: ../workspace/browser/tiles/templates/sidebar.pt:92
 msgid "Cut"
 msgstr "Ausschneiden"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:203
+#: ../workspace/browser/tiles/templates/sidebar.pt:207
 msgid "Date and time of the latest modification"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:159
+#: ../workspace/browser/templates/content_macros.pt:165
 msgid "Declined"
 msgstr ""
 
 #: ../todo/browser/templates/todo_view.pt:34
-#: ../workspace/basecontent/templates/document_view.pt:35
-#: ../workspace/basecontent/templates/event_view.pt:50
+#: ../workspace/basecontent/templates/document_view.pt:38
+#: ../workspace/basecontent/templates/event_view.pt:49
 msgid "Delete"
 msgstr "Löschen"
 
 #: ../todo/browser/templates/todo_view.pt:34
-#: ../workspace/basecontent/templates/document_view.pt:35
+#: ../workspace/basecontent/templates/document_view.pt:38
 msgid "Delete this document"
 msgstr ""
 
-#: ../workspace/basecontent/templates/event_view.pt:50
+#: ../workspace/basecontent/templates/event_view.pt:49
 msgid "Delete this event"
 msgstr ""
 
@@ -371,22 +370,22 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: ../workspace/browser/templates/add_content.pt:27
+#: ../workspace/browser/templates/add_content.pt:29
 #: ../workspace/browser/templates/add_folder.pt:15
 msgid "Description for search results (Optional)"
 msgstr "Beschreibung für die Suchergebnisse (optional)"
 
 #: ../workspace/browser/tiles/templates/navigation.pt:36
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:37
-#: ../workspace/browser/tiles/templates/sidebar.pt:82
+#: ../workspace/browser/tiles/templates/sidebar.pt:86
 msgid "Deslect all"
 msgstr "Alles abwählen"
 
-#: ../search/browser/templates/all_results.pt:91
+#: ../search/browser/templates/all_results.pt:81
 msgid "Did you mean"
 msgstr ""
 
-#: ../workspace/browser/templates/add_content.pt:25
+#: ../workspace/browser/templates/add_content.pt:27
 msgid "Document title"
 msgstr "Titel des Dokuments"
 
@@ -394,11 +393,11 @@ msgstr "Titel des Dokuments"
 msgid "Documents"
 msgstr "Dokumente"
 
-#: ../todo/browser/templates/todo_view.pt:51
+#: ../todo/browser/templates/todo_view.pt:65
 msgid "Done"
 msgstr ""
 
-#: ../workspace/basecontent/templates/document_view.pt:109
+#: ../workspace/basecontent/templates/document_view.pt:113
 msgid "Download as"
 msgstr ""
 
@@ -415,7 +414,7 @@ msgstr ""
 msgid "Edit latest news portlet"
 msgstr "\"Aktuelle Nachrichten\" Portlet bearbeiten"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:146
+#: ../workspace/browser/tiles/templates/sidebar.pt:150
 msgid "Edit name/description"
 msgstr ""
 
@@ -425,10 +424,6 @@ msgstr ""
 
 #: ../userprofile/content/userprofile.py:45
 msgid "Email"
-msgstr ""
-
-#: ../workspace/browser/tiles/templates/sidebar.pt:422
-msgid "Ended"
 msgstr ""
 
 #: ../workspace/browser/templates/add_event.pt:25
@@ -465,6 +460,10 @@ msgstr ""
 #: ../core/browser/stream.py:56
 msgid "Explore"
 msgstr "Durchsuchen"
+
+#: ../userprofile/sync.py:80
+msgid "External property sync complete."
+msgstr ""
 
 msgid "File"
 msgstr ""
@@ -514,7 +513,7 @@ msgstr ""
 msgid "For cases, security is managed by the case workflow. You cannot configure it here like in workspaces. Instead please just assign the correct roles to users and groups in the \"Members\" tab."
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:106
+#: ../workspace/browser/templates/content_macros.pt:109
 msgid "From"
 msgstr ""
 
@@ -530,11 +529,11 @@ msgstr ""
 msgid "Functions"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:469
+#: ../workspace/browser/tiles/templates/sidebar.pt:494
 msgid "General"
 msgstr "Allgemein"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:296
+#: ../workspace/browser/tiles/templates/sidebar.pt:300
 msgid "General tasks"
 msgstr ""
 
@@ -563,7 +562,7 @@ msgstr ""
 msgid "If checked, users will be removed from workspace"
 msgstr "Wenn angewählt werden die Benutzer aus dem Arbeitsbereich entfernt."
 
-#: ../workspace/browser/templates/add_content.pt:21
+#: ../workspace/browser/templates/add_content.pt:23
 msgid "Image"
 msgstr "Bild"
 
@@ -576,7 +575,7 @@ msgstr ""
 msgid "Images"
 msgstr ""
 
-#: ../userprofile/browser/templates/user_import_form.pt:31
+#: ../userprofile/browser/templates/user_import_form.pt:62
 msgid "Import users from file"
 msgstr ""
 
@@ -605,15 +604,15 @@ msgid "Invitations"
 msgstr "Einladungen"
 
 #: ../workspace/browser/templates/roster-edit.pt:169
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:118
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:121
 msgid "Invite users to this workspace (via email)"
 msgstr "Lade Benutzer in diesen Arbeitsbereich ein (per Email)"
 
-#: ../workspace/browser/templates/content_macros.pt:150
+#: ../workspace/browser/templates/content_macros.pt:156
 msgid "Invitees"
 msgstr ""
 
-#: ../workspace/browser/add_content.py:89
+#: ../workspace/browser/add_content.py:104
 msgid "Item created."
 msgstr ""
 
@@ -621,19 +620,19 @@ msgstr ""
 msgid "Item edited."
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:630
+#: ../workspace/browser/tiles/sidebar.py:629
 msgid "Items modified last month"
 msgstr "Alles, was sich letzten Monat geändert wurde"
 
-#: ../workspace/browser/tiles/sidebar.py:624
+#: ../workspace/browser/tiles/sidebar.py:623
 msgid "Items modified last week"
 msgstr "Alles, was sich letzte Woche geändert hat"
 
-#: ../workspace/browser/tiles/sidebar.py:618
+#: ../workspace/browser/tiles/sidebar.py:617
 msgid "Items modified today"
 msgstr "Alles, was sich heute geändert hat"
 
-#: ../workspace/browser/tiles/sidebar.py:636
+#: ../workspace/browser/tiles/sidebar.py:635
 msgid "Items since ever"
 msgstr "Alles"
 
@@ -652,19 +651,19 @@ msgstr ""
 msgid "Join now"
 msgstr "Jetzt registrieren!"
 
-#: ../search/browser/templates/all_results.pt:38
+#: ../search/browser/templates/all_results.pt:34
 msgid "Last Modified"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:629
+#: ../workspace/browser/tiles/sidebar.py:628
 msgid "Last Month"
 msgstr "Letzten Monat"
 
-#: ../workspace/browser/tiles/sidebar.py:623
+#: ../workspace/browser/tiles/sidebar.py:622
 msgid "Last Week"
 msgstr "Letzte Woche"
 
-#: ../search/browser/templates/all_results.pt:49
+#: ../search/browser/templates/all_results.pt:45
 msgid "Last month"
 msgstr ""
 
@@ -672,7 +671,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:46
+#: ../search/browser/templates/all_results.pt:42
 msgid "Last week"
 msgstr ""
 
@@ -684,7 +683,7 @@ msgstr "Aktuelle Nachrichten"
 msgid "Leave a comment"
 msgstr "Schreibe einen Kommentar"
 
-#: ../core/browser/tiles/templates/my_documents.pt:8
+#: ../core/browser/tiles/templates/my_documents.pt:9
 #: ../library/profiles/default/actions.xml
 msgid "Library"
 msgstr ""
@@ -732,16 +731,16 @@ msgstr "Markiere den Inhalt als \"Muss\" für alle Benutzer"
 msgid "Member"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:168
+#: ../workspace/browser/tiles/sidebar.py:178
 msgid "Member(s) added"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:176
+#: ../workspace/browser/tiles/sidebar.py:183
 msgid "Member(s) removed"
 msgstr ""
 
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:20
-#: ../workspace/browser/tiles/templates/sidebar.pt:473
+#: ../workspace/browser/tiles/templates/sidebar.pt:498
 msgid "Members"
 msgstr "Benutzer"
 
@@ -787,7 +786,7 @@ msgstr "Moderat"
 msgid "More information about"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:185
+#: ../search/browser/templates/all_results.pt:175
 #: ../search/browser/templates/file_results.pt:32
 #: ../search/browser/templates/image_results.pt:32
 msgid "More results"
@@ -842,7 +841,7 @@ msgstr "Keine ungelesenen Benachrichtigungen"
 msgid "No such user ${userid}."
 msgstr "Benutzer ${userid} nicht gefunden."
 
-#: ../layout/browser/templates/tasks-tile.pt:9
+#: ../layout/browser/templates/tasks-tile.pt:11
 msgid "No tasks available"
 msgstr ""
 
@@ -850,7 +849,6 @@ msgstr ""
 msgid "No token id given in sub-path.Use .../@@accept-token/tokenid"
 msgstr "Keine Token ID übergeben in Teilpfad. Benutze .../@@accept-token/tokenid"
 
-#: ../search/browser/templates/all_results.pt:25
 #: ../workspace/browser/tiles/templates/navigation.pt:36
 msgid "None"
 msgstr ""
@@ -883,7 +881,7 @@ msgstr "Das war jetzt unerwartet, aber Sie sind bereits ein Mitglied."
 msgid "Ok"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:451
+#: ../workspace/browser/tiles/templates/sidebar.pt:476
 msgid "Older events"
 msgstr "Ältere Termine"
 
@@ -891,7 +889,7 @@ msgstr "Ältere Termine"
 msgid "Only administrators can add workspace members."
 msgstr "Nur Administratoren können Mitglieder zu Arbeitsbereichen hinzufügen."
 
-#: ../todo/browser/templates/todo_view.pt:50
+#: ../todo/browser/templates/todo_view.pt:63
 #: ../workspace/policies.py:23
 msgid "Open"
 msgstr "Offen"
@@ -918,7 +916,7 @@ msgstr "Das PDF wurde noch nicht generiert. "
 msgid "Page"
 msgstr "Seite"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:102
+#: ../workspace/browser/tiles/templates/sidebar.pt:106
 msgid "Paste"
 msgstr "Einfügen"
 
@@ -953,7 +951,11 @@ msgstr ""
 msgid "Pick an initiator"
 msgstr ""
 
-#: ../workspace/browser/add_content.py:48
+#: ../todo/browser/templates/todo_view.pt:64
+msgid "Planned"
+msgstr ""
+
+#: ../workspace/browser/add_content.py:63
 msgid "Please specify which Case Template to use"
 msgstr ""
 
@@ -1009,15 +1011,19 @@ msgstr ""
 msgid "Remove role"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:360
+#: ../todo/browser/templates/todo_view.pt:71
+msgid "Reopen"
+msgstr ""
+
+#: ../workspace/browser/tiles/templates/sidebar.pt:383
 msgid "Reopen milestone"
 msgstr ""
 
-#: ../workspace/browser/templates/add_content.pt:15
+#: ../workspace/browser/templates/add_content.pt:17
 msgid "Rich text"
 msgstr "Formatierter Text"
 
-#: ../workspace/browser/tiles/sidebar.py:189
+#: ../workspace/browser/tiles/sidebar.py:190
 msgid "Role updated"
 msgstr ""
 
@@ -1025,13 +1031,13 @@ msgstr ""
 msgid "Roster updated."
 msgstr "Mitgliederliste aktualisiert"
 
-#: ../todo/browser/templates/todo_view.pt:56
+#: ../todo/browser/templates/todo_view.pt:77
 #: ../userprofile/browser/templates/userprofile-edit.pt:47
 #: ../workspace/basecontent/document.py:73
 msgid "Save"
 msgstr "Sichern"
 
-#: ../workspace/basecontent/templates/event_view.pt:86
+#: ../workspace/basecontent/templates/event_view.pt:85
 msgid "Save this document"
 msgstr ""
 
@@ -1057,7 +1063,7 @@ msgstr ""
 msgid "Secret"
 msgstr "Geheimnis"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:477
+#: ../workspace/browser/tiles/templates/sidebar.pt:502
 msgid "Security"
 msgstr "Sicherheit"
 
@@ -1068,7 +1074,7 @@ msgstr "Auswählen"
 
 #: ../workspace/browser/tiles/templates/navigation.pt:35
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:36
-#: ../workspace/browser/tiles/templates/sidebar.pt:81
+#: ../workspace/browser/tiles/templates/sidebar.pt:85
 msgid "Select all"
 msgstr "Alles anwählen"
 
@@ -1100,17 +1106,17 @@ msgstr ""
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: ../workspace/basecontent/templates/document_view.pt:37
+#: ../workspace/basecontent/templates/document_view.pt:40
 msgid "Share"
 msgstr "Teilen"
 
-#: ../workspace/basecontent/templates/document_view.pt:37
+#: ../workspace/basecontent/templates/document_view.pt:40
 msgid "Share this document"
 msgstr ""
 
 #: ../todo/browser/templates/todo_view.pt:43
-#: ../workspace/basecontent/templates/document_view.pt:38
-#: ../workspace/basecontent/templates/event_view.pt:63
+#: ../workspace/basecontent/templates/document_view.pt:41
+#: ../workspace/basecontent/templates/event_view.pt:62
 msgid "Show extra metadata fields"
 msgstr ""
 
@@ -1130,13 +1136,13 @@ msgstr ""
 msgid "Start date should be lower than end date"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:417
-msgid "Starts"
-msgstr "Startet"
-
 #: ../network/browser/templates/author.pt:29
 msgid "Status updates by ${fullname}:"
 msgstr "Statusänderung von ${fullname}:"
+
+#: ../layout/browser/templates/dashboard.pt:21
+msgid "Task centric view"
+msgstr ""
 
 #: ../todo/utils.py:31
 msgid "Task state changed"
@@ -1146,6 +1152,7 @@ msgstr ""
 msgid "Task title"
 msgstr ""
 
+#: ../layout/browser/templates/tasks-tile.pt:10
 #: ../workspace/browser/tiles/templates/workspace-tabs-tile.pt:22
 msgid "Tasks"
 msgstr "Aufgaben"
@@ -1158,7 +1165,7 @@ msgstr "Teamverwaltet"
 msgid "Telephone Number"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:158
+#: ../workspace/browser/templates/content_macros.pt:164
 msgid "Tentative"
 msgstr ""
 
@@ -1278,7 +1285,7 @@ msgstr ""
 msgid "The workspace will only be accessible for team members. Any member can add a new team member. Once you're in the team, you can do pretty much anything. Nothing in this group will ever be visible to non-members."
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:294
+#: ../workspace/browser/tiles/sidebar.py:293
 msgid "There was a problem updating the content: %s."
 msgstr ""
 
@@ -1286,7 +1293,7 @@ msgstr ""
 msgid "There was a problem: %s"
 msgstr ""
 
-#: ../workspace/browser/add_content.py:95
+#: ../workspace/browser/add_content.py:110
 #: ../workspace/browser/edit_content.py:38
 msgid "There was a problem: %s."
 msgstr ""
@@ -1311,11 +1318,11 @@ msgstr ""
 msgid "Timeline"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:138
+#: ../workspace/browser/templates/content_macros.pt:144
 msgid "Timezone"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:123
+#: ../workspace/browser/templates/content_macros.pt:127
 msgid "To"
 msgstr ""
 
@@ -1323,8 +1330,8 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:43
-#: ../workspace/browser/tiles/sidebar.py:617
+#: ../search/browser/templates/all_results.pt:39
+#: ../workspace/browser/tiles/sidebar.py:616
 msgid "Today"
 msgstr "Heute"
 
@@ -1332,8 +1339,8 @@ msgid "Todo"
 msgstr ""
 
 #: ../todo/browser/templates/todo_view.pt:43
-#: ../workspace/basecontent/templates/document_view.pt:38
-#: ../workspace/basecontent/templates/event_view.pt:63
+#: ../workspace/basecontent/templates/document_view.pt:41
+#: ../workspace/basecontent/templates/event_view.pt:62
 msgid "Toggle extra metadata"
 msgstr ""
 
@@ -1342,15 +1349,15 @@ msgid "Token no longer valid"
 msgstr "Token nicht länger gültig."
 
 #: ../workspace/browser/templates/roster-edit.pt:176
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:124
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:127
 msgid "Transfer members to another workspace."
 msgstr "Mitglieder zu anderem Arbeitsbereich übertragen."
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:367
+#: ../workspace/browser/tiles/templates/sidebar.pt:390
 msgid "Unassigned"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:156
+#: ../workspace/browser/templates/content_macros.pt:162
 msgid "Undecided"
 msgstr ""
 
@@ -1358,7 +1365,7 @@ msgstr ""
 msgid "Unfollow"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:195
+#: ../workspace/browser/tiles/sidebar.py:193
 msgid "Unknown function"
 msgstr ""
 
@@ -1366,12 +1373,12 @@ msgstr ""
 msgid "Unlike"
 msgstr "Unlike"
 
-#: ../workspace/browser/tiles/templates/events.pt:9
-#: ../workspace/browser/tiles/templates/sidebar.pt:400
+#: ../workspace/browser/tiles/templates/events.pt:10
+#: ../workspace/browser/tiles/templates/sidebar.pt:423
 msgid "Upcoming events"
 msgstr "Anstehende Termine"
 
-#: ../userprofile/browser/templates/user_import_form.pt:25
+#: ../userprofile/browser/templates/user_import_form.pt:56
 msgid "Update details for existing users (matching on username)"
 msgstr ""
 
@@ -1380,9 +1387,13 @@ msgstr ""
 msgid "Updates"
 msgstr "Aktualisierungen"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:244
+#: ../workspace/browser/tiles/templates/sidebar.pt:248
 msgid "Upload file(s)"
 msgstr "Dateien hochladen"
+
+#: ../userprofile/browser/templates/user_import_form.pt:18
+msgid "User profile management"
+msgstr ""
 
 #: ../microblog/interfaces.py:17
 msgid "Userid"
@@ -1447,7 +1458,7 @@ msgstr "Mitglieder des Arbeitsbereichs können Inhalte lesen, hinzufügen und pu
 msgid "Workspace policy"
 msgstr "Richtlinie des Arbeitsbereichs"
 
-#: ../workspace/browser/tiles/sidebar.py:247
+#: ../workspace/browser/tiles/sidebar.py:246
 msgid "Workspace security policy changes saved"
 msgstr "Die Änderungen an der Sicherheitsrichtlinie des Arbeitsbereiches wurden gesichert."
 
@@ -1476,7 +1487,7 @@ msgstr ""
 msgid "You can become a member of this workspace"
 msgstr "Sie können ein Mitglied dieses Arbeitsbereichs werden."
 
-#: ../workspace/browser/tiles/sidebar.py:160
+#: ../workspace/browser/tiles/sidebar.py:161
 msgid "You do not have permission to change the workspace policy"
 msgstr "Sie haben nicht die erforderlichen Berechtigungen um die Richtlinien des Arbeitsbereichs zu ändern."
 
@@ -1518,6 +1529,11 @@ msgstr "Geschäfte"
 msgid "date"
 msgstr "Datum"
 
+#. Default: "Start time should be lower than end time. The system set the end time to: ${date}"
+#: ../workspace/browser/add_content.py:164
+msgid "dates_hijacked"
+msgstr ""
+
 #: ../workspace/browser/tiles/templates/navigation.pt:21
 #: ../workspace/browser/tiles/templates/sidebar.pt:37
 msgid "document type"
@@ -1529,7 +1545,7 @@ msgid "download"
 msgstr ""
 
 #. Default: "Drop files here or click to browse..."
-#: ../workspace/browser/tiles/sidebar.py:310
+#: ../workspace/browser/tiles/sidebar.py:309
 msgid "drop_files_here"
 msgstr "Dateien hier hin schieben oder auf Durchsuchen klicken."
 
@@ -1549,7 +1565,7 @@ msgid "expand/reduce sidebar"
 msgstr ""
 
 #. Default: "External visibility"
-#: ../workspace/browser/tiles/sidebar.py:215
+#: ../workspace/browser/tiles/sidebar.py:214
 msgid "external_visibility_label"
 msgstr "Sichtbarkeit von Aussen"
 
@@ -1593,14 +1609,14 @@ msgstr "Wenn diese URL geklickt wird, wird automatisch ein Benutzerkonto angeleg
 msgid "invititations"
 msgstr "Einladungen"
 
-#: ../search/browser/templates/all_results.pt:87
+#: ../search/browser/templates/all_results.pt:77
 #: ../search/browser/templates/image_results.pt:14
 #: ../search/browser/templates/people_results.pt:14
 msgid "items matched your search."
 msgstr ""
 
 #. Default: "Join policy"
-#: ../workspace/browser/tiles/sidebar.py:214
+#: ../workspace/browser/tiles/sidebar.py:213
 msgid "join_policy_label"
 msgstr "Teilnahmerichtlinie"
 
@@ -1618,13 +1634,13 @@ msgstr ""
 msgid "label_name"
 msgstr ""
 
-#. Default: "News"
-#: ../layout/browser/templates/news-tile.pt:8
+#. Default: "<a href=\"${context/portal_url}/library/news\">News</a>"
+#: ../layout/browser/templates/news-tile.pt:9
 msgid "label_news"
 msgstr ""
 
 #. Default: "No events available"
-#: ../workspace/browser/tiles/templates/sidebar.pt:460
+#: ../workspace/browser/tiles/templates/sidebar.pt:485
 msgid "label_no_events_available"
 msgstr ""
 
@@ -1674,36 +1690,36 @@ msgid "leave_a_comment"
 msgstr "Kommentar verfassen"
 
 #. Default: "More sharing options coming soon"
-#: ../workspace/basecontent/templates/document_view.pt:111
+#: ../workspace/basecontent/templates/document_view.pt:115
 msgid "more_sharing_soon"
 msgstr ""
 
 #. Default: "No tasks created yet"
-#: ../workspace/browser/tiles/templates/sidebar.pt:298
+#: ../workspace/browser/tiles/templates/sidebar.pt:302
 msgid "no-task-found"
 msgstr "Keine Aufgaben vorhanden"
 
 #. Default: "${no_members} Members"
-#: ../workspace/workspacefolder.py:167
+#: ../workspace/workspacefolder.py:172
 msgid "number_of_members"
 msgstr ""
 
 #. Default: "Participant policy"
-#: ../workspace/browser/tiles/sidebar.py:217
+#: ../workspace/browser/tiles/sidebar.py:216
 msgid "participant_policy_label"
 msgstr "Teilnehmerrichtlinie"
 
 #. Default: "Description"
-#: ../workspace/basecontent/templates/event_view.pt:101
+#: ../workspace/basecontent/templates/event_view.pt:100
 msgid "placeholder"
 msgstr ""
 
-#: ../workspace/browser/tiles/workspaces.py:109
+#: ../workspace/browser/tiles/workspaces.py:120
 msgid "posted"
 msgstr "abgeschickt"
 
 #. Default: "Read more..."
-#: ../layout/browser/templates/news-tile.pt:19
+#: ../layout/browser/templates/news-tile.pt:20
 #: ../library/browser/templates/library.html:148
 msgid "read-more"
 msgstr ""
@@ -1715,13 +1731,13 @@ msgstr ""
 
 #. Default: "All"
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:36
-#: ../workspace/browser/tiles/templates/sidebar.pt:81
+#: ../workspace/browser/tiles/templates/sidebar.pt:85
 msgid "select_all"
 msgstr "Alles"
 
 #. Default: "None"
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:37
-#: ../workspace/browser/tiles/templates/sidebar.pt:82
+#: ../workspace/browser/tiles/templates/sidebar.pt:86
 msgid "select_none"
 msgstr "Nichts"
 
@@ -1733,6 +1749,16 @@ msgstr "Als Teilnahmerichtlinie dieses Arbeitsbereichs ist ${policy_name} gesetz
 #: ../workspace/browser/tiles/templates/sidebar.pt:35
 msgid "tag"
 msgstr "Tag"
+
+#. Cases
+#: ../layout/browser/templates/dashboard.pt
+msgid "tile_ploneintranet.workspace.case"
+msgstr "Geschäfte"
+
+#. Workspaces
+#: ../layout/browser/templates/dashboard.pt
+msgid "tile_ploneintranet.workspace.workspacefolder"
+msgstr "Arbeitsbereiche"
 
 #: ../network/browser/templates/maxiauthor_provider.pt:72
 #: ../network/browser/templates/miniauthor_provider.pt:38

--- a/src/ploneintranet/core/locales/en/LC_MESSAGES/ploneintranet.po
+++ b/src/ploneintranet/core/locales/en/LC_MESSAGES/ploneintranet.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-08-28 08:33+0000\n"
+"POT-Creation-Date: 2015-10-01 12:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -50,11 +50,15 @@ msgstr ""
 msgid "A user with this username already exists"
 msgstr ""
 
+#: ../layout/browser/templates/dashboard.pt:18
+msgid "Activity centric view"
+msgstr ""
+
 #: ../messaging/browser/messaging.py:26
 msgid "Add a comment"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:91
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:94
 msgid "Add group"
 msgstr ""
 
@@ -71,7 +75,7 @@ msgstr ""
 msgid "Add tags"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:88
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:91
 msgid "Add user"
 msgstr ""
 
@@ -88,47 +92,46 @@ msgid "Admin-Managed"
 msgstr ""
 
 #: ../workspace/browser/templates/roster-edit.pt:167
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:116
-#: ../workspace/browser/tiles/templates/sidebar.pt:481
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:119
+#: ../workspace/browser/tiles/templates/sidebar.pt:506
 msgid "Advanced"
 msgstr ""
 
 #: ../workspace/browser/templates/roster-edit.pt:183
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:130
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:133
 msgid "Advanced permissions"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:24
 #: ../search/browser/templates/search_template.pt:24
 #: ../workspace/browser/tiles/templates/navigation.pt:35
 msgid "All"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:385
+#: ../workspace/browser/tiles/sidebar.py:384
 msgid "All Authors"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:381
+#: ../workspace/browser/tiles/sidebar.py:380
 msgid "All Dates"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:389
+#: ../workspace/browser/tiles/sidebar.py:388
 msgid "All Letters"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:383
+#: ../workspace/browser/tiles/sidebar.py:382
 msgid "All Tags"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:635
+#: ../workspace/browser/tiles/sidebar.py:634
 msgid "All Time"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:387
+#: ../workspace/browser/tiles/sidebar.py:386
 msgid "All Types"
 msgstr ""
 
-#: ../workspace/browser/tiles/events.py:49
+#: ../workspace/browser/tiles/events.py:52
 msgid "All day"
 msgstr ""
 
@@ -152,7 +155,7 @@ msgstr ""
 msgid "Any logged-in user is allowed to join the group and participate. Anything in this group is visible for any logged-in user, even if they're not a member."
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:40
+#: ../search/browser/templates/all_results.pt:36
 msgid "Any modification date"
 msgstr ""
 
@@ -179,15 +182,15 @@ msgstr ""
 msgid "Attach a file (or create a picture)"
 msgstr ""
 
-#: ../workspace/basecontent/templates/event_view.pt:60
+#: ../workspace/basecontent/templates/event_view.pt:59
 msgid "Attach documents"
 msgstr ""
 
-#: ../workspace/basecontent/templates/event_view.pt:60
+#: ../workspace/basecontent/templates/event_view.pt:59
 msgid "Attachments"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:286
+#: ../workspace/browser/tiles/sidebar.py:285
 msgid "Attributes changed."
 msgstr ""
 
@@ -195,19 +198,19 @@ msgstr ""
 msgid "Author name (for display)"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:200
+#: ../workspace/browser/tiles/templates/sidebar.pt:204
 msgid "Author of this document"
 msgstr ""
 
-#: ../userprofile/browser/templates/user_import_form.pt:39
+#: ../userprofile/browser/templates/user_import_form.pt:70
 msgid "Available fields/columns"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:391
+#: ../workspace/browser/tiles/sidebar.py:390
 msgid "Back"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:52
+#: ../search/browser/templates/all_results.pt:48
 msgid "Before last month"
 msgstr ""
 
@@ -215,16 +218,12 @@ msgstr ""
 msgid "Biography"
 msgstr ""
 
-#: ../userprofile/browser/templates/user_import_form.pt:13
-msgid "Bulk import users"
-msgstr ""
-
 msgid "CSV document"
 msgstr ""
 
 #: ../messaging/browser/send-message.pt:63
 #: ../workspace/basecontent/document.py:77
-#: ../workspace/browser/templates/add_content.pt:36
+#: ../workspace/browser/templates/add_content.pt:38
 msgid "Cancel"
 msgstr ""
 
@@ -249,7 +248,7 @@ msgid "Change role of member"
 msgstr ""
 
 #: ../todo/browser/templates/todo_view.pt:48
-#: ../workspace/basecontent/templates/document_view.pt:41
+#: ../workspace/basecontent/templates/document_view.pt:44
 msgid "Change the workflow state"
 msgstr ""
 
@@ -257,11 +256,11 @@ msgstr ""
 msgid "Changes applied"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:357
+#: ../workspace/browser/tiles/templates/sidebar.pt:380
 msgid "Close milestone"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:157
+#: ../workspace/browser/templates/content_macros.pt:163
 msgid "Confirmed"
 msgstr ""
 
@@ -278,25 +277,25 @@ msgstr ""
 msgid "Contact"
 msgstr ""
 
-#: ../userprofile/browser/tiles/templates/contacts_search.pt:9
+#: ../userprofile/browser/tiles/templates/contacts_search.pt:10
 msgid "Contacts"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:27
+#: ../search/browser/templates/all_results.pt:23
 msgid "Content types"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:95
+#: ../workspace/browser/tiles/templates/sidebar.pt:99
 msgid "Copy"
 msgstr ""
 
-#: ../workspace/browser/templates/add_content.pt:33
+#: ../workspace/browser/templates/add_content.pt:35
 #: ../workspace/browser/templates/add_folder.pt:20
 #: ../workspace/browser/templates/add_task.pt:24
 msgid "Create"
 msgstr ""
 
-#: ../workspace/browser/templates/workspaces.pt:24
+#: ../workspace/browser/templates/workspaces.pt:30
 msgid "Create a new workspace"
 msgstr ""
 
@@ -310,11 +309,11 @@ msgid "Create event"
 msgstr ""
 
 #: ../workspace/browser/templates/add_folder.pt:7
-#: ../workspace/browser/tiles/templates/sidebar.pt:221
+#: ../workspace/browser/tiles/templates/sidebar.pt:225
 msgid "Create folder"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:289
+#: ../workspace/browser/tiles/templates/sidebar.pt:293
 msgid "Create new task"
 msgstr ""
 
@@ -324,7 +323,7 @@ msgstr ""
 
 #: ../theme/browser/templates/workspaces.pt:25
 #: ../workspace/browser/templates/workspace-add.pt:11
-#: ../workspace/browser/templates/workspaces.pt:24
+#: ../workspace/browser/templates/workspaces.pt:30
 msgid "Create workspace"
 msgstr ""
 
@@ -332,30 +331,30 @@ msgstr ""
 msgid "Creation date"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:88
+#: ../workspace/browser/tiles/templates/sidebar.pt:92
 msgid "Cut"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:203
+#: ../workspace/browser/tiles/templates/sidebar.pt:207
 msgid "Date and time of the latest modification"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:159
+#: ../workspace/browser/templates/content_macros.pt:165
 msgid "Declined"
 msgstr ""
 
 #: ../todo/browser/templates/todo_view.pt:34
-#: ../workspace/basecontent/templates/document_view.pt:35
-#: ../workspace/basecontent/templates/event_view.pt:50
+#: ../workspace/basecontent/templates/document_view.pt:38
+#: ../workspace/basecontent/templates/event_view.pt:49
 msgid "Delete"
 msgstr ""
 
 #: ../todo/browser/templates/todo_view.pt:34
-#: ../workspace/basecontent/templates/document_view.pt:35
+#: ../workspace/basecontent/templates/document_view.pt:38
 msgid "Delete this document"
 msgstr ""
 
-#: ../workspace/basecontent/templates/event_view.pt:50
+#: ../workspace/basecontent/templates/event_view.pt:49
 msgid "Delete this event"
 msgstr ""
 
@@ -367,22 +366,22 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: ../workspace/browser/templates/add_content.pt:27
+#: ../workspace/browser/templates/add_content.pt:29
 #: ../workspace/browser/templates/add_folder.pt:15
 msgid "Description for search results (Optional)"
 msgstr ""
 
 #: ../workspace/browser/tiles/templates/navigation.pt:36
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:37
-#: ../workspace/browser/tiles/templates/sidebar.pt:82
+#: ../workspace/browser/tiles/templates/sidebar.pt:86
 msgid "Deslect all"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:91
+#: ../search/browser/templates/all_results.pt:81
 msgid "Did you mean"
 msgstr ""
 
-#: ../workspace/browser/templates/add_content.pt:25
+#: ../workspace/browser/templates/add_content.pt:27
 msgid "Document title"
 msgstr ""
 
@@ -390,11 +389,11 @@ msgstr ""
 msgid "Documents"
 msgstr ""
 
-#: ../todo/browser/templates/todo_view.pt:51
+#: ../todo/browser/templates/todo_view.pt:65
 msgid "Done"
 msgstr ""
 
-#: ../workspace/basecontent/templates/document_view.pt:109
+#: ../workspace/basecontent/templates/document_view.pt:113
 msgid "Download as"
 msgstr ""
 
@@ -411,7 +410,7 @@ msgstr ""
 msgid "Edit latest news portlet"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:146
+#: ../workspace/browser/tiles/templates/sidebar.pt:150
 msgid "Edit name/description"
 msgstr ""
 
@@ -421,10 +420,6 @@ msgstr ""
 
 #: ../userprofile/content/userprofile.py:45
 msgid "Email"
-msgstr ""
-
-#: ../workspace/browser/tiles/templates/sidebar.pt:422
-msgid "Ended"
 msgstr ""
 
 #: ../workspace/browser/templates/add_event.pt:25
@@ -460,6 +455,10 @@ msgstr ""
 
 #: ../core/browser/stream.py:56
 msgid "Explore"
+msgstr ""
+
+#: ../userprofile/sync.py:80
+msgid "External property sync complete."
 msgstr ""
 
 msgid "File"
@@ -510,7 +509,7 @@ msgstr ""
 msgid "For cases, security is managed by the case workflow. You cannot configure it here like in workspaces. Instead please just assign the correct roles to users and groups in the \"Members\" tab."
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:106
+#: ../workspace/browser/templates/content_macros.pt:109
 msgid "From"
 msgstr ""
 
@@ -526,11 +525,11 @@ msgstr ""
 msgid "Functions"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:469
+#: ../workspace/browser/tiles/templates/sidebar.pt:494
 msgid "General"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:296
+#: ../workspace/browser/tiles/templates/sidebar.pt:300
 msgid "General tasks"
 msgstr ""
 
@@ -559,7 +558,7 @@ msgstr ""
 msgid "If checked, users will be removed from workspace"
 msgstr ""
 
-#: ../workspace/browser/templates/add_content.pt:21
+#: ../workspace/browser/templates/add_content.pt:23
 msgid "Image"
 msgstr ""
 
@@ -572,7 +571,7 @@ msgstr ""
 msgid "Images"
 msgstr ""
 
-#: ../userprofile/browser/templates/user_import_form.pt:31
+#: ../userprofile/browser/templates/user_import_form.pt:62
 msgid "Import users from file"
 msgstr ""
 
@@ -601,15 +600,15 @@ msgid "Invitations"
 msgstr ""
 
 #: ../workspace/browser/templates/roster-edit.pt:169
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:118
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:121
 msgid "Invite users to this workspace (via email)"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:150
+#: ../workspace/browser/templates/content_macros.pt:156
 msgid "Invitees"
 msgstr ""
 
-#: ../workspace/browser/add_content.py:89
+#: ../workspace/browser/add_content.py:104
 msgid "Item created."
 msgstr ""
 
@@ -617,19 +616,19 @@ msgstr ""
 msgid "Item edited."
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:630
+#: ../workspace/browser/tiles/sidebar.py:629
 msgid "Items modified last month"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:624
+#: ../workspace/browser/tiles/sidebar.py:623
 msgid "Items modified last week"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:618
+#: ../workspace/browser/tiles/sidebar.py:617
 msgid "Items modified today"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:636
+#: ../workspace/browser/tiles/sidebar.py:635
 msgid "Items since ever"
 msgstr ""
 
@@ -648,19 +647,19 @@ msgstr ""
 msgid "Join now"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:38
+#: ../search/browser/templates/all_results.pt:34
 msgid "Last Modified"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:629
+#: ../workspace/browser/tiles/sidebar.py:628
 msgid "Last Month"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:623
+#: ../workspace/browser/tiles/sidebar.py:622
 msgid "Last Week"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:49
+#: ../search/browser/templates/all_results.pt:45
 msgid "Last month"
 msgstr ""
 
@@ -668,7 +667,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:46
+#: ../search/browser/templates/all_results.pt:42
 msgid "Last week"
 msgstr ""
 
@@ -680,7 +679,7 @@ msgstr ""
 msgid "Leave a comment"
 msgstr ""
 
-#: ../core/browser/tiles/templates/my_documents.pt:8
+#: ../core/browser/tiles/templates/my_documents.pt:9
 #: ../library/profiles/default/actions.xml
 msgid "Library"
 msgstr ""
@@ -728,16 +727,16 @@ msgstr ""
 msgid "Member"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:168
+#: ../workspace/browser/tiles/sidebar.py:178
 msgid "Member(s) added"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:176
+#: ../workspace/browser/tiles/sidebar.py:183
 msgid "Member(s) removed"
 msgstr ""
 
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:20
-#: ../workspace/browser/tiles/templates/sidebar.pt:473
+#: ../workspace/browser/tiles/templates/sidebar.pt:498
 msgid "Members"
 msgstr ""
 
@@ -783,7 +782,7 @@ msgstr ""
 msgid "More information about"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:185
+#: ../search/browser/templates/all_results.pt:175
 #: ../search/browser/templates/file_results.pt:32
 #: ../search/browser/templates/image_results.pt:32
 msgid "More results"
@@ -838,7 +837,7 @@ msgstr ""
 msgid "No such user ${userid}."
 msgstr ""
 
-#: ../layout/browser/templates/tasks-tile.pt:9
+#: ../layout/browser/templates/tasks-tile.pt:11
 msgid "No tasks available"
 msgstr ""
 
@@ -846,7 +845,6 @@ msgstr ""
 msgid "No token id given in sub-path.Use .../@@accept-token/tokenid"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:25
 #: ../workspace/browser/tiles/templates/navigation.pt:36
 msgid "None"
 msgstr ""
@@ -879,7 +877,7 @@ msgstr ""
 msgid "Ok"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:451
+#: ../workspace/browser/tiles/templates/sidebar.pt:476
 msgid "Older events"
 msgstr ""
 
@@ -887,7 +885,7 @@ msgstr ""
 msgid "Only administrators can add workspace members."
 msgstr ""
 
-#: ../todo/browser/templates/todo_view.pt:50
+#: ../todo/browser/templates/todo_view.pt:63
 #: ../workspace/policies.py:23
 msgid "Open"
 msgstr ""
@@ -914,7 +912,7 @@ msgstr ""
 msgid "Page"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:102
+#: ../workspace/browser/tiles/templates/sidebar.pt:106
 msgid "Paste"
 msgstr ""
 
@@ -949,7 +947,11 @@ msgstr ""
 msgid "Pick an initiator"
 msgstr ""
 
-#: ../workspace/browser/add_content.py:48
+#: ../todo/browser/templates/todo_view.pt:64
+msgid "Planned"
+msgstr ""
+
+#: ../workspace/browser/add_content.py:63
 msgid "Please specify which Case Template to use"
 msgstr ""
 
@@ -1005,15 +1007,19 @@ msgstr ""
 msgid "Remove role"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:360
+#: ../todo/browser/templates/todo_view.pt:71
+msgid "Reopen"
+msgstr ""
+
+#: ../workspace/browser/tiles/templates/sidebar.pt:383
 msgid "Reopen milestone"
 msgstr ""
 
-#: ../workspace/browser/templates/add_content.pt:15
+#: ../workspace/browser/templates/add_content.pt:17
 msgid "Rich text"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:189
+#: ../workspace/browser/tiles/sidebar.py:190
 msgid "Role updated"
 msgstr ""
 
@@ -1021,13 +1027,13 @@ msgstr ""
 msgid "Roster updated."
 msgstr ""
 
-#: ../todo/browser/templates/todo_view.pt:56
+#: ../todo/browser/templates/todo_view.pt:77
 #: ../userprofile/browser/templates/userprofile-edit.pt:47
 #: ../workspace/basecontent/document.py:73
 msgid "Save"
 msgstr ""
 
-#: ../workspace/basecontent/templates/event_view.pt:86
+#: ../workspace/basecontent/templates/event_view.pt:85
 msgid "Save this document"
 msgstr ""
 
@@ -1053,7 +1059,7 @@ msgstr ""
 msgid "Secret"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:477
+#: ../workspace/browser/tiles/templates/sidebar.pt:502
 msgid "Security"
 msgstr ""
 
@@ -1064,7 +1070,7 @@ msgstr ""
 
 #: ../workspace/browser/tiles/templates/navigation.pt:35
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:36
-#: ../workspace/browser/tiles/templates/sidebar.pt:81
+#: ../workspace/browser/tiles/templates/sidebar.pt:85
 msgid "Select all"
 msgstr ""
 
@@ -1096,17 +1102,17 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: ../workspace/basecontent/templates/document_view.pt:37
+#: ../workspace/basecontent/templates/document_view.pt:40
 msgid "Share"
 msgstr ""
 
-#: ../workspace/basecontent/templates/document_view.pt:37
+#: ../workspace/basecontent/templates/document_view.pt:40
 msgid "Share this document"
 msgstr ""
 
 #: ../todo/browser/templates/todo_view.pt:43
-#: ../workspace/basecontent/templates/document_view.pt:38
-#: ../workspace/basecontent/templates/event_view.pt:63
+#: ../workspace/basecontent/templates/document_view.pt:41
+#: ../workspace/basecontent/templates/event_view.pt:62
 msgid "Show extra metadata fields"
 msgstr ""
 
@@ -1126,12 +1132,12 @@ msgstr ""
 msgid "Start date should be lower than end date"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:417
-msgid "Starts"
-msgstr ""
-
 #: ../network/browser/templates/author.pt:29
 msgid "Status updates by ${fullname}:"
+msgstr ""
+
+#: ../layout/browser/templates/dashboard.pt:21
+msgid "Task centric view"
 msgstr ""
 
 #: ../todo/utils.py:31
@@ -1142,6 +1148,7 @@ msgstr ""
 msgid "Task title"
 msgstr ""
 
+#: ../layout/browser/templates/tasks-tile.pt:10
 #: ../workspace/browser/tiles/templates/workspace-tabs-tile.pt:22
 msgid "Tasks"
 msgstr ""
@@ -1154,7 +1161,7 @@ msgstr ""
 msgid "Telephone Number"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:158
+#: ../workspace/browser/templates/content_macros.pt:164
 msgid "Tentative"
 msgstr ""
 
@@ -1274,7 +1281,7 @@ msgstr ""
 msgid "The workspace will only be accessible for team members. Any member can add a new team member. Once you're in the team, you can do pretty much anything. Nothing in this group will ever be visible to non-members."
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:294
+#: ../workspace/browser/tiles/sidebar.py:293
 msgid "There was a problem updating the content: %s."
 msgstr ""
 
@@ -1282,7 +1289,7 @@ msgstr ""
 msgid "There was a problem: %s"
 msgstr ""
 
-#: ../workspace/browser/add_content.py:95
+#: ../workspace/browser/add_content.py:110
 #: ../workspace/browser/edit_content.py:38
 msgid "There was a problem: %s."
 msgstr ""
@@ -1307,11 +1314,11 @@ msgstr ""
 msgid "Timeline"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:138
+#: ../workspace/browser/templates/content_macros.pt:144
 msgid "Timezone"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:123
+#: ../workspace/browser/templates/content_macros.pt:127
 msgid "To"
 msgstr ""
 
@@ -1319,8 +1326,8 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:43
-#: ../workspace/browser/tiles/sidebar.py:617
+#: ../search/browser/templates/all_results.pt:39
+#: ../workspace/browser/tiles/sidebar.py:616
 msgid "Today"
 msgstr ""
 
@@ -1328,8 +1335,8 @@ msgid "Todo"
 msgstr ""
 
 #: ../todo/browser/templates/todo_view.pt:43
-#: ../workspace/basecontent/templates/document_view.pt:38
-#: ../workspace/basecontent/templates/event_view.pt:63
+#: ../workspace/basecontent/templates/document_view.pt:41
+#: ../workspace/basecontent/templates/event_view.pt:62
 msgid "Toggle extra metadata"
 msgstr ""
 
@@ -1338,15 +1345,15 @@ msgid "Token no longer valid"
 msgstr ""
 
 #: ../workspace/browser/templates/roster-edit.pt:176
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:124
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:127
 msgid "Transfer members to another workspace."
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:367
+#: ../workspace/browser/tiles/templates/sidebar.pt:390
 msgid "Unassigned"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:156
+#: ../workspace/browser/templates/content_macros.pt:162
 msgid "Undecided"
 msgstr ""
 
@@ -1354,7 +1361,7 @@ msgstr ""
 msgid "Unfollow"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:195
+#: ../workspace/browser/tiles/sidebar.py:193
 msgid "Unknown function"
 msgstr ""
 
@@ -1362,12 +1369,12 @@ msgstr ""
 msgid "Unlike"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/events.pt:9
-#: ../workspace/browser/tiles/templates/sidebar.pt:400
+#: ../workspace/browser/tiles/templates/events.pt:10
+#: ../workspace/browser/tiles/templates/sidebar.pt:423
 msgid "Upcoming events"
 msgstr ""
 
-#: ../userprofile/browser/templates/user_import_form.pt:25
+#: ../userprofile/browser/templates/user_import_form.pt:56
 msgid "Update details for existing users (matching on username)"
 msgstr ""
 
@@ -1376,8 +1383,12 @@ msgstr ""
 msgid "Updates"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:244
+#: ../workspace/browser/tiles/templates/sidebar.pt:248
 msgid "Upload file(s)"
+msgstr ""
+
+#: ../userprofile/browser/templates/user_import_form.pt:18
+msgid "User profile management"
 msgstr ""
 
 #: ../microblog/interfaces.py:17
@@ -1443,7 +1454,7 @@ msgstr ""
 msgid "Workspace policy"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:247
+#: ../workspace/browser/tiles/sidebar.py:246
 msgid "Workspace security policy changes saved"
 msgstr ""
 
@@ -1472,7 +1483,7 @@ msgstr ""
 msgid "You can become a member of this workspace"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:160
+#: ../workspace/browser/tiles/sidebar.py:161
 msgid "You do not have permission to change the workspace policy"
 msgstr ""
 
@@ -1514,6 +1525,11 @@ msgstr "Cases"
 msgid "date"
 msgstr ""
 
+#. Default: "Start time should be lower than end time. The system set the end time to: ${date}"
+#: ../workspace/browser/add_content.py:164
+msgid "dates_hijacked"
+msgstr ""
+
 #: ../workspace/browser/tiles/templates/navigation.pt:21
 #: ../workspace/browser/tiles/templates/sidebar.pt:37
 msgid "document type"
@@ -1525,7 +1541,7 @@ msgid "download"
 msgstr ""
 
 #. Default: "Drop files here or click to browse..."
-#: ../workspace/browser/tiles/sidebar.py:310
+#: ../workspace/browser/tiles/sidebar.py:309
 msgid "drop_files_here"
 msgstr ""
 
@@ -1545,7 +1561,7 @@ msgid "expand/reduce sidebar"
 msgstr ""
 
 #. Default: "External visibility"
-#: ../workspace/browser/tiles/sidebar.py:215
+#: ../workspace/browser/tiles/sidebar.py:214
 msgid "external_visibility_label"
 msgstr ""
 
@@ -1584,14 +1600,14 @@ msgstr ""
 msgid "invititations"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:87
+#: ../search/browser/templates/all_results.pt:77
 #: ../search/browser/templates/image_results.pt:14
 #: ../search/browser/templates/people_results.pt:14
 msgid "items matched your search."
 msgstr ""
 
 #. Default: "Join policy"
-#: ../workspace/browser/tiles/sidebar.py:214
+#: ../workspace/browser/tiles/sidebar.py:213
 msgid "join_policy_label"
 msgstr ""
 
@@ -1609,13 +1625,13 @@ msgstr ""
 msgid "label_name"
 msgstr ""
 
-#. Default: "News"
-#: ../layout/browser/templates/news-tile.pt:8
+#. Default: "<a href=\"${context/portal_url}/library/news\">News</a>"
+#: ../layout/browser/templates/news-tile.pt:9
 msgid "label_news"
 msgstr ""
 
 #. Default: "No events available"
-#: ../workspace/browser/tiles/templates/sidebar.pt:460
+#: ../workspace/browser/tiles/templates/sidebar.pt:485
 msgid "label_no_events_available"
 msgstr ""
 
@@ -1665,36 +1681,36 @@ msgid "leave_a_comment"
 msgstr ""
 
 #. Default: "More sharing options coming soon"
-#: ../workspace/basecontent/templates/document_view.pt:111
+#: ../workspace/basecontent/templates/document_view.pt:115
 msgid "more_sharing_soon"
 msgstr ""
 
 #. Default: "No tasks created yet"
-#: ../workspace/browser/tiles/templates/sidebar.pt:298
+#: ../workspace/browser/tiles/templates/sidebar.pt:302
 msgid "no-task-found"
 msgstr ""
 
 #. Default: "${no_members} Members"
-#: ../workspace/workspacefolder.py:167
+#: ../workspace/workspacefolder.py:172
 msgid "number_of_members"
 msgstr ""
 
 #. Default: "Participant policy"
-#: ../workspace/browser/tiles/sidebar.py:217
+#: ../workspace/browser/tiles/sidebar.py:216
 msgid "participant_policy_label"
 msgstr ""
 
 #. Default: "Description"
-#: ../workspace/basecontent/templates/event_view.pt:101
+#: ../workspace/basecontent/templates/event_view.pt:100
 msgid "placeholder"
 msgstr ""
 
-#: ../workspace/browser/tiles/workspaces.py:109
+#: ../workspace/browser/tiles/workspaces.py:120
 msgid "posted"
 msgstr ""
 
 #. Default: "Read more..."
-#: ../layout/browser/templates/news-tile.pt:19
+#: ../layout/browser/templates/news-tile.pt:20
 #: ../library/browser/templates/library.html:148
 msgid "read-more"
 msgstr ""
@@ -1706,13 +1722,13 @@ msgstr ""
 
 #. Default: "All"
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:36
-#: ../workspace/browser/tiles/templates/sidebar.pt:81
+#: ../workspace/browser/tiles/templates/sidebar.pt:85
 msgid "select_all"
 msgstr ""
 
 #. Default: "None"
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:37
-#: ../workspace/browser/tiles/templates/sidebar.pt:82
+#: ../workspace/browser/tiles/templates/sidebar.pt:86
 msgid "select_none"
 msgstr ""
 
@@ -1724,6 +1740,16 @@ msgstr ""
 #: ../workspace/browser/tiles/templates/sidebar.pt:35
 msgid "tag"
 msgstr ""
+
+#. Cases
+#: ../layout/browser/templates/dashboard.pt
+msgid "tile_ploneintranet.workspace.case"
+msgstr "Cases"
+
+#. Workspaces
+#: ../layout/browser/templates/dashboard.pt
+msgid "tile_ploneintranet.workspace.workspacefolder"
+msgstr "Workspaces"
 
 #: ../network/browser/templates/maxiauthor_provider.pt:72
 #: ../network/browser/templates/miniauthor_provider.pt:38

--- a/src/ploneintranet/core/locales/es/LC_MESSAGES/ploneintranet.po
+++ b/src/ploneintranet/core/locales/es/LC_MESSAGES/ploneintranet.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone Intranet\n"
-"POT-Creation-Date: 2015-08-28 08:33+0000\n"
+"POT-Creation-Date: 2015-10-01 12:49+0000\n"
 "PO-Revision-Date: 2015-05-23 00:20+0000\n"
 "Last-Translator: Leonardo J. Caballero G. <leonardocaballero@gmail.com>\n"
 "Language-Team: Spanish (http://www.transifex.com/projects/p/plone-intranet/language/es/)\n"
@@ -54,11 +54,15 @@ msgstr "Un usuario (o un grupo) asignado a esta tarea"
 msgid "A user with this username already exists"
 msgstr ""
 
+#: ../layout/browser/templates/dashboard.pt:18
+msgid "Activity centric view"
+msgstr ""
+
 #: ../messaging/browser/messaging.py:26
 msgid "Add a comment"
 msgstr "Agregar un comentario"
 
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:91
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:94
 msgid "Add group"
 msgstr ""
 
@@ -75,7 +79,7 @@ msgstr "Agregar portlet de últimas noticias"
 msgid "Add tags"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:88
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:91
 msgid "Add user"
 msgstr ""
 
@@ -92,47 +96,46 @@ msgid "Admin-Managed"
 msgstr "Gestionado por el Administador"
 
 #: ../workspace/browser/templates/roster-edit.pt:167
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:116
-#: ../workspace/browser/tiles/templates/sidebar.pt:481
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:119
+#: ../workspace/browser/tiles/templates/sidebar.pt:506
 msgid "Advanced"
 msgstr "Avanzado"
 
 #: ../workspace/browser/templates/roster-edit.pt:183
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:130
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:133
 msgid "Advanced permissions"
 msgstr "Permisos avanzados"
 
-#: ../search/browser/templates/all_results.pt:24
 #: ../search/browser/templates/search_template.pt:24
 #: ../workspace/browser/tiles/templates/navigation.pt:35
 msgid "All"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:385
+#: ../workspace/browser/tiles/sidebar.py:384
 msgid "All Authors"
 msgstr "Todos los autores"
 
-#: ../workspace/browser/tiles/sidebar.py:381
+#: ../workspace/browser/tiles/sidebar.py:380
 msgid "All Dates"
 msgstr "Todos las fechas"
 
-#: ../workspace/browser/tiles/sidebar.py:389
+#: ../workspace/browser/tiles/sidebar.py:388
 msgid "All Letters"
 msgstr "Todos las cartas"
 
-#: ../workspace/browser/tiles/sidebar.py:383
+#: ../workspace/browser/tiles/sidebar.py:382
 msgid "All Tags"
 msgstr "Todos las etiquetas"
 
-#: ../workspace/browser/tiles/sidebar.py:635
+#: ../workspace/browser/tiles/sidebar.py:634
 msgid "All Time"
 msgstr "Toda la hora"
 
-#: ../workspace/browser/tiles/sidebar.py:387
+#: ../workspace/browser/tiles/sidebar.py:386
 msgid "All Types"
 msgstr "Todos los tipos"
 
-#: ../workspace/browser/tiles/events.py:49
+#: ../workspace/browser/tiles/events.py:52
 msgid "All day"
 msgstr ""
 
@@ -156,7 +159,7 @@ msgstr ""
 msgid "Any logged-in user is allowed to join the group and participate. Anything in this group is visible for any logged-in user, even if they're not a member."
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:40
+#: ../search/browser/templates/all_results.pt:36
 msgid "Any modification date"
 msgstr ""
 
@@ -183,15 +186,15 @@ msgstr "Adjuntar un archivo"
 msgid "Attach a file (or create a picture)"
 msgstr "Adjuntar un archivo (o cree una imagen)"
 
-#: ../workspace/basecontent/templates/event_view.pt:60
+#: ../workspace/basecontent/templates/event_view.pt:59
 msgid "Attach documents"
 msgstr ""
 
-#: ../workspace/basecontent/templates/event_view.pt:60
+#: ../workspace/basecontent/templates/event_view.pt:59
 msgid "Attachments"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:286
+#: ../workspace/browser/tiles/sidebar.py:285
 msgid "Attributes changed."
 msgstr ""
 
@@ -199,19 +202,19 @@ msgstr ""
 msgid "Author name (for display)"
 msgstr "Nombre de autor (para mostrar)"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:200
+#: ../workspace/browser/tiles/templates/sidebar.pt:204
 msgid "Author of this document"
 msgstr ""
 
-#: ../userprofile/browser/templates/user_import_form.pt:39
+#: ../userprofile/browser/templates/user_import_form.pt:70
 msgid "Available fields/columns"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:391
+#: ../workspace/browser/tiles/sidebar.py:390
 msgid "Back"
 msgstr "Volver"
 
-#: ../search/browser/templates/all_results.pt:52
+#: ../search/browser/templates/all_results.pt:48
 msgid "Before last month"
 msgstr ""
 
@@ -219,16 +222,12 @@ msgstr ""
 msgid "Biography"
 msgstr ""
 
-#: ../userprofile/browser/templates/user_import_form.pt:13
-msgid "Bulk import users"
-msgstr ""
-
 msgid "CSV document"
 msgstr ""
 
 #: ../messaging/browser/send-message.pt:63
 #: ../workspace/basecontent/document.py:77
-#: ../workspace/browser/templates/add_content.pt:36
+#: ../workspace/browser/templates/add_content.pt:38
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -253,7 +252,7 @@ msgid "Change role of member"
 msgstr ""
 
 #: ../todo/browser/templates/todo_view.pt:48
-#: ../workspace/basecontent/templates/document_view.pt:41
+#: ../workspace/basecontent/templates/document_view.pt:44
 msgid "Change the workflow state"
 msgstr ""
 
@@ -261,11 +260,11 @@ msgstr ""
 msgid "Changes applied"
 msgstr "Cambios aplicados."
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:357
+#: ../workspace/browser/tiles/templates/sidebar.pt:380
 msgid "Close milestone"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:157
+#: ../workspace/browser/templates/content_macros.pt:163
 msgid "Confirmed"
 msgstr ""
 
@@ -282,25 +281,25 @@ msgstr "Consumir"
 msgid "Contact"
 msgstr ""
 
-#: ../userprofile/browser/tiles/templates/contacts_search.pt:9
+#: ../userprofile/browser/tiles/templates/contacts_search.pt:10
 msgid "Contacts"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:27
+#: ../search/browser/templates/all_results.pt:23
 msgid "Content types"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:95
+#: ../workspace/browser/tiles/templates/sidebar.pt:99
 msgid "Copy"
 msgstr "Copiar"
 
-#: ../workspace/browser/templates/add_content.pt:33
+#: ../workspace/browser/templates/add_content.pt:35
 #: ../workspace/browser/templates/add_folder.pt:20
 #: ../workspace/browser/templates/add_task.pt:24
 msgid "Create"
 msgstr "Crear"
 
-#: ../workspace/browser/templates/workspaces.pt:24
+#: ../workspace/browser/templates/workspaces.pt:30
 msgid "Create a new workspace"
 msgstr ""
 
@@ -314,11 +313,11 @@ msgid "Create event"
 msgstr ""
 
 #: ../workspace/browser/templates/add_folder.pt:7
-#: ../workspace/browser/tiles/templates/sidebar.pt:221
+#: ../workspace/browser/tiles/templates/sidebar.pt:225
 msgid "Create folder"
 msgstr "Crear carpeta"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:289
+#: ../workspace/browser/tiles/templates/sidebar.pt:293
 msgid "Create new task"
 msgstr ""
 
@@ -328,7 +327,7 @@ msgstr ""
 
 #: ../theme/browser/templates/workspaces.pt:25
 #: ../workspace/browser/templates/workspace-add.pt:11
-#: ../workspace/browser/templates/workspaces.pt:24
+#: ../workspace/browser/templates/workspaces.pt:30
 msgid "Create workspace"
 msgstr ""
 
@@ -336,30 +335,30 @@ msgstr ""
 msgid "Creation date"
 msgstr "Fecha de creación"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:88
+#: ../workspace/browser/tiles/templates/sidebar.pt:92
 msgid "Cut"
 msgstr "Cortar"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:203
+#: ../workspace/browser/tiles/templates/sidebar.pt:207
 msgid "Date and time of the latest modification"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:159
+#: ../workspace/browser/templates/content_macros.pt:165
 msgid "Declined"
 msgstr ""
 
 #: ../todo/browser/templates/todo_view.pt:34
-#: ../workspace/basecontent/templates/document_view.pt:35
-#: ../workspace/basecontent/templates/event_view.pt:50
+#: ../workspace/basecontent/templates/document_view.pt:38
+#: ../workspace/basecontent/templates/event_view.pt:49
 msgid "Delete"
 msgstr "Eliminar"
 
 #: ../todo/browser/templates/todo_view.pt:34
-#: ../workspace/basecontent/templates/document_view.pt:35
+#: ../workspace/basecontent/templates/document_view.pt:38
 msgid "Delete this document"
 msgstr ""
 
-#: ../workspace/basecontent/templates/event_view.pt:50
+#: ../workspace/basecontent/templates/event_view.pt:49
 msgid "Delete this event"
 msgstr ""
 
@@ -371,22 +370,22 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: ../workspace/browser/templates/add_content.pt:27
+#: ../workspace/browser/templates/add_content.pt:29
 #: ../workspace/browser/templates/add_folder.pt:15
 msgid "Description for search results (Optional)"
 msgstr "Descripción de resultados de búsqueda (opcional)"
 
 #: ../workspace/browser/tiles/templates/navigation.pt:36
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:37
-#: ../workspace/browser/tiles/templates/sidebar.pt:82
+#: ../workspace/browser/tiles/templates/sidebar.pt:86
 msgid "Deslect all"
 msgstr "Deseleccione todos"
 
-#: ../search/browser/templates/all_results.pt:91
+#: ../search/browser/templates/all_results.pt:81
 msgid "Did you mean"
 msgstr ""
 
-#: ../workspace/browser/templates/add_content.pt:25
+#: ../workspace/browser/templates/add_content.pt:27
 msgid "Document title"
 msgstr "Título del documento"
 
@@ -394,11 +393,11 @@ msgstr "Título del documento"
 msgid "Documents"
 msgstr "Documentos"
 
-#: ../todo/browser/templates/todo_view.pt:51
+#: ../todo/browser/templates/todo_view.pt:65
 msgid "Done"
 msgstr ""
 
-#: ../workspace/basecontent/templates/document_view.pt:109
+#: ../workspace/basecontent/templates/document_view.pt:113
 msgid "Download as"
 msgstr ""
 
@@ -415,7 +414,7 @@ msgstr ""
 msgid "Edit latest news portlet"
 msgstr "Editar portlet de últimas noticias"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:146
+#: ../workspace/browser/tiles/templates/sidebar.pt:150
 msgid "Edit name/description"
 msgstr ""
 
@@ -425,10 +424,6 @@ msgstr ""
 
 #: ../userprofile/content/userprofile.py:45
 msgid "Email"
-msgstr ""
-
-#: ../workspace/browser/tiles/templates/sidebar.pt:422
-msgid "Ended"
 msgstr ""
 
 #: ../workspace/browser/templates/add_event.pt:25
@@ -465,6 +460,10 @@ msgstr ""
 #: ../core/browser/stream.py:56
 msgid "Explore"
 msgstr "Explorar"
+
+#: ../userprofile/sync.py:80
+msgid "External property sync complete."
+msgstr ""
 
 msgid "File"
 msgstr ""
@@ -514,7 +513,7 @@ msgstr ""
 msgid "For cases, security is managed by the case workflow. You cannot configure it here like in workspaces. Instead please just assign the correct roles to users and groups in the \"Members\" tab."
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:106
+#: ../workspace/browser/templates/content_macros.pt:109
 msgid "From"
 msgstr ""
 
@@ -530,11 +529,11 @@ msgstr ""
 msgid "Functions"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:469
+#: ../workspace/browser/tiles/templates/sidebar.pt:494
 msgid "General"
 msgstr "General"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:296
+#: ../workspace/browser/tiles/templates/sidebar.pt:300
 msgid "General tasks"
 msgstr ""
 
@@ -563,7 +562,7 @@ msgstr ""
 msgid "If checked, users will be removed from workspace"
 msgstr "Si se marca, los usuarios se eliminarán del espacio de trabajo"
 
-#: ../workspace/browser/templates/add_content.pt:21
+#: ../workspace/browser/templates/add_content.pt:23
 msgid "Image"
 msgstr "Imagen"
 
@@ -576,7 +575,7 @@ msgstr ""
 msgid "Images"
 msgstr ""
 
-#: ../userprofile/browser/templates/user_import_form.pt:31
+#: ../userprofile/browser/templates/user_import_form.pt:62
 msgid "Import users from file"
 msgstr ""
 
@@ -605,15 +604,15 @@ msgid "Invitations"
 msgstr "Invitaciones"
 
 #: ../workspace/browser/templates/roster-edit.pt:169
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:118
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:121
 msgid "Invite users to this workspace (via email)"
 msgstr "Invite a los usuarios a este espacio de trabajo (por correo electrónico)"
 
-#: ../workspace/browser/templates/content_macros.pt:150
+#: ../workspace/browser/templates/content_macros.pt:156
 msgid "Invitees"
 msgstr ""
 
-#: ../workspace/browser/add_content.py:89
+#: ../workspace/browser/add_content.py:104
 msgid "Item created."
 msgstr ""
 
@@ -621,19 +620,19 @@ msgstr ""
 msgid "Item edited."
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:630
+#: ../workspace/browser/tiles/sidebar.py:629
 msgid "Items modified last month"
 msgstr "Elementos modificados el último mes"
 
-#: ../workspace/browser/tiles/sidebar.py:624
+#: ../workspace/browser/tiles/sidebar.py:623
 msgid "Items modified last week"
 msgstr "Elementos modificados la última semana"
 
-#: ../workspace/browser/tiles/sidebar.py:618
+#: ../workspace/browser/tiles/sidebar.py:617
 msgid "Items modified today"
 msgstr "Elementos modificados hoy"
 
-#: ../workspace/browser/tiles/sidebar.py:636
+#: ../workspace/browser/tiles/sidebar.py:635
 msgid "Items since ever"
 msgstr "Elementos desde entonces"
 
@@ -652,19 +651,19 @@ msgstr ""
 msgid "Join now"
 msgstr "Únase ahora"
 
-#: ../search/browser/templates/all_results.pt:38
+#: ../search/browser/templates/all_results.pt:34
 msgid "Last Modified"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:629
+#: ../workspace/browser/tiles/sidebar.py:628
 msgid "Last Month"
 msgstr "Último mes"
 
-#: ../workspace/browser/tiles/sidebar.py:623
+#: ../workspace/browser/tiles/sidebar.py:622
 msgid "Last Week"
 msgstr "Último semana"
 
-#: ../search/browser/templates/all_results.pt:49
+#: ../search/browser/templates/all_results.pt:45
 msgid "Last month"
 msgstr ""
 
@@ -672,7 +671,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:46
+#: ../search/browser/templates/all_results.pt:42
 msgid "Last week"
 msgstr ""
 
@@ -684,7 +683,7 @@ msgstr "Últimas noticias"
 msgid "Leave a comment"
 msgstr "Dejar un comentario"
 
-#: ../core/browser/tiles/templates/my_documents.pt:8
+#: ../core/browser/tiles/templates/my_documents.pt:9
 #: ../library/profiles/default/actions.xml
 msgid "Library"
 msgstr ""
@@ -732,16 +731,16 @@ msgstr "Marcar el contenido como 'Debe leer' para todos los usuarios."
 msgid "Member"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:168
+#: ../workspace/browser/tiles/sidebar.py:178
 msgid "Member(s) added"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:176
+#: ../workspace/browser/tiles/sidebar.py:183
 msgid "Member(s) removed"
 msgstr ""
 
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:20
-#: ../workspace/browser/tiles/templates/sidebar.pt:473
+#: ../workspace/browser/tiles/templates/sidebar.pt:498
 msgid "Members"
 msgstr "Miembros"
 
@@ -787,7 +786,7 @@ msgstr "Moderado"
 msgid "More information about"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:185
+#: ../search/browser/templates/all_results.pt:175
 #: ../search/browser/templates/file_results.pt:32
 #: ../search/browser/templates/image_results.pt:32
 msgid "More results"
@@ -842,7 +841,7 @@ msgstr "Sin notificaciones pendientes"
 msgid "No such user ${userid}."
 msgstr "No existe usuario ${userid}."
 
-#: ../layout/browser/templates/tasks-tile.pt:9
+#: ../layout/browser/templates/tasks-tile.pt:11
 msgid "No tasks available"
 msgstr ""
 
@@ -850,7 +849,6 @@ msgstr ""
 msgid "No token id given in sub-path.Use .../@@accept-token/tokenid"
 msgstr "No hay id del token dado en el sub-ruta. Utilice .../@@accept-token/tokenid"
 
-#: ../search/browser/templates/all_results.pt:25
 #: ../workspace/browser/tiles/templates/navigation.pt:36
 msgid "None"
 msgstr ""
@@ -883,7 +881,7 @@ msgstr "Oh, muchacho, madre mía, que ya es un miembro"
 msgid "Ok"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:451
+#: ../workspace/browser/tiles/templates/sidebar.pt:476
 msgid "Older events"
 msgstr "Antiguos eventos"
 
@@ -891,7 +889,7 @@ msgstr "Antiguos eventos"
 msgid "Only administrators can add workspace members."
 msgstr "Solamente los administradores pueden agregar miembros al espacio de trabajo."
 
-#: ../todo/browser/templates/todo_view.pt:50
+#: ../todo/browser/templates/todo_view.pt:63
 #: ../workspace/policies.py:23
 msgid "Open"
 msgstr "Abrir"
@@ -918,7 +916,7 @@ msgstr "PDF no ha sido generado aun"
 msgid "Page"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:102
+#: ../workspace/browser/tiles/templates/sidebar.pt:106
 msgid "Paste"
 msgstr "Pegar"
 
@@ -953,7 +951,11 @@ msgstr ""
 msgid "Pick an initiator"
 msgstr ""
 
-#: ../workspace/browser/add_content.py:48
+#: ../todo/browser/templates/todo_view.pt:64
+msgid "Planned"
+msgstr ""
+
+#: ../workspace/browser/add_content.py:63
 msgid "Please specify which Case Template to use"
 msgstr ""
 
@@ -1009,15 +1011,19 @@ msgstr ""
 msgid "Remove role"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:360
+#: ../todo/browser/templates/todo_view.pt:71
+msgid "Reopen"
+msgstr ""
+
+#: ../workspace/browser/tiles/templates/sidebar.pt:383
 msgid "Reopen milestone"
 msgstr ""
 
-#: ../workspace/browser/templates/add_content.pt:15
+#: ../workspace/browser/templates/add_content.pt:17
 msgid "Rich text"
 msgstr "Texto enriquecido"
 
-#: ../workspace/browser/tiles/sidebar.py:189
+#: ../workspace/browser/tiles/sidebar.py:190
 msgid "Role updated"
 msgstr ""
 
@@ -1025,13 +1031,13 @@ msgstr ""
 msgid "Roster updated."
 msgstr "Lista de miembros actualizada."
 
-#: ../todo/browser/templates/todo_view.pt:56
+#: ../todo/browser/templates/todo_view.pt:77
 #: ../userprofile/browser/templates/userprofile-edit.pt:47
 #: ../workspace/basecontent/document.py:73
 msgid "Save"
 msgstr "Guardar"
 
-#: ../workspace/basecontent/templates/event_view.pt:86
+#: ../workspace/basecontent/templates/event_view.pt:85
 msgid "Save this document"
 msgstr ""
 
@@ -1057,7 +1063,7 @@ msgstr ""
 msgid "Secret"
 msgstr "Secreto"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:477
+#: ../workspace/browser/tiles/templates/sidebar.pt:502
 msgid "Security"
 msgstr "Seguridad"
 
@@ -1068,7 +1074,7 @@ msgstr "Seleccione"
 
 #: ../workspace/browser/tiles/templates/navigation.pt:35
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:36
-#: ../workspace/browser/tiles/templates/sidebar.pt:81
+#: ../workspace/browser/tiles/templates/sidebar.pt:85
 msgid "Select all"
 msgstr "Seleccione todos"
 
@@ -1100,17 +1106,17 @@ msgstr ""
 msgid "Settings"
 msgstr "Configuración"
 
-#: ../workspace/basecontent/templates/document_view.pt:37
+#: ../workspace/basecontent/templates/document_view.pt:40
 msgid "Share"
 msgstr "Compartir"
 
-#: ../workspace/basecontent/templates/document_view.pt:37
+#: ../workspace/basecontent/templates/document_view.pt:40
 msgid "Share this document"
 msgstr ""
 
 #: ../todo/browser/templates/todo_view.pt:43
-#: ../workspace/basecontent/templates/document_view.pt:38
-#: ../workspace/basecontent/templates/event_view.pt:63
+#: ../workspace/basecontent/templates/document_view.pt:41
+#: ../workspace/basecontent/templates/event_view.pt:62
 msgid "Show extra metadata fields"
 msgstr ""
 
@@ -1130,13 +1136,13 @@ msgstr ""
 msgid "Start date should be lower than end date"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:417
-msgid "Starts"
-msgstr "Inicio"
-
 #: ../network/browser/templates/author.pt:29
 msgid "Status updates by ${fullname}:"
 msgstr "Las actualizaciones de estado para ${fullname}:"
+
+#: ../layout/browser/templates/dashboard.pt:21
+msgid "Task centric view"
+msgstr ""
 
 #: ../todo/utils.py:31
 msgid "Task state changed"
@@ -1146,6 +1152,7 @@ msgstr ""
 msgid "Task title"
 msgstr ""
 
+#: ../layout/browser/templates/tasks-tile.pt:10
 #: ../workspace/browser/tiles/templates/workspace-tabs-tile.pt:22
 msgid "Tasks"
 msgstr "Tareas"
@@ -1158,7 +1165,7 @@ msgstr "Gestionado por el equipo"
 msgid "Telephone Number"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:158
+#: ../workspace/browser/templates/content_macros.pt:164
 msgid "Tentative"
 msgstr ""
 
@@ -1278,7 +1285,7 @@ msgstr ""
 msgid "The workspace will only be accessible for team members. Any member can add a new team member. Once you're in the team, you can do pretty much anything. Nothing in this group will ever be visible to non-members."
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:294
+#: ../workspace/browser/tiles/sidebar.py:293
 msgid "There was a problem updating the content: %s."
 msgstr ""
 
@@ -1286,7 +1293,7 @@ msgstr ""
 msgid "There was a problem: %s"
 msgstr ""
 
-#: ../workspace/browser/add_content.py:95
+#: ../workspace/browser/add_content.py:110
 #: ../workspace/browser/edit_content.py:38
 msgid "There was a problem: %s."
 msgstr ""
@@ -1311,11 +1318,11 @@ msgstr ""
 msgid "Timeline"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:138
+#: ../workspace/browser/templates/content_macros.pt:144
 msgid "Timezone"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:123
+#: ../workspace/browser/templates/content_macros.pt:127
 msgid "To"
 msgstr ""
 
@@ -1323,8 +1330,8 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:43
-#: ../workspace/browser/tiles/sidebar.py:617
+#: ../search/browser/templates/all_results.pt:39
+#: ../workspace/browser/tiles/sidebar.py:616
 msgid "Today"
 msgstr "Hoy"
 
@@ -1332,8 +1339,8 @@ msgid "Todo"
 msgstr ""
 
 #: ../todo/browser/templates/todo_view.pt:43
-#: ../workspace/basecontent/templates/document_view.pt:38
-#: ../workspace/basecontent/templates/event_view.pt:63
+#: ../workspace/basecontent/templates/document_view.pt:41
+#: ../workspace/basecontent/templates/event_view.pt:62
 msgid "Toggle extra metadata"
 msgstr ""
 
@@ -1342,15 +1349,15 @@ msgid "Token no longer valid"
 msgstr "Token no mas valido"
 
 #: ../workspace/browser/templates/roster-edit.pt:176
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:124
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:127
 msgid "Transfer members to another workspace."
 msgstr "Transferir miembros a otro espacio de trabajo."
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:367
+#: ../workspace/browser/tiles/templates/sidebar.pt:390
 msgid "Unassigned"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:156
+#: ../workspace/browser/templates/content_macros.pt:162
 msgid "Undecided"
 msgstr ""
 
@@ -1358,7 +1365,7 @@ msgstr ""
 msgid "Unfollow"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:195
+#: ../workspace/browser/tiles/sidebar.py:193
 msgid "Unknown function"
 msgstr ""
 
@@ -1366,12 +1373,12 @@ msgstr ""
 msgid "Unlike"
 msgstr "No gustar"
 
-#: ../workspace/browser/tiles/templates/events.pt:9
-#: ../workspace/browser/tiles/templates/sidebar.pt:400
+#: ../workspace/browser/tiles/templates/events.pt:10
+#: ../workspace/browser/tiles/templates/sidebar.pt:423
 msgid "Upcoming events"
 msgstr "Próximos eventos"
 
-#: ../userprofile/browser/templates/user_import_form.pt:25
+#: ../userprofile/browser/templates/user_import_form.pt:56
 msgid "Update details for existing users (matching on username)"
 msgstr ""
 
@@ -1380,9 +1387,13 @@ msgstr ""
 msgid "Updates"
 msgstr "Actualizaciones"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:244
+#: ../workspace/browser/tiles/templates/sidebar.pt:248
 msgid "Upload file(s)"
 msgstr "Cargar archivo(s)"
+
+#: ../userprofile/browser/templates/user_import_form.pt:18
+msgid "User profile management"
+msgstr ""
 
 #: ../microblog/interfaces.py:17
 msgid "Userid"
@@ -1447,7 +1458,7 @@ msgstr "Miembros del espacio de trabajo pueden leer, agregar, publicar contenido
 msgid "Workspace policy"
 msgstr "Políticas del espacio de trabajo"
 
-#: ../workspace/browser/tiles/sidebar.py:247
+#: ../workspace/browser/tiles/sidebar.py:246
 msgid "Workspace security policy changes saved"
 msgstr "Las cambios de las políticas de seguridad del espacio de trabajo se guardadas."
 
@@ -1476,7 +1487,7 @@ msgstr ""
 msgid "You can become a member of this workspace"
 msgstr "Usted puede convertirse en un miembro de este espacio de trabajo"
 
-#: ../workspace/browser/tiles/sidebar.py:160
+#: ../workspace/browser/tiles/sidebar.py:161
 msgid "You do not have permission to change the workspace policy"
 msgstr "Usted no tiene permiso para agregar la cambiar la política de espacio de trabajo"
 
@@ -1518,6 +1529,11 @@ msgstr ""
 msgid "date"
 msgstr "fecha"
 
+#. Default: "Start time should be lower than end time. The system set the end time to: ${date}"
+#: ../workspace/browser/add_content.py:164
+msgid "dates_hijacked"
+msgstr ""
+
 #: ../workspace/browser/tiles/templates/navigation.pt:21
 #: ../workspace/browser/tiles/templates/sidebar.pt:37
 msgid "document type"
@@ -1529,7 +1545,7 @@ msgid "download"
 msgstr ""
 
 #. Default: "Drop files here or click to browse..."
-#: ../workspace/browser/tiles/sidebar.py:310
+#: ../workspace/browser/tiles/sidebar.py:309
 msgid "drop_files_here"
 msgstr "Lanzar los archivos o haga clic para navegarlos..."
 
@@ -1549,7 +1565,7 @@ msgid "expand/reduce sidebar"
 msgstr ""
 
 #. Default: "External visibility"
-#: ../workspace/browser/tiles/sidebar.py:215
+#: ../workspace/browser/tiles/sidebar.py:214
 msgid "external_visibility_label"
 msgstr "Visibilidad externa"
 
@@ -1593,14 +1609,14 @@ msgstr "Cuando la dirección URL del token único es accedido, una cuenta de usu
 msgid "invititations"
 msgstr "Invitaciones"
 
-#: ../search/browser/templates/all_results.pt:87
+#: ../search/browser/templates/all_results.pt:77
 #: ../search/browser/templates/image_results.pt:14
 #: ../search/browser/templates/people_results.pt:14
 msgid "items matched your search."
 msgstr ""
 
 #. Default: "Join policy"
-#: ../workspace/browser/tiles/sidebar.py:214
+#: ../workspace/browser/tiles/sidebar.py:213
 msgid "join_policy_label"
 msgstr "Unir política"
 
@@ -1618,13 +1634,13 @@ msgstr ""
 msgid "label_name"
 msgstr ""
 
-#. Default: "News"
-#: ../layout/browser/templates/news-tile.pt:8
+#. Default: "<a href=\"${context/portal_url}/library/news\">News</a>"
+#: ../layout/browser/templates/news-tile.pt:9
 msgid "label_news"
 msgstr ""
 
 #. Default: "No events available"
-#: ../workspace/browser/tiles/templates/sidebar.pt:460
+#: ../workspace/browser/tiles/templates/sidebar.pt:485
 msgid "label_no_events_available"
 msgstr ""
 
@@ -1674,36 +1690,36 @@ msgid "leave_a_comment"
 msgstr "Dejar un comentario..."
 
 #. Default: "More sharing options coming soon"
-#: ../workspace/basecontent/templates/document_view.pt:111
+#: ../workspace/basecontent/templates/document_view.pt:115
 msgid "more_sharing_soon"
 msgstr ""
 
 #. Default: "No tasks created yet"
-#: ../workspace/browser/tiles/templates/sidebar.pt:298
+#: ../workspace/browser/tiles/templates/sidebar.pt:302
 msgid "no-task-found"
 msgstr "Sin tareas creadas aun"
 
 #. Default: "${no_members} Members"
-#: ../workspace/workspacefolder.py:167
+#: ../workspace/workspacefolder.py:172
 msgid "number_of_members"
 msgstr ""
 
 #. Default: "Participant policy"
-#: ../workspace/browser/tiles/sidebar.py:217
+#: ../workspace/browser/tiles/sidebar.py:216
 msgid "participant_policy_label"
 msgstr "Política de participantes"
 
 #. Default: "Description"
-#: ../workspace/basecontent/templates/event_view.pt:101
+#: ../workspace/basecontent/templates/event_view.pt:100
 msgid "placeholder"
 msgstr ""
 
-#: ../workspace/browser/tiles/workspaces.py:109
+#: ../workspace/browser/tiles/workspaces.py:120
 msgid "posted"
 msgstr "enviado"
 
 #. Default: "Read more..."
-#: ../layout/browser/templates/news-tile.pt:19
+#: ../layout/browser/templates/news-tile.pt:20
 #: ../library/browser/templates/library.html:148
 msgid "read-more"
 msgstr ""
@@ -1715,13 +1731,13 @@ msgstr ""
 
 #. Default: "All"
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:36
-#: ../workspace/browser/tiles/templates/sidebar.pt:81
+#: ../workspace/browser/tiles/templates/sidebar.pt:85
 msgid "select_all"
 msgstr "Todos"
 
 #. Default: "None"
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:37
-#: ../workspace/browser/tiles/templates/sidebar.pt:82
+#: ../workspace/browser/tiles/templates/sidebar.pt:86
 msgid "select_none"
 msgstr "Ninguno"
 
@@ -1733,6 +1749,16 @@ msgstr "La política de participantes de este espacio de trabajo es ${policy_nam
 #: ../workspace/browser/tiles/templates/sidebar.pt:35
 msgid "tag"
 msgstr "etiqueta"
+
+#. Cases
+#: ../layout/browser/templates/dashboard.pt
+msgid "tile_ploneintranet.workspace.case"
+msgstr ""
+
+#. Workspaces
+#: ../layout/browser/templates/dashboard.pt
+msgid "tile_ploneintranet.workspace.workspacefolder"
+msgstr ""
 
 #: ../network/browser/templates/maxiauthor_provider.pt:72
 #: ../network/browser/templates/miniauthor_provider.pt:38

--- a/src/ploneintranet/core/locales/fr/LC_MESSAGES/ploneintranet.po
+++ b/src/ploneintranet/core/locales/fr/LC_MESSAGES/ploneintranet.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone Intranet\n"
-"POT-Creation-Date: 2015-08-28 08:33+0000\n"
+"POT-Creation-Date: 2015-10-01 12:49+0000\n"
 "PO-Revision-Date: 2015-05-22 10:54+0000\n"
 "Last-Translator: gnafou <fmgre-fboi@yahoo.fr>\n"
 "Language-Team: French (http://www.transifex.com/projects/p/plone-intranet/language/fr/)\n"
@@ -55,11 +55,15 @@ msgstr "Un utilisateur (ou un groupe) auquel cette tâche est assignée"
 msgid "A user with this username already exists"
 msgstr ""
 
+#: ../layout/browser/templates/dashboard.pt:18
+msgid "Activity centric view"
+msgstr ""
+
 #: ../messaging/browser/messaging.py:26
 msgid "Add a comment"
 msgstr "Ajouter un commentaire"
 
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:91
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:94
 msgid "Add group"
 msgstr ""
 
@@ -76,7 +80,7 @@ msgstr "Ajouter la portlet des actualités récentes"
 msgid "Add tags"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:88
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:91
 msgid "Add user"
 msgstr ""
 
@@ -93,47 +97,46 @@ msgid "Admin-Managed"
 msgstr "Géré par les administrateurs"
 
 #: ../workspace/browser/templates/roster-edit.pt:167
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:116
-#: ../workspace/browser/tiles/templates/sidebar.pt:481
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:119
+#: ../workspace/browser/tiles/templates/sidebar.pt:506
 msgid "Advanced"
 msgstr "Avancé"
 
 #: ../workspace/browser/templates/roster-edit.pt:183
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:130
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:133
 msgid "Advanced permissions"
 msgstr "Permissions avancées"
 
-#: ../search/browser/templates/all_results.pt:24
 #: ../search/browser/templates/search_template.pt:24
 #: ../workspace/browser/tiles/templates/navigation.pt:35
 msgid "All"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:385
+#: ../workspace/browser/tiles/sidebar.py:384
 msgid "All Authors"
 msgstr "Tous les auteurs"
 
-#: ../workspace/browser/tiles/sidebar.py:381
+#: ../workspace/browser/tiles/sidebar.py:380
 msgid "All Dates"
 msgstr "Toutes les dates"
 
-#: ../workspace/browser/tiles/sidebar.py:389
+#: ../workspace/browser/tiles/sidebar.py:388
 msgid "All Letters"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:383
+#: ../workspace/browser/tiles/sidebar.py:382
 msgid "All Tags"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:635
+#: ../workspace/browser/tiles/sidebar.py:634
 msgid "All Time"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:387
+#: ../workspace/browser/tiles/sidebar.py:386
 msgid "All Types"
 msgstr ""
 
-#: ../workspace/browser/tiles/events.py:49
+#: ../workspace/browser/tiles/events.py:52
 msgid "All day"
 msgstr ""
 
@@ -157,7 +160,7 @@ msgstr ""
 msgid "Any logged-in user is allowed to join the group and participate. Anything in this group is visible for any logged-in user, even if they're not a member."
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:40
+#: ../search/browser/templates/all_results.pt:36
 msgid "Any modification date"
 msgstr ""
 
@@ -184,15 +187,15 @@ msgstr "Joindre un fichier"
 msgid "Attach a file (or create a picture)"
 msgstr "Joindre un fichier ( ou créer une image ) "
 
-#: ../workspace/basecontent/templates/event_view.pt:60
+#: ../workspace/basecontent/templates/event_view.pt:59
 msgid "Attach documents"
 msgstr ""
 
-#: ../workspace/basecontent/templates/event_view.pt:60
+#: ../workspace/basecontent/templates/event_view.pt:59
 msgid "Attachments"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:286
+#: ../workspace/browser/tiles/sidebar.py:285
 msgid "Attributes changed."
 msgstr ""
 
@@ -200,19 +203,19 @@ msgstr ""
 msgid "Author name (for display)"
 msgstr "Nom de l'auteur (pour l'affichage)"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:200
+#: ../workspace/browser/tiles/templates/sidebar.pt:204
 msgid "Author of this document"
 msgstr ""
 
-#: ../userprofile/browser/templates/user_import_form.pt:39
+#: ../userprofile/browser/templates/user_import_form.pt:70
 msgid "Available fields/columns"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:391
+#: ../workspace/browser/tiles/sidebar.py:390
 msgid "Back"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:52
+#: ../search/browser/templates/all_results.pt:48
 msgid "Before last month"
 msgstr ""
 
@@ -220,16 +223,12 @@ msgstr ""
 msgid "Biography"
 msgstr ""
 
-#: ../userprofile/browser/templates/user_import_form.pt:13
-msgid "Bulk import users"
-msgstr ""
-
 msgid "CSV document"
 msgstr ""
 
 #: ../messaging/browser/send-message.pt:63
 #: ../workspace/basecontent/document.py:77
-#: ../workspace/browser/templates/add_content.pt:36
+#: ../workspace/browser/templates/add_content.pt:38
 msgid "Cancel"
 msgstr "Annuler"
 
@@ -254,7 +253,7 @@ msgid "Change role of member"
 msgstr ""
 
 #: ../todo/browser/templates/todo_view.pt:48
-#: ../workspace/basecontent/templates/document_view.pt:41
+#: ../workspace/basecontent/templates/document_view.pt:44
 msgid "Change the workflow state"
 msgstr ""
 
@@ -262,11 +261,11 @@ msgstr ""
 msgid "Changes applied"
 msgstr "Les modifications ont été appliquées"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:357
+#: ../workspace/browser/tiles/templates/sidebar.pt:380
 msgid "Close milestone"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:157
+#: ../workspace/browser/templates/content_macros.pt:163
 msgid "Confirmed"
 msgstr ""
 
@@ -283,25 +282,25 @@ msgstr ""
 msgid "Contact"
 msgstr ""
 
-#: ../userprofile/browser/tiles/templates/contacts_search.pt:9
+#: ../userprofile/browser/tiles/templates/contacts_search.pt:10
 msgid "Contacts"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:27
+#: ../search/browser/templates/all_results.pt:23
 msgid "Content types"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:95
+#: ../workspace/browser/tiles/templates/sidebar.pt:99
 msgid "Copy"
 msgstr "Copier"
 
-#: ../workspace/browser/templates/add_content.pt:33
+#: ../workspace/browser/templates/add_content.pt:35
 #: ../workspace/browser/templates/add_folder.pt:20
 #: ../workspace/browser/templates/add_task.pt:24
 msgid "Create"
 msgstr "Création"
 
-#: ../workspace/browser/templates/workspaces.pt:24
+#: ../workspace/browser/templates/workspaces.pt:30
 msgid "Create a new workspace"
 msgstr ""
 
@@ -315,11 +314,11 @@ msgid "Create event"
 msgstr ""
 
 #: ../workspace/browser/templates/add_folder.pt:7
-#: ../workspace/browser/tiles/templates/sidebar.pt:221
+#: ../workspace/browser/tiles/templates/sidebar.pt:225
 msgid "Create folder"
 msgstr "Créer un dossier"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:289
+#: ../workspace/browser/tiles/templates/sidebar.pt:293
 msgid "Create new task"
 msgstr ""
 
@@ -329,7 +328,7 @@ msgstr ""
 
 #: ../theme/browser/templates/workspaces.pt:25
 #: ../workspace/browser/templates/workspace-add.pt:11
-#: ../workspace/browser/templates/workspaces.pt:24
+#: ../workspace/browser/templates/workspaces.pt:30
 msgid "Create workspace"
 msgstr ""
 
@@ -337,30 +336,30 @@ msgstr ""
 msgid "Creation date"
 msgstr "Date de création"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:88
+#: ../workspace/browser/tiles/templates/sidebar.pt:92
 msgid "Cut"
 msgstr "Couper"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:203
+#: ../workspace/browser/tiles/templates/sidebar.pt:207
 msgid "Date and time of the latest modification"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:159
+#: ../workspace/browser/templates/content_macros.pt:165
 msgid "Declined"
 msgstr ""
 
 #: ../todo/browser/templates/todo_view.pt:34
-#: ../workspace/basecontent/templates/document_view.pt:35
-#: ../workspace/basecontent/templates/event_view.pt:50
+#: ../workspace/basecontent/templates/document_view.pt:38
+#: ../workspace/basecontent/templates/event_view.pt:49
 msgid "Delete"
 msgstr "Supprimer le permis"
 
 #: ../todo/browser/templates/todo_view.pt:34
-#: ../workspace/basecontent/templates/document_view.pt:35
+#: ../workspace/basecontent/templates/document_view.pt:38
 msgid "Delete this document"
 msgstr ""
 
-#: ../workspace/basecontent/templates/event_view.pt:50
+#: ../workspace/basecontent/templates/event_view.pt:49
 msgid "Delete this event"
 msgstr ""
 
@@ -372,22 +371,22 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: ../workspace/browser/templates/add_content.pt:27
+#: ../workspace/browser/templates/add_content.pt:29
 #: ../workspace/browser/templates/add_folder.pt:15
 msgid "Description for search results (Optional)"
 msgstr ""
 
 #: ../workspace/browser/tiles/templates/navigation.pt:36
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:37
-#: ../workspace/browser/tiles/templates/sidebar.pt:82
+#: ../workspace/browser/tiles/templates/sidebar.pt:86
 msgid "Deslect all"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:91
+#: ../search/browser/templates/all_results.pt:81
 msgid "Did you mean"
 msgstr ""
 
-#: ../workspace/browser/templates/add_content.pt:25
+#: ../workspace/browser/templates/add_content.pt:27
 msgid "Document title"
 msgstr ""
 
@@ -395,11 +394,11 @@ msgstr ""
 msgid "Documents"
 msgstr ""
 
-#: ../todo/browser/templates/todo_view.pt:51
+#: ../todo/browser/templates/todo_view.pt:65
 msgid "Done"
 msgstr ""
 
-#: ../workspace/basecontent/templates/document_view.pt:109
+#: ../workspace/basecontent/templates/document_view.pt:113
 msgid "Download as"
 msgstr ""
 
@@ -416,7 +415,7 @@ msgstr ""
 msgid "Edit latest news portlet"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:146
+#: ../workspace/browser/tiles/templates/sidebar.pt:150
 msgid "Edit name/description"
 msgstr ""
 
@@ -426,10 +425,6 @@ msgstr ""
 
 #: ../userprofile/content/userprofile.py:45
 msgid "Email"
-msgstr ""
-
-#: ../workspace/browser/tiles/templates/sidebar.pt:422
-msgid "Ended"
 msgstr ""
 
 #: ../workspace/browser/templates/add_event.pt:25
@@ -465,6 +460,10 @@ msgstr ""
 
 #: ../core/browser/stream.py:56
 msgid "Explore"
+msgstr ""
+
+#: ../userprofile/sync.py:80
+msgid "External property sync complete."
 msgstr ""
 
 msgid "File"
@@ -515,7 +514,7 @@ msgstr ""
 msgid "For cases, security is managed by the case workflow. You cannot configure it here like in workspaces. Instead please just assign the correct roles to users and groups in the \"Members\" tab."
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:106
+#: ../workspace/browser/templates/content_macros.pt:109
 msgid "From"
 msgstr ""
 
@@ -531,11 +530,11 @@ msgstr ""
 msgid "Functions"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:469
+#: ../workspace/browser/tiles/templates/sidebar.pt:494
 msgid "General"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:296
+#: ../workspace/browser/tiles/templates/sidebar.pt:300
 msgid "General tasks"
 msgstr ""
 
@@ -564,7 +563,7 @@ msgstr ""
 msgid "If checked, users will be removed from workspace"
 msgstr ""
 
-#: ../workspace/browser/templates/add_content.pt:21
+#: ../workspace/browser/templates/add_content.pt:23
 msgid "Image"
 msgstr "Image"
 
@@ -577,7 +576,7 @@ msgstr ""
 msgid "Images"
 msgstr ""
 
-#: ../userprofile/browser/templates/user_import_form.pt:31
+#: ../userprofile/browser/templates/user_import_form.pt:62
 msgid "Import users from file"
 msgstr ""
 
@@ -606,15 +605,15 @@ msgid "Invitations"
 msgstr ""
 
 #: ../workspace/browser/templates/roster-edit.pt:169
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:118
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:121
 msgid "Invite users to this workspace (via email)"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:150
+#: ../workspace/browser/templates/content_macros.pt:156
 msgid "Invitees"
 msgstr ""
 
-#: ../workspace/browser/add_content.py:89
+#: ../workspace/browser/add_content.py:104
 msgid "Item created."
 msgstr ""
 
@@ -622,19 +621,19 @@ msgstr ""
 msgid "Item edited."
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:630
+#: ../workspace/browser/tiles/sidebar.py:629
 msgid "Items modified last month"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:624
+#: ../workspace/browser/tiles/sidebar.py:623
 msgid "Items modified last week"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:618
+#: ../workspace/browser/tiles/sidebar.py:617
 msgid "Items modified today"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:636
+#: ../workspace/browser/tiles/sidebar.py:635
 msgid "Items since ever"
 msgstr ""
 
@@ -653,19 +652,19 @@ msgstr ""
 msgid "Join now"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:38
+#: ../search/browser/templates/all_results.pt:34
 msgid "Last Modified"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:629
+#: ../workspace/browser/tiles/sidebar.py:628
 msgid "Last Month"
 msgstr "le mois dernier"
 
-#: ../workspace/browser/tiles/sidebar.py:623
+#: ../workspace/browser/tiles/sidebar.py:622
 msgid "Last Week"
 msgstr "la semaine dernière"
 
-#: ../search/browser/templates/all_results.pt:49
+#: ../search/browser/templates/all_results.pt:45
 msgid "Last month"
 msgstr ""
 
@@ -673,7 +672,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:46
+#: ../search/browser/templates/all_results.pt:42
 msgid "Last week"
 msgstr ""
 
@@ -685,7 +684,7 @@ msgstr "nouvelles récentes"
 msgid "Leave a comment"
 msgstr "laisser un commentaire"
 
-#: ../core/browser/tiles/templates/my_documents.pt:8
+#: ../core/browser/tiles/templates/my_documents.pt:9
 #: ../library/profiles/default/actions.xml
 msgid "Library"
 msgstr ""
@@ -733,16 +732,16 @@ msgstr ""
 msgid "Member"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:168
+#: ../workspace/browser/tiles/sidebar.py:178
 msgid "Member(s) added"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:176
+#: ../workspace/browser/tiles/sidebar.py:183
 msgid "Member(s) removed"
 msgstr ""
 
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:20
-#: ../workspace/browser/tiles/templates/sidebar.pt:473
+#: ../workspace/browser/tiles/templates/sidebar.pt:498
 msgid "Members"
 msgstr "Membres"
 
@@ -788,7 +787,7 @@ msgstr ""
 msgid "More information about"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:185
+#: ../search/browser/templates/all_results.pt:175
 #: ../search/browser/templates/file_results.pt:32
 #: ../search/browser/templates/image_results.pt:32
 msgid "More results"
@@ -843,7 +842,7 @@ msgstr ""
 msgid "No such user ${userid}."
 msgstr ""
 
-#: ../layout/browser/templates/tasks-tile.pt:9
+#: ../layout/browser/templates/tasks-tile.pt:11
 msgid "No tasks available"
 msgstr ""
 
@@ -851,7 +850,6 @@ msgstr ""
 msgid "No token id given in sub-path.Use .../@@accept-token/tokenid"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:25
 #: ../workspace/browser/tiles/templates/navigation.pt:36
 msgid "None"
 msgstr ""
@@ -884,7 +882,7 @@ msgstr ""
 msgid "Ok"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:451
+#: ../workspace/browser/tiles/templates/sidebar.pt:476
 msgid "Older events"
 msgstr ""
 
@@ -892,7 +890,7 @@ msgstr ""
 msgid "Only administrators can add workspace members."
 msgstr ""
 
-#: ../todo/browser/templates/todo_view.pt:50
+#: ../todo/browser/templates/todo_view.pt:63
 #: ../workspace/policies.py:23
 msgid "Open"
 msgstr "En suspens"
@@ -919,7 +917,7 @@ msgstr ""
 msgid "Page"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:102
+#: ../workspace/browser/tiles/templates/sidebar.pt:106
 msgid "Paste"
 msgstr "Coller"
 
@@ -954,7 +952,11 @@ msgstr ""
 msgid "Pick an initiator"
 msgstr ""
 
-#: ../workspace/browser/add_content.py:48
+#: ../todo/browser/templates/todo_view.pt:64
+msgid "Planned"
+msgstr ""
+
+#: ../workspace/browser/add_content.py:63
 msgid "Please specify which Case Template to use"
 msgstr ""
 
@@ -1010,15 +1012,19 @@ msgstr ""
 msgid "Remove role"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:360
+#: ../todo/browser/templates/todo_view.pt:71
+msgid "Reopen"
+msgstr ""
+
+#: ../workspace/browser/tiles/templates/sidebar.pt:383
 msgid "Reopen milestone"
 msgstr ""
 
-#: ../workspace/browser/templates/add_content.pt:15
+#: ../workspace/browser/templates/add_content.pt:17
 msgid "Rich text"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:189
+#: ../workspace/browser/tiles/sidebar.py:190
 msgid "Role updated"
 msgstr ""
 
@@ -1026,13 +1032,13 @@ msgstr ""
 msgid "Roster updated."
 msgstr ""
 
-#: ../todo/browser/templates/todo_view.pt:56
+#: ../todo/browser/templates/todo_view.pt:77
 #: ../userprofile/browser/templates/userprofile-edit.pt:47
 #: ../workspace/basecontent/document.py:73
 msgid "Save"
 msgstr "Enregistrer"
 
-#: ../workspace/basecontent/templates/event_view.pt:86
+#: ../workspace/basecontent/templates/event_view.pt:85
 msgid "Save this document"
 msgstr ""
 
@@ -1058,7 +1064,7 @@ msgstr ""
 msgid "Secret"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:477
+#: ../workspace/browser/tiles/templates/sidebar.pt:502
 msgid "Security"
 msgstr "Sécurité"
 
@@ -1069,7 +1075,7 @@ msgstr ""
 
 #: ../workspace/browser/tiles/templates/navigation.pt:35
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:36
-#: ../workspace/browser/tiles/templates/sidebar.pt:81
+#: ../workspace/browser/tiles/templates/sidebar.pt:85
 msgid "Select all"
 msgstr ""
 
@@ -1101,17 +1107,17 @@ msgstr ""
 msgid "Settings"
 msgstr "Paramètres"
 
-#: ../workspace/basecontent/templates/document_view.pt:37
+#: ../workspace/basecontent/templates/document_view.pt:40
 msgid "Share"
 msgstr ""
 
-#: ../workspace/basecontent/templates/document_view.pt:37
+#: ../workspace/basecontent/templates/document_view.pt:40
 msgid "Share this document"
 msgstr ""
 
 #: ../todo/browser/templates/todo_view.pt:43
-#: ../workspace/basecontent/templates/document_view.pt:38
-#: ../workspace/basecontent/templates/event_view.pt:63
+#: ../workspace/basecontent/templates/document_view.pt:41
+#: ../workspace/basecontent/templates/event_view.pt:62
 msgid "Show extra metadata fields"
 msgstr ""
 
@@ -1131,12 +1137,12 @@ msgstr ""
 msgid "Start date should be lower than end date"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:417
-msgid "Starts"
-msgstr ""
-
 #: ../network/browser/templates/author.pt:29
 msgid "Status updates by ${fullname}:"
+msgstr ""
+
+#: ../layout/browser/templates/dashboard.pt:21
+msgid "Task centric view"
 msgstr ""
 
 #: ../todo/utils.py:31
@@ -1147,6 +1153,7 @@ msgstr ""
 msgid "Task title"
 msgstr ""
 
+#: ../layout/browser/templates/tasks-tile.pt:10
 #: ../workspace/browser/tiles/templates/workspace-tabs-tile.pt:22
 msgid "Tasks"
 msgstr ""
@@ -1159,7 +1166,7 @@ msgstr ""
 msgid "Telephone Number"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:158
+#: ../workspace/browser/templates/content_macros.pt:164
 msgid "Tentative"
 msgstr ""
 
@@ -1279,7 +1286,7 @@ msgstr ""
 msgid "The workspace will only be accessible for team members. Any member can add a new team member. Once you're in the team, you can do pretty much anything. Nothing in this group will ever be visible to non-members."
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:294
+#: ../workspace/browser/tiles/sidebar.py:293
 msgid "There was a problem updating the content: %s."
 msgstr ""
 
@@ -1287,7 +1294,7 @@ msgstr ""
 msgid "There was a problem: %s"
 msgstr ""
 
-#: ../workspace/browser/add_content.py:95
+#: ../workspace/browser/add_content.py:110
 #: ../workspace/browser/edit_content.py:38
 msgid "There was a problem: %s."
 msgstr ""
@@ -1312,11 +1319,11 @@ msgstr ""
 msgid "Timeline"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:138
+#: ../workspace/browser/templates/content_macros.pt:144
 msgid "Timezone"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:123
+#: ../workspace/browser/templates/content_macros.pt:127
 msgid "To"
 msgstr ""
 
@@ -1324,8 +1331,8 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:43
-#: ../workspace/browser/tiles/sidebar.py:617
+#: ../search/browser/templates/all_results.pt:39
+#: ../workspace/browser/tiles/sidebar.py:616
 msgid "Today"
 msgstr "Aujourd'hui"
 
@@ -1333,8 +1340,8 @@ msgid "Todo"
 msgstr ""
 
 #: ../todo/browser/templates/todo_view.pt:43
-#: ../workspace/basecontent/templates/document_view.pt:38
-#: ../workspace/basecontent/templates/event_view.pt:63
+#: ../workspace/basecontent/templates/document_view.pt:41
+#: ../workspace/basecontent/templates/event_view.pt:62
 msgid "Toggle extra metadata"
 msgstr ""
 
@@ -1343,15 +1350,15 @@ msgid "Token no longer valid"
 msgstr ""
 
 #: ../workspace/browser/templates/roster-edit.pt:176
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:124
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:127
 msgid "Transfer members to another workspace."
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:367
+#: ../workspace/browser/tiles/templates/sidebar.pt:390
 msgid "Unassigned"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:156
+#: ../workspace/browser/templates/content_macros.pt:162
 msgid "Undecided"
 msgstr ""
 
@@ -1359,7 +1366,7 @@ msgstr ""
 msgid "Unfollow"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:195
+#: ../workspace/browser/tiles/sidebar.py:193
 msgid "Unknown function"
 msgstr ""
 
@@ -1367,12 +1374,12 @@ msgstr ""
 msgid "Unlike"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/events.pt:9
-#: ../workspace/browser/tiles/templates/sidebar.pt:400
+#: ../workspace/browser/tiles/templates/events.pt:10
+#: ../workspace/browser/tiles/templates/sidebar.pt:423
 msgid "Upcoming events"
 msgstr ""
 
-#: ../userprofile/browser/templates/user_import_form.pt:25
+#: ../userprofile/browser/templates/user_import_form.pt:56
 msgid "Update details for existing users (matching on username)"
 msgstr ""
 
@@ -1381,8 +1388,12 @@ msgstr ""
 msgid "Updates"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:244
+#: ../workspace/browser/tiles/templates/sidebar.pt:248
 msgid "Upload file(s)"
+msgstr ""
+
+#: ../userprofile/browser/templates/user_import_form.pt:18
+msgid "User profile management"
 msgstr ""
 
 #: ../microblog/interfaces.py:17
@@ -1448,7 +1459,7 @@ msgstr ""
 msgid "Workspace policy"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:247
+#: ../workspace/browser/tiles/sidebar.py:246
 msgid "Workspace security policy changes saved"
 msgstr ""
 
@@ -1477,7 +1488,7 @@ msgstr ""
 msgid "You can become a member of this workspace"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:160
+#: ../workspace/browser/tiles/sidebar.py:161
 msgid "You do not have permission to change the workspace policy"
 msgstr ""
 
@@ -1519,6 +1530,11 @@ msgstr ""
 msgid "date"
 msgstr "date"
 
+#. Default: "Start time should be lower than end time. The system set the end time to: ${date}"
+#: ../workspace/browser/add_content.py:164
+msgid "dates_hijacked"
+msgstr ""
+
 #: ../workspace/browser/tiles/templates/navigation.pt:21
 #: ../workspace/browser/tiles/templates/sidebar.pt:37
 msgid "document type"
@@ -1530,7 +1546,7 @@ msgid "download"
 msgstr ""
 
 #. Default: "Drop files here or click to browse..."
-#: ../workspace/browser/tiles/sidebar.py:310
+#: ../workspace/browser/tiles/sidebar.py:309
 msgid "drop_files_here"
 msgstr ""
 
@@ -1550,7 +1566,7 @@ msgid "expand/reduce sidebar"
 msgstr ""
 
 #. Default: "External visibility"
-#: ../workspace/browser/tiles/sidebar.py:215
+#: ../workspace/browser/tiles/sidebar.py:214
 msgid "external_visibility_label"
 msgstr ""
 
@@ -1592,14 +1608,14 @@ msgstr ""
 msgid "invititations"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:87
+#: ../search/browser/templates/all_results.pt:77
 #: ../search/browser/templates/image_results.pt:14
 #: ../search/browser/templates/people_results.pt:14
 msgid "items matched your search."
 msgstr ""
 
 #. Default: "Join policy"
-#: ../workspace/browser/tiles/sidebar.py:214
+#: ../workspace/browser/tiles/sidebar.py:213
 msgid "join_policy_label"
 msgstr ""
 
@@ -1617,13 +1633,13 @@ msgstr ""
 msgid "label_name"
 msgstr ""
 
-#. Default: "News"
-#: ../layout/browser/templates/news-tile.pt:8
+#. Default: "<a href=\"${context/portal_url}/library/news\">News</a>"
+#: ../layout/browser/templates/news-tile.pt:9
 msgid "label_news"
 msgstr ""
 
 #. Default: "No events available"
-#: ../workspace/browser/tiles/templates/sidebar.pt:460
+#: ../workspace/browser/tiles/templates/sidebar.pt:485
 msgid "label_no_events_available"
 msgstr ""
 
@@ -1673,36 +1689,36 @@ msgid "leave_a_comment"
 msgstr ""
 
 #. Default: "More sharing options coming soon"
-#: ../workspace/basecontent/templates/document_view.pt:111
+#: ../workspace/basecontent/templates/document_view.pt:115
 msgid "more_sharing_soon"
 msgstr ""
 
 #. Default: "No tasks created yet"
-#: ../workspace/browser/tiles/templates/sidebar.pt:298
+#: ../workspace/browser/tiles/templates/sidebar.pt:302
 msgid "no-task-found"
 msgstr ""
 
 #. Default: "${no_members} Members"
-#: ../workspace/workspacefolder.py:167
+#: ../workspace/workspacefolder.py:172
 msgid "number_of_members"
 msgstr ""
 
 #. Default: "Participant policy"
-#: ../workspace/browser/tiles/sidebar.py:217
+#: ../workspace/browser/tiles/sidebar.py:216
 msgid "participant_policy_label"
 msgstr ""
 
 #. Default: "Description"
-#: ../workspace/basecontent/templates/event_view.pt:101
+#: ../workspace/basecontent/templates/event_view.pt:100
 msgid "placeholder"
 msgstr ""
 
-#: ../workspace/browser/tiles/workspaces.py:109
+#: ../workspace/browser/tiles/workspaces.py:120
 msgid "posted"
 msgstr ""
 
 #. Default: "Read more..."
-#: ../layout/browser/templates/news-tile.pt:19
+#: ../layout/browser/templates/news-tile.pt:20
 #: ../library/browser/templates/library.html:148
 msgid "read-more"
 msgstr ""
@@ -1714,13 +1730,13 @@ msgstr ""
 
 #. Default: "All"
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:36
-#: ../workspace/browser/tiles/templates/sidebar.pt:81
+#: ../workspace/browser/tiles/templates/sidebar.pt:85
 msgid "select_all"
 msgstr ""
 
 #. Default: "None"
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:37
-#: ../workspace/browser/tiles/templates/sidebar.pt:82
+#: ../workspace/browser/tiles/templates/sidebar.pt:86
 msgid "select_none"
 msgstr ""
 
@@ -1732,6 +1748,16 @@ msgstr ""
 #: ../workspace/browser/tiles/templates/sidebar.pt:35
 msgid "tag"
 msgstr "tag"
+
+#. Cases
+#: ../layout/browser/templates/dashboard.pt
+msgid "tile_ploneintranet.workspace.case"
+msgstr ""
+
+#. Workspaces
+#: ../layout/browser/templates/dashboard.pt
+msgid "tile_ploneintranet.workspace.workspacefolder"
+msgstr ""
 
 #: ../network/browser/templates/maxiauthor_provider.pt:72
 #: ../network/browser/templates/miniauthor_provider.pt:38

--- a/src/ploneintranet/core/locales/it/LC_MESSAGES/ploneintranet.po
+++ b/src/ploneintranet/core/locales/it/LC_MESSAGES/ploneintranet.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone Intranet\n"
-"POT-Creation-Date: 2015-08-28 08:33+0000\n"
+"POT-Creation-Date: 2015-10-01 12:49+0000\n"
 "PO-Revision-Date: 2015-05-22 10:12+0000\n"
 "Last-Translator: Giacomo <giacomo.spettoli@gmail.com>\n"
 "Language-Team: Italian (http://www.transifex.com/projects/p/plone-intranet/language/it/)\n"
@@ -54,11 +54,15 @@ msgstr "Un utente (o un gruppo) assegnato a questa attività"
 msgid "A user with this username already exists"
 msgstr ""
 
+#: ../layout/browser/templates/dashboard.pt:18
+msgid "Activity centric view"
+msgstr ""
+
 #: ../messaging/browser/messaging.py:26
 msgid "Add a comment"
 msgstr "Aggiungi un commento"
 
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:91
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:94
 msgid "Add group"
 msgstr ""
 
@@ -75,7 +79,7 @@ msgstr "Aggiungi una portlet con le ultime notizie"
 msgid "Add tags"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:88
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:91
 msgid "Add user"
 msgstr ""
 
@@ -92,47 +96,46 @@ msgid "Admin-Managed"
 msgstr "Gestito dal amministratore"
 
 #: ../workspace/browser/templates/roster-edit.pt:167
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:116
-#: ../workspace/browser/tiles/templates/sidebar.pt:481
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:119
+#: ../workspace/browser/tiles/templates/sidebar.pt:506
 msgid "Advanced"
 msgstr "Avanzate"
 
 #: ../workspace/browser/templates/roster-edit.pt:183
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:130
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:133
 msgid "Advanced permissions"
 msgstr "Permessi avanzati"
 
-#: ../search/browser/templates/all_results.pt:24
 #: ../search/browser/templates/search_template.pt:24
 #: ../workspace/browser/tiles/templates/navigation.pt:35
 msgid "All"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:385
+#: ../workspace/browser/tiles/sidebar.py:384
 msgid "All Authors"
 msgstr "Tutti gli autori"
 
-#: ../workspace/browser/tiles/sidebar.py:381
+#: ../workspace/browser/tiles/sidebar.py:380
 msgid "All Dates"
 msgstr "Tutte le date"
 
-#: ../workspace/browser/tiles/sidebar.py:389
+#: ../workspace/browser/tiles/sidebar.py:388
 msgid "All Letters"
 msgstr "Tutte le lettere"
 
-#: ../workspace/browser/tiles/sidebar.py:383
+#: ../workspace/browser/tiles/sidebar.py:382
 msgid "All Tags"
 msgstr "Tutti i tag"
 
-#: ../workspace/browser/tiles/sidebar.py:635
+#: ../workspace/browser/tiles/sidebar.py:634
 msgid "All Time"
 msgstr "Tutti i tempi"
 
-#: ../workspace/browser/tiles/sidebar.py:387
+#: ../workspace/browser/tiles/sidebar.py:386
 msgid "All Types"
 msgstr "Tutti i tipi"
 
-#: ../workspace/browser/tiles/events.py:49
+#: ../workspace/browser/tiles/events.py:52
 msgid "All day"
 msgstr ""
 
@@ -156,7 +159,7 @@ msgstr ""
 msgid "Any logged-in user is allowed to join the group and participate. Anything in this group is visible for any logged-in user, even if they're not a member."
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:40
+#: ../search/browser/templates/all_results.pt:36
 msgid "Any modification date"
 msgstr ""
 
@@ -183,15 +186,15 @@ msgstr "Allega un file"
 msgid "Attach a file (or create a picture)"
 msgstr "Allega un file (o crea un'immagine)"
 
-#: ../workspace/basecontent/templates/event_view.pt:60
+#: ../workspace/basecontent/templates/event_view.pt:59
 msgid "Attach documents"
 msgstr ""
 
-#: ../workspace/basecontent/templates/event_view.pt:60
+#: ../workspace/basecontent/templates/event_view.pt:59
 msgid "Attachments"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:286
+#: ../workspace/browser/tiles/sidebar.py:285
 msgid "Attributes changed."
 msgstr ""
 
@@ -199,19 +202,19 @@ msgstr ""
 msgid "Author name (for display)"
 msgstr "Nome dell'autore (da mostrare)"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:200
+#: ../workspace/browser/tiles/templates/sidebar.pt:204
 msgid "Author of this document"
 msgstr ""
 
-#: ../userprofile/browser/templates/user_import_form.pt:39
+#: ../userprofile/browser/templates/user_import_form.pt:70
 msgid "Available fields/columns"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:391
+#: ../workspace/browser/tiles/sidebar.py:390
 msgid "Back"
 msgstr "Indietro"
 
-#: ../search/browser/templates/all_results.pt:52
+#: ../search/browser/templates/all_results.pt:48
 msgid "Before last month"
 msgstr ""
 
@@ -219,16 +222,12 @@ msgstr ""
 msgid "Biography"
 msgstr ""
 
-#: ../userprofile/browser/templates/user_import_form.pt:13
-msgid "Bulk import users"
-msgstr ""
-
 msgid "CSV document"
 msgstr ""
 
 #: ../messaging/browser/send-message.pt:63
 #: ../workspace/basecontent/document.py:77
-#: ../workspace/browser/templates/add_content.pt:36
+#: ../workspace/browser/templates/add_content.pt:38
 msgid "Cancel"
 msgstr "Annulla"
 
@@ -253,7 +252,7 @@ msgid "Change role of member"
 msgstr ""
 
 #: ../todo/browser/templates/todo_view.pt:48
-#: ../workspace/basecontent/templates/document_view.pt:41
+#: ../workspace/basecontent/templates/document_view.pt:44
 msgid "Change the workflow state"
 msgstr ""
 
@@ -261,11 +260,11 @@ msgstr ""
 msgid "Changes applied"
 msgstr "Modifiche applicate"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:357
+#: ../workspace/browser/tiles/templates/sidebar.pt:380
 msgid "Close milestone"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:157
+#: ../workspace/browser/templates/content_macros.pt:163
 msgid "Confirmed"
 msgstr ""
 
@@ -282,25 +281,25 @@ msgstr "Consuma"
 msgid "Contact"
 msgstr ""
 
-#: ../userprofile/browser/tiles/templates/contacts_search.pt:9
+#: ../userprofile/browser/tiles/templates/contacts_search.pt:10
 msgid "Contacts"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:27
+#: ../search/browser/templates/all_results.pt:23
 msgid "Content types"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:95
+#: ../workspace/browser/tiles/templates/sidebar.pt:99
 msgid "Copy"
 msgstr "Copia"
 
-#: ../workspace/browser/templates/add_content.pt:33
+#: ../workspace/browser/templates/add_content.pt:35
 #: ../workspace/browser/templates/add_folder.pt:20
 #: ../workspace/browser/templates/add_task.pt:24
 msgid "Create"
 msgstr "Crea"
 
-#: ../workspace/browser/templates/workspaces.pt:24
+#: ../workspace/browser/templates/workspaces.pt:30
 msgid "Create a new workspace"
 msgstr ""
 
@@ -314,11 +313,11 @@ msgid "Create event"
 msgstr ""
 
 #: ../workspace/browser/templates/add_folder.pt:7
-#: ../workspace/browser/tiles/templates/sidebar.pt:221
+#: ../workspace/browser/tiles/templates/sidebar.pt:225
 msgid "Create folder"
 msgstr "Crea cartella"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:289
+#: ../workspace/browser/tiles/templates/sidebar.pt:293
 msgid "Create new task"
 msgstr ""
 
@@ -328,7 +327,7 @@ msgstr ""
 
 #: ../theme/browser/templates/workspaces.pt:25
 #: ../workspace/browser/templates/workspace-add.pt:11
-#: ../workspace/browser/templates/workspaces.pt:24
+#: ../workspace/browser/templates/workspaces.pt:30
 msgid "Create workspace"
 msgstr ""
 
@@ -336,30 +335,30 @@ msgstr ""
 msgid "Creation date"
 msgstr "Data di creazione"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:88
+#: ../workspace/browser/tiles/templates/sidebar.pt:92
 msgid "Cut"
 msgstr "Taglia"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:203
+#: ../workspace/browser/tiles/templates/sidebar.pt:207
 msgid "Date and time of the latest modification"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:159
+#: ../workspace/browser/templates/content_macros.pt:165
 msgid "Declined"
 msgstr ""
 
 #: ../todo/browser/templates/todo_view.pt:34
-#: ../workspace/basecontent/templates/document_view.pt:35
-#: ../workspace/basecontent/templates/event_view.pt:50
+#: ../workspace/basecontent/templates/document_view.pt:38
+#: ../workspace/basecontent/templates/event_view.pt:49
 msgid "Delete"
 msgstr "Elimina"
 
 #: ../todo/browser/templates/todo_view.pt:34
-#: ../workspace/basecontent/templates/document_view.pt:35
+#: ../workspace/basecontent/templates/document_view.pt:38
 msgid "Delete this document"
 msgstr ""
 
-#: ../workspace/basecontent/templates/event_view.pt:50
+#: ../workspace/basecontent/templates/event_view.pt:49
 msgid "Delete this event"
 msgstr ""
 
@@ -371,22 +370,22 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: ../workspace/browser/templates/add_content.pt:27
+#: ../workspace/browser/templates/add_content.pt:29
 #: ../workspace/browser/templates/add_folder.pt:15
 msgid "Description for search results (Optional)"
 msgstr "Descrizione per la ricerca (Opzionale)"
 
 #: ../workspace/browser/tiles/templates/navigation.pt:36
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:37
-#: ../workspace/browser/tiles/templates/sidebar.pt:82
+#: ../workspace/browser/tiles/templates/sidebar.pt:86
 msgid "Deslect all"
 msgstr "Deseleziona tutto"
 
-#: ../search/browser/templates/all_results.pt:91
+#: ../search/browser/templates/all_results.pt:81
 msgid "Did you mean"
 msgstr ""
 
-#: ../workspace/browser/templates/add_content.pt:25
+#: ../workspace/browser/templates/add_content.pt:27
 msgid "Document title"
 msgstr "Titolo della pagina"
 
@@ -394,11 +393,11 @@ msgstr "Titolo della pagina"
 msgid "Documents"
 msgstr "Pagine"
 
-#: ../todo/browser/templates/todo_view.pt:51
+#: ../todo/browser/templates/todo_view.pt:65
 msgid "Done"
 msgstr ""
 
-#: ../workspace/basecontent/templates/document_view.pt:109
+#: ../workspace/basecontent/templates/document_view.pt:113
 msgid "Download as"
 msgstr ""
 
@@ -415,7 +414,7 @@ msgstr ""
 msgid "Edit latest news portlet"
 msgstr "Modifica la portlet con le ultime notizie"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:146
+#: ../workspace/browser/tiles/templates/sidebar.pt:150
 msgid "Edit name/description"
 msgstr ""
 
@@ -425,10 +424,6 @@ msgstr ""
 
 #: ../userprofile/content/userprofile.py:45
 msgid "Email"
-msgstr ""
-
-#: ../workspace/browser/tiles/templates/sidebar.pt:422
-msgid "Ended"
 msgstr ""
 
 #: ../workspace/browser/templates/add_event.pt:25
@@ -465,6 +460,10 @@ msgstr ""
 #: ../core/browser/stream.py:56
 msgid "Explore"
 msgstr "Esplora"
+
+#: ../userprofile/sync.py:80
+msgid "External property sync complete."
+msgstr ""
 
 msgid "File"
 msgstr ""
@@ -514,7 +513,7 @@ msgstr ""
 msgid "For cases, security is managed by the case workflow. You cannot configure it here like in workspaces. Instead please just assign the correct roles to users and groups in the \"Members\" tab."
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:106
+#: ../workspace/browser/templates/content_macros.pt:109
 msgid "From"
 msgstr ""
 
@@ -530,11 +529,11 @@ msgstr ""
 msgid "Functions"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:469
+#: ../workspace/browser/tiles/templates/sidebar.pt:494
 msgid "General"
 msgstr "Generale"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:296
+#: ../workspace/browser/tiles/templates/sidebar.pt:300
 msgid "General tasks"
 msgstr ""
 
@@ -563,7 +562,7 @@ msgstr ""
 msgid "If checked, users will be removed from workspace"
 msgstr "Se selezionato, gli utenti verranno rimossi dall'area di lavoro"
 
-#: ../workspace/browser/templates/add_content.pt:21
+#: ../workspace/browser/templates/add_content.pt:23
 msgid "Image"
 msgstr "Immagine"
 
@@ -576,7 +575,7 @@ msgstr ""
 msgid "Images"
 msgstr ""
 
-#: ../userprofile/browser/templates/user_import_form.pt:31
+#: ../userprofile/browser/templates/user_import_form.pt:62
 msgid "Import users from file"
 msgstr ""
 
@@ -605,15 +604,15 @@ msgid "Invitations"
 msgstr "Inviti"
 
 #: ../workspace/browser/templates/roster-edit.pt:169
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:118
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:121
 msgid "Invite users to this workspace (via email)"
 msgstr "Invita gli utenti in questa area di lavoro (via email)"
 
-#: ../workspace/browser/templates/content_macros.pt:150
+#: ../workspace/browser/templates/content_macros.pt:156
 msgid "Invitees"
 msgstr ""
 
-#: ../workspace/browser/add_content.py:89
+#: ../workspace/browser/add_content.py:104
 msgid "Item created."
 msgstr ""
 
@@ -621,19 +620,19 @@ msgstr ""
 msgid "Item edited."
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:630
+#: ../workspace/browser/tiles/sidebar.py:629
 msgid "Items modified last month"
 msgstr "Contenuti modificati nell'ultimo mese"
 
-#: ../workspace/browser/tiles/sidebar.py:624
+#: ../workspace/browser/tiles/sidebar.py:623
 msgid "Items modified last week"
 msgstr "Contenuti modificati nell'ultima settimana"
 
-#: ../workspace/browser/tiles/sidebar.py:618
+#: ../workspace/browser/tiles/sidebar.py:617
 msgid "Items modified today"
 msgstr "Contenuti modificati oggi"
 
-#: ../workspace/browser/tiles/sidebar.py:636
+#: ../workspace/browser/tiles/sidebar.py:635
 msgid "Items since ever"
 msgstr "Tutti i contenuti"
 
@@ -652,19 +651,19 @@ msgstr ""
 msgid "Join now"
 msgstr "Unisciti adesso"
 
-#: ../search/browser/templates/all_results.pt:38
+#: ../search/browser/templates/all_results.pt:34
 msgid "Last Modified"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:629
+#: ../workspace/browser/tiles/sidebar.py:628
 msgid "Last Month"
 msgstr "Ultimo mese"
 
-#: ../workspace/browser/tiles/sidebar.py:623
+#: ../workspace/browser/tiles/sidebar.py:622
 msgid "Last Week"
 msgstr "Ultima settimana"
 
-#: ../search/browser/templates/all_results.pt:49
+#: ../search/browser/templates/all_results.pt:45
 msgid "Last month"
 msgstr ""
 
@@ -672,7 +671,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:46
+#: ../search/browser/templates/all_results.pt:42
 msgid "Last week"
 msgstr ""
 
@@ -684,7 +683,7 @@ msgstr "Ultime notizie"
 msgid "Leave a comment"
 msgstr "Lascia un commento"
 
-#: ../core/browser/tiles/templates/my_documents.pt:8
+#: ../core/browser/tiles/templates/my_documents.pt:9
 #: ../library/profiles/default/actions.xml
 msgid "Library"
 msgstr ""
@@ -732,16 +731,16 @@ msgstr "Marca il contenuto come \"Da leggere\" per tutti gli utenti."
 msgid "Member"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:168
+#: ../workspace/browser/tiles/sidebar.py:178
 msgid "Member(s) added"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:176
+#: ../workspace/browser/tiles/sidebar.py:183
 msgid "Member(s) removed"
 msgstr ""
 
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:20
-#: ../workspace/browser/tiles/templates/sidebar.pt:473
+#: ../workspace/browser/tiles/templates/sidebar.pt:498
 msgid "Members"
 msgstr "Membri"
 
@@ -787,7 +786,7 @@ msgstr "Moderare"
 msgid "More information about"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:185
+#: ../search/browser/templates/all_results.pt:175
 #: ../search/browser/templates/file_results.pt:32
 #: ../search/browser/templates/image_results.pt:32
 msgid "More results"
@@ -842,7 +841,7 @@ msgstr "Nessuna notifica in sospeso"
 msgid "No such user ${userid}."
 msgstr "Nessun utente trovato con id ${userid}"
 
-#: ../layout/browser/templates/tasks-tile.pt:9
+#: ../layout/browser/templates/tasks-tile.pt:11
 msgid "No tasks available"
 msgstr ""
 
@@ -850,7 +849,6 @@ msgstr ""
 msgid "No token id given in sub-path.Use .../@@accept-token/tokenid"
 msgstr "Nessun id di elemento nel sub-path. Usa .../@@accept-token/tokenid"
 
-#: ../search/browser/templates/all_results.pt:25
 #: ../workspace/browser/tiles/templates/navigation.pt:36
 msgid "None"
 msgstr ""
@@ -883,7 +881,7 @@ msgstr "Sei già un membro"
 msgid "Ok"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:451
+#: ../workspace/browser/tiles/templates/sidebar.pt:476
 msgid "Older events"
 msgstr "Eventi passati"
 
@@ -891,7 +889,7 @@ msgstr "Eventi passati"
 msgid "Only administrators can add workspace members."
 msgstr "Solo gli amministratori possono aggiungere nuovi membri all'area di lavoro"
 
-#: ../todo/browser/templates/todo_view.pt:50
+#: ../todo/browser/templates/todo_view.pt:63
 #: ../workspace/policies.py:23
 msgid "Open"
 msgstr "Aperto"
@@ -918,7 +916,7 @@ msgstr "Il file PDF non è stato ancora generato"
 msgid "Page"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:102
+#: ../workspace/browser/tiles/templates/sidebar.pt:106
 msgid "Paste"
 msgstr "Incolla"
 
@@ -953,7 +951,11 @@ msgstr ""
 msgid "Pick an initiator"
 msgstr ""
 
-#: ../workspace/browser/add_content.py:48
+#: ../todo/browser/templates/todo_view.pt:64
+msgid "Planned"
+msgstr ""
+
+#: ../workspace/browser/add_content.py:63
 msgid "Please specify which Case Template to use"
 msgstr ""
 
@@ -1009,15 +1011,19 @@ msgstr ""
 msgid "Remove role"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:360
+#: ../todo/browser/templates/todo_view.pt:71
+msgid "Reopen"
+msgstr ""
+
+#: ../workspace/browser/tiles/templates/sidebar.pt:383
 msgid "Reopen milestone"
 msgstr ""
 
-#: ../workspace/browser/templates/add_content.pt:15
+#: ../workspace/browser/templates/add_content.pt:17
 msgid "Rich text"
 msgstr "Testo"
 
-#: ../workspace/browser/tiles/sidebar.py:189
+#: ../workspace/browser/tiles/sidebar.py:190
 msgid "Role updated"
 msgstr ""
 
@@ -1025,13 +1031,13 @@ msgstr ""
 msgid "Roster updated."
 msgstr "Lista aggiornata"
 
-#: ../todo/browser/templates/todo_view.pt:56
+#: ../todo/browser/templates/todo_view.pt:77
 #: ../userprofile/browser/templates/userprofile-edit.pt:47
 #: ../workspace/basecontent/document.py:73
 msgid "Save"
 msgstr "Salva"
 
-#: ../workspace/basecontent/templates/event_view.pt:86
+#: ../workspace/basecontent/templates/event_view.pt:85
 msgid "Save this document"
 msgstr ""
 
@@ -1057,7 +1063,7 @@ msgstr ""
 msgid "Secret"
 msgstr "Nascosto"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:477
+#: ../workspace/browser/tiles/templates/sidebar.pt:502
 msgid "Security"
 msgstr "Sicurezza"
 
@@ -1068,7 +1074,7 @@ msgstr "Seleziona"
 
 #: ../workspace/browser/tiles/templates/navigation.pt:35
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:36
-#: ../workspace/browser/tiles/templates/sidebar.pt:81
+#: ../workspace/browser/tiles/templates/sidebar.pt:85
 msgid "Select all"
 msgstr "Seleziona tutto"
 
@@ -1100,17 +1106,17 @@ msgstr ""
 msgid "Settings"
 msgstr "Impostazioni"
 
-#: ../workspace/basecontent/templates/document_view.pt:37
+#: ../workspace/basecontent/templates/document_view.pt:40
 msgid "Share"
 msgstr "Condividi"
 
-#: ../workspace/basecontent/templates/document_view.pt:37
+#: ../workspace/basecontent/templates/document_view.pt:40
 msgid "Share this document"
 msgstr ""
 
 #: ../todo/browser/templates/todo_view.pt:43
-#: ../workspace/basecontent/templates/document_view.pt:38
-#: ../workspace/basecontent/templates/event_view.pt:63
+#: ../workspace/basecontent/templates/document_view.pt:41
+#: ../workspace/basecontent/templates/event_view.pt:62
 msgid "Show extra metadata fields"
 msgstr ""
 
@@ -1130,13 +1136,13 @@ msgstr ""
 msgid "Start date should be lower than end date"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:417
-msgid "Starts"
-msgstr "Inizio"
-
 #: ../network/browser/templates/author.pt:29
 msgid "Status updates by ${fullname}:"
 msgstr "Aggiornamenti di stato di ${fullname}:"
+
+#: ../layout/browser/templates/dashboard.pt:21
+msgid "Task centric view"
+msgstr ""
 
 #: ../todo/utils.py:31
 msgid "Task state changed"
@@ -1146,6 +1152,7 @@ msgstr ""
 msgid "Task title"
 msgstr ""
 
+#: ../layout/browser/templates/tasks-tile.pt:10
 #: ../workspace/browser/tiles/templates/workspace-tabs-tile.pt:22
 msgid "Tasks"
 msgstr "Attività"
@@ -1158,7 +1165,7 @@ msgstr "Gestito dal team"
 msgid "Telephone Number"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:158
+#: ../workspace/browser/templates/content_macros.pt:164
 msgid "Tentative"
 msgstr ""
 
@@ -1278,7 +1285,7 @@ msgstr ""
 msgid "The workspace will only be accessible for team members. Any member can add a new team member. Once you're in the team, you can do pretty much anything. Nothing in this group will ever be visible to non-members."
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:294
+#: ../workspace/browser/tiles/sidebar.py:293
 msgid "There was a problem updating the content: %s."
 msgstr ""
 
@@ -1286,7 +1293,7 @@ msgstr ""
 msgid "There was a problem: %s"
 msgstr ""
 
-#: ../workspace/browser/add_content.py:95
+#: ../workspace/browser/add_content.py:110
 #: ../workspace/browser/edit_content.py:38
 msgid "There was a problem: %s."
 msgstr ""
@@ -1311,11 +1318,11 @@ msgstr ""
 msgid "Timeline"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:138
+#: ../workspace/browser/templates/content_macros.pt:144
 msgid "Timezone"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:123
+#: ../workspace/browser/templates/content_macros.pt:127
 msgid "To"
 msgstr ""
 
@@ -1323,8 +1330,8 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:43
-#: ../workspace/browser/tiles/sidebar.py:617
+#: ../search/browser/templates/all_results.pt:39
+#: ../workspace/browser/tiles/sidebar.py:616
 msgid "Today"
 msgstr "Oggi"
 
@@ -1332,8 +1339,8 @@ msgid "Todo"
 msgstr ""
 
 #: ../todo/browser/templates/todo_view.pt:43
-#: ../workspace/basecontent/templates/document_view.pt:38
-#: ../workspace/basecontent/templates/event_view.pt:63
+#: ../workspace/basecontent/templates/document_view.pt:41
+#: ../workspace/basecontent/templates/event_view.pt:62
 msgid "Toggle extra metadata"
 msgstr ""
 
@@ -1342,15 +1349,15 @@ msgid "Token no longer valid"
 msgstr "Il token non è più valido"
 
 #: ../workspace/browser/templates/roster-edit.pt:176
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:124
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:127
 msgid "Transfer members to another workspace."
 msgstr "Sposta i membri in un'altra area di lavoro"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:367
+#: ../workspace/browser/tiles/templates/sidebar.pt:390
 msgid "Unassigned"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:156
+#: ../workspace/browser/templates/content_macros.pt:162
 msgid "Undecided"
 msgstr ""
 
@@ -1358,7 +1365,7 @@ msgstr ""
 msgid "Unfollow"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:195
+#: ../workspace/browser/tiles/sidebar.py:193
 msgid "Unknown function"
 msgstr ""
 
@@ -1366,12 +1373,12 @@ msgstr ""
 msgid "Unlike"
 msgstr "Togli mi piace"
 
-#: ../workspace/browser/tiles/templates/events.pt:9
-#: ../workspace/browser/tiles/templates/sidebar.pt:400
+#: ../workspace/browser/tiles/templates/events.pt:10
+#: ../workspace/browser/tiles/templates/sidebar.pt:423
 msgid "Upcoming events"
 msgstr "Prossimi eventi"
 
-#: ../userprofile/browser/templates/user_import_form.pt:25
+#: ../userprofile/browser/templates/user_import_form.pt:56
 msgid "Update details for existing users (matching on username)"
 msgstr ""
 
@@ -1380,9 +1387,13 @@ msgstr ""
 msgid "Updates"
 msgstr "Aggiornamenti"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:244
+#: ../workspace/browser/tiles/templates/sidebar.pt:248
 msgid "Upload file(s)"
 msgstr "Carica uno o più file"
+
+#: ../userprofile/browser/templates/user_import_form.pt:18
+msgid "User profile management"
+msgstr ""
 
 #: ../microblog/interfaces.py:17
 msgid "Userid"
@@ -1447,7 +1458,7 @@ msgstr "I membri dell'area di lavoro possono leggere, aggiungere e pubblicare i 
 msgid "Workspace policy"
 msgstr "Policy di sicurezza dell'area di lavoro"
 
-#: ../workspace/browser/tiles/sidebar.py:247
+#: ../workspace/browser/tiles/sidebar.py:246
 msgid "Workspace security policy changes saved"
 msgstr "Le modifiche alla policy di sicurezza dell'area di lavoro sono state salvate."
 
@@ -1476,7 +1487,7 @@ msgstr ""
 msgid "You can become a member of this workspace"
 msgstr "Puoi diventare un membro di questa area di lavoro"
 
-#: ../workspace/browser/tiles/sidebar.py:160
+#: ../workspace/browser/tiles/sidebar.py:161
 msgid "You do not have permission to change the workspace policy"
 msgstr "Non hai il permesso necessario per poter cambiare la politica di sicurezza dell'area di lavoro"
 
@@ -1518,6 +1529,11 @@ msgstr ""
 msgid "date"
 msgstr "data"
 
+#. Default: "Start time should be lower than end time. The system set the end time to: ${date}"
+#: ../workspace/browser/add_content.py:164
+msgid "dates_hijacked"
+msgstr ""
+
 #: ../workspace/browser/tiles/templates/navigation.pt:21
 #: ../workspace/browser/tiles/templates/sidebar.pt:37
 msgid "document type"
@@ -1529,7 +1545,7 @@ msgid "download"
 msgstr ""
 
 #. Default: "Drop files here or click to browse..."
-#: ../workspace/browser/tiles/sidebar.py:310
+#: ../workspace/browser/tiles/sidebar.py:309
 msgid "drop_files_here"
 msgstr "Sposta i file qui o clicca per cercare..."
 
@@ -1549,7 +1565,7 @@ msgid "expand/reduce sidebar"
 msgstr ""
 
 #. Default: "External visibility"
-#: ../workspace/browser/tiles/sidebar.py:215
+#: ../workspace/browser/tiles/sidebar.py:214
 msgid "external_visibility_label"
 msgstr "Visibilità all'esterno"
 
@@ -1593,14 +1609,14 @@ msgstr "Quando l'url con il token unico viene usato, un account utente verrà au
 msgid "invititations"
 msgstr "inviti"
 
-#: ../search/browser/templates/all_results.pt:87
+#: ../search/browser/templates/all_results.pt:77
 #: ../search/browser/templates/image_results.pt:14
 #: ../search/browser/templates/people_results.pt:14
 msgid "items matched your search."
 msgstr ""
 
 #. Default: "Join policy"
-#: ../workspace/browser/tiles/sidebar.py:214
+#: ../workspace/browser/tiles/sidebar.py:213
 msgid "join_policy_label"
 msgstr "Policy di ingresso"
 
@@ -1618,13 +1634,13 @@ msgstr ""
 msgid "label_name"
 msgstr ""
 
-#. Default: "News"
-#: ../layout/browser/templates/news-tile.pt:8
+#. Default: "<a href=\"${context/portal_url}/library/news\">News</a>"
+#: ../layout/browser/templates/news-tile.pt:9
 msgid "label_news"
 msgstr ""
 
 #. Default: "No events available"
-#: ../workspace/browser/tiles/templates/sidebar.pt:460
+#: ../workspace/browser/tiles/templates/sidebar.pt:485
 msgid "label_no_events_available"
 msgstr ""
 
@@ -1674,36 +1690,36 @@ msgid "leave_a_comment"
 msgstr "Lascia un commento"
 
 #. Default: "More sharing options coming soon"
-#: ../workspace/basecontent/templates/document_view.pt:111
+#: ../workspace/basecontent/templates/document_view.pt:115
 msgid "more_sharing_soon"
 msgstr ""
 
 #. Default: "No tasks created yet"
-#: ../workspace/browser/tiles/templates/sidebar.pt:298
+#: ../workspace/browser/tiles/templates/sidebar.pt:302
 msgid "no-task-found"
 msgstr "Nessuna attività è stata ancora creata"
 
 #. Default: "${no_members} Members"
-#: ../workspace/workspacefolder.py:167
+#: ../workspace/workspacefolder.py:172
 msgid "number_of_members"
 msgstr ""
 
 #. Default: "Participant policy"
-#: ../workspace/browser/tiles/sidebar.py:217
+#: ../workspace/browser/tiles/sidebar.py:216
 msgid "participant_policy_label"
 msgstr "Policy di partecipazione"
 
 #. Default: "Description"
-#: ../workspace/basecontent/templates/event_view.pt:101
+#: ../workspace/basecontent/templates/event_view.pt:100
 msgid "placeholder"
 msgstr ""
 
-#: ../workspace/browser/tiles/workspaces.py:109
+#: ../workspace/browser/tiles/workspaces.py:120
 msgid "posted"
 msgstr "ha scritto"
 
 #. Default: "Read more..."
-#: ../layout/browser/templates/news-tile.pt:19
+#: ../layout/browser/templates/news-tile.pt:20
 #: ../library/browser/templates/library.html:148
 msgid "read-more"
 msgstr ""
@@ -1715,13 +1731,13 @@ msgstr ""
 
 #. Default: "All"
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:36
-#: ../workspace/browser/tiles/templates/sidebar.pt:81
+#: ../workspace/browser/tiles/templates/sidebar.pt:85
 msgid "select_all"
 msgstr "Tutti"
 
 #. Default: "None"
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:37
-#: ../workspace/browser/tiles/templates/sidebar.pt:82
+#: ../workspace/browser/tiles/templates/sidebar.pt:86
 msgid "select_none"
 msgstr "Nessuno"
 
@@ -1733,6 +1749,16 @@ msgstr "La policy di partecipazione di questa area di lavoro è ${policy_name}"
 #: ../workspace/browser/tiles/templates/sidebar.pt:35
 msgid "tag"
 msgstr "tag"
+
+#. Cases
+#: ../layout/browser/templates/dashboard.pt
+msgid "tile_ploneintranet.workspace.case"
+msgstr ""
+
+#. Workspaces
+#: ../layout/browser/templates/dashboard.pt
+msgid "tile_ploneintranet.workspace.workspacefolder"
+msgstr ""
 
 #: ../network/browser/templates/maxiauthor_provider.pt:72
 #: ../network/browser/templates/miniauthor_provider.pt:38

--- a/src/ploneintranet/core/locales/manual.pot
+++ b/src/ploneintranet/core/locales/manual.pot
@@ -70,3 +70,13 @@ msgstr ""
 
 msgid "Person"
 msgstr ""
+
+#: ../layout/browser/templates/dashboard.pt
+#. Workspaces
+msgid "tile_ploneintranet.workspace.workspacefolder"
+msgstr ""
+
+#: ../layout/browser/templates/dashboard.pt
+#. Cases
+msgid "tile_ploneintranet.workspace.case"
+msgstr ""

--- a/src/ploneintranet/core/locales/nl/LC_MESSAGES/ploneintranet.po
+++ b/src/ploneintranet/core/locales/nl/LC_MESSAGES/ploneintranet.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone Intranet\n"
-"POT-Creation-Date: 2015-08-28 08:33+0000\n"
+"POT-Creation-Date: 2015-10-01 12:49+0000\n"
 "PO-Revision-Date: 2015-05-22 10:00+0000\n"
 "Last-Translator: Coen van der Kamp <cvanderkamp@gmail.com>\n"
 "Language-Team: Dutch (http://www.transifex.com/projects/p/plone-intranet/language/nl/)\n"
@@ -54,11 +54,15 @@ msgstr "Een gebruiker (of een groep) toegewezen aan deze taak"
 msgid "A user with this username already exists"
 msgstr ""
 
+#: ../layout/browser/templates/dashboard.pt:18
+msgid "Activity centric view"
+msgstr ""
+
 #: ../messaging/browser/messaging.py:26
 msgid "Add a comment"
 msgstr "Reactie toevoegen"
 
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:91
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:94
 msgid "Add group"
 msgstr ""
 
@@ -75,7 +79,7 @@ msgstr "Laatste nieuws-portlet toevoegen"
 msgid "Add tags"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:88
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:91
 msgid "Add user"
 msgstr ""
 
@@ -92,47 +96,46 @@ msgid "Admin-Managed"
 msgstr "Beheerd door beheerder"
 
 #: ../workspace/browser/templates/roster-edit.pt:167
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:116
-#: ../workspace/browser/tiles/templates/sidebar.pt:481
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:119
+#: ../workspace/browser/tiles/templates/sidebar.pt:506
 msgid "Advanced"
 msgstr "Geavanceerd"
 
 #: ../workspace/browser/templates/roster-edit.pt:183
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:130
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:133
 msgid "Advanced permissions"
 msgstr "Geavanceerde permissies"
 
-#: ../search/browser/templates/all_results.pt:24
 #: ../search/browser/templates/search_template.pt:24
 #: ../workspace/browser/tiles/templates/navigation.pt:35
 msgid "All"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:385
+#: ../workspace/browser/tiles/sidebar.py:384
 msgid "All Authors"
 msgstr "Alle Auteurs"
 
-#: ../workspace/browser/tiles/sidebar.py:381
+#: ../workspace/browser/tiles/sidebar.py:380
 msgid "All Dates"
 msgstr "Alle Datums"
 
-#: ../workspace/browser/tiles/sidebar.py:389
+#: ../workspace/browser/tiles/sidebar.py:388
 msgid "All Letters"
 msgstr "Alle Brieven"
 
-#: ../workspace/browser/tiles/sidebar.py:383
+#: ../workspace/browser/tiles/sidebar.py:382
 msgid "All Tags"
 msgstr "Alle Tags"
 
-#: ../workspace/browser/tiles/sidebar.py:635
+#: ../workspace/browser/tiles/sidebar.py:634
 msgid "All Time"
 msgstr "Alle Tijden"
 
-#: ../workspace/browser/tiles/sidebar.py:387
+#: ../workspace/browser/tiles/sidebar.py:386
 msgid "All Types"
 msgstr "Alle Type"
 
-#: ../workspace/browser/tiles/events.py:49
+#: ../workspace/browser/tiles/events.py:52
 msgid "All day"
 msgstr ""
 
@@ -156,7 +159,7 @@ msgstr ""
 msgid "Any logged-in user is allowed to join the group and participate. Anything in this group is visible for any logged-in user, even if they're not a member."
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:40
+#: ../search/browser/templates/all_results.pt:36
 msgid "Any modification date"
 msgstr ""
 
@@ -183,15 +186,15 @@ msgstr "Voeg een bestand toe"
 msgid "Attach a file (or create a picture)"
 msgstr "Voeg een bestand toe (of maak een afbeelding)"
 
-#: ../workspace/basecontent/templates/event_view.pt:60
+#: ../workspace/basecontent/templates/event_view.pt:59
 msgid "Attach documents"
 msgstr ""
 
-#: ../workspace/basecontent/templates/event_view.pt:60
+#: ../workspace/basecontent/templates/event_view.pt:59
 msgid "Attachments"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:286
+#: ../workspace/browser/tiles/sidebar.py:285
 msgid "Attributes changed."
 msgstr ""
 
@@ -199,19 +202,19 @@ msgstr ""
 msgid "Author name (for display)"
 msgstr "Auteursnaam (voor weergave)"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:200
+#: ../workspace/browser/tiles/templates/sidebar.pt:204
 msgid "Author of this document"
 msgstr ""
 
-#: ../userprofile/browser/templates/user_import_form.pt:39
+#: ../userprofile/browser/templates/user_import_form.pt:70
 msgid "Available fields/columns"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:391
+#: ../workspace/browser/tiles/sidebar.py:390
 msgid "Back"
 msgstr "Vorige"
 
-#: ../search/browser/templates/all_results.pt:52
+#: ../search/browser/templates/all_results.pt:48
 msgid "Before last month"
 msgstr ""
 
@@ -219,16 +222,12 @@ msgstr ""
 msgid "Biography"
 msgstr ""
 
-#: ../userprofile/browser/templates/user_import_form.pt:13
-msgid "Bulk import users"
-msgstr ""
-
 msgid "CSV document"
 msgstr ""
 
 #: ../messaging/browser/send-message.pt:63
 #: ../workspace/basecontent/document.py:77
-#: ../workspace/browser/templates/add_content.pt:36
+#: ../workspace/browser/templates/add_content.pt:38
 msgid "Cancel"
 msgstr "Annuleren "
 
@@ -253,7 +252,7 @@ msgid "Change role of member"
 msgstr ""
 
 #: ../todo/browser/templates/todo_view.pt:48
-#: ../workspace/basecontent/templates/document_view.pt:41
+#: ../workspace/basecontent/templates/document_view.pt:44
 msgid "Change the workflow state"
 msgstr ""
 
@@ -261,11 +260,11 @@ msgstr ""
 msgid "Changes applied"
 msgstr "Wijzigingen toegepast"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:357
+#: ../workspace/browser/tiles/templates/sidebar.pt:380
 msgid "Close milestone"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:157
+#: ../workspace/browser/templates/content_macros.pt:163
 msgid "Confirmed"
 msgstr ""
 
@@ -282,25 +281,25 @@ msgstr "Consumeren"
 msgid "Contact"
 msgstr ""
 
-#: ../userprofile/browser/tiles/templates/contacts_search.pt:9
+#: ../userprofile/browser/tiles/templates/contacts_search.pt:10
 msgid "Contacts"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:27
+#: ../search/browser/templates/all_results.pt:23
 msgid "Content types"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:95
+#: ../workspace/browser/tiles/templates/sidebar.pt:99
 msgid "Copy"
 msgstr "Kopiëren"
 
-#: ../workspace/browser/templates/add_content.pt:33
+#: ../workspace/browser/templates/add_content.pt:35
 #: ../workspace/browser/templates/add_folder.pt:20
 #: ../workspace/browser/templates/add_task.pt:24
 msgid "Create"
 msgstr "Aanmaken"
 
-#: ../workspace/browser/templates/workspaces.pt:24
+#: ../workspace/browser/templates/workspaces.pt:30
 msgid "Create a new workspace"
 msgstr ""
 
@@ -314,11 +313,11 @@ msgid "Create event"
 msgstr ""
 
 #: ../workspace/browser/templates/add_folder.pt:7
-#: ../workspace/browser/tiles/templates/sidebar.pt:221
+#: ../workspace/browser/tiles/templates/sidebar.pt:225
 msgid "Create folder"
 msgstr "Folder aanmaken"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:289
+#: ../workspace/browser/tiles/templates/sidebar.pt:293
 msgid "Create new task"
 msgstr ""
 
@@ -328,7 +327,7 @@ msgstr ""
 
 #: ../theme/browser/templates/workspaces.pt:25
 #: ../workspace/browser/templates/workspace-add.pt:11
-#: ../workspace/browser/templates/workspaces.pt:24
+#: ../workspace/browser/templates/workspaces.pt:30
 msgid "Create workspace"
 msgstr ""
 
@@ -336,30 +335,30 @@ msgstr ""
 msgid "Creation date"
 msgstr "Aanmaakdatum"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:88
+#: ../workspace/browser/tiles/templates/sidebar.pt:92
 msgid "Cut"
 msgstr "Knippen"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:203
+#: ../workspace/browser/tiles/templates/sidebar.pt:207
 msgid "Date and time of the latest modification"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:159
+#: ../workspace/browser/templates/content_macros.pt:165
 msgid "Declined"
 msgstr ""
 
 #: ../todo/browser/templates/todo_view.pt:34
-#: ../workspace/basecontent/templates/document_view.pt:35
-#: ../workspace/basecontent/templates/event_view.pt:50
+#: ../workspace/basecontent/templates/document_view.pt:38
+#: ../workspace/basecontent/templates/event_view.pt:49
 msgid "Delete"
 msgstr "Verwijderen"
 
 #: ../todo/browser/templates/todo_view.pt:34
-#: ../workspace/basecontent/templates/document_view.pt:35
+#: ../workspace/basecontent/templates/document_view.pt:38
 msgid "Delete this document"
 msgstr ""
 
-#: ../workspace/basecontent/templates/event_view.pt:50
+#: ../workspace/basecontent/templates/event_view.pt:49
 msgid "Delete this event"
 msgstr ""
 
@@ -371,22 +370,22 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: ../workspace/browser/templates/add_content.pt:27
+#: ../workspace/browser/templates/add_content.pt:29
 #: ../workspace/browser/templates/add_folder.pt:15
 msgid "Description for search results (Optional)"
 msgstr "Omschrijving van zoekresultaten (optioneel)"
 
 #: ../workspace/browser/tiles/templates/navigation.pt:36
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:37
-#: ../workspace/browser/tiles/templates/sidebar.pt:82
+#: ../workspace/browser/tiles/templates/sidebar.pt:86
 msgid "Deslect all"
 msgstr "Deselecteer alles"
 
-#: ../search/browser/templates/all_results.pt:91
+#: ../search/browser/templates/all_results.pt:81
 msgid "Did you mean"
 msgstr ""
 
-#: ../workspace/browser/templates/add_content.pt:25
+#: ../workspace/browser/templates/add_content.pt:27
 msgid "Document title"
 msgstr "Documenttitel"
 
@@ -394,11 +393,11 @@ msgstr "Documenttitel"
 msgid "Documents"
 msgstr "Documenten"
 
-#: ../todo/browser/templates/todo_view.pt:51
+#: ../todo/browser/templates/todo_view.pt:65
 msgid "Done"
 msgstr ""
 
-#: ../workspace/basecontent/templates/document_view.pt:109
+#: ../workspace/basecontent/templates/document_view.pt:113
 msgid "Download as"
 msgstr ""
 
@@ -415,7 +414,7 @@ msgstr ""
 msgid "Edit latest news portlet"
 msgstr "Wijzig laatste nieuws-portlet"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:146
+#: ../workspace/browser/tiles/templates/sidebar.pt:150
 msgid "Edit name/description"
 msgstr ""
 
@@ -425,10 +424,6 @@ msgstr ""
 
 #: ../userprofile/content/userprofile.py:45
 msgid "Email"
-msgstr ""
-
-#: ../workspace/browser/tiles/templates/sidebar.pt:422
-msgid "Ended"
 msgstr ""
 
 #: ../workspace/browser/templates/add_event.pt:25
@@ -465,6 +460,10 @@ msgstr ""
 #: ../core/browser/stream.py:56
 msgid "Explore"
 msgstr "Ontdekken"
+
+#: ../userprofile/sync.py:80
+msgid "External property sync complete."
+msgstr ""
 
 msgid "File"
 msgstr ""
@@ -514,7 +513,7 @@ msgstr ""
 msgid "For cases, security is managed by the case workflow. You cannot configure it here like in workspaces. Instead please just assign the correct roles to users and groups in the \"Members\" tab."
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:106
+#: ../workspace/browser/templates/content_macros.pt:109
 msgid "From"
 msgstr ""
 
@@ -530,11 +529,11 @@ msgstr ""
 msgid "Functions"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:469
+#: ../workspace/browser/tiles/templates/sidebar.pt:494
 msgid "General"
 msgstr "Algemeen"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:296
+#: ../workspace/browser/tiles/templates/sidebar.pt:300
 msgid "General tasks"
 msgstr ""
 
@@ -563,7 +562,7 @@ msgstr ""
 msgid "If checked, users will be removed from workspace"
 msgstr "Als aangevinkt dan zullen gebruikers worden verwijderd uit de werkruimte"
 
-#: ../workspace/browser/templates/add_content.pt:21
+#: ../workspace/browser/templates/add_content.pt:23
 msgid "Image"
 msgstr "Afbeelding"
 
@@ -576,7 +575,7 @@ msgstr ""
 msgid "Images"
 msgstr ""
 
-#: ../userprofile/browser/templates/user_import_form.pt:31
+#: ../userprofile/browser/templates/user_import_form.pt:62
 msgid "Import users from file"
 msgstr ""
 
@@ -605,15 +604,15 @@ msgid "Invitations"
 msgstr "Uitnodigingen"
 
 #: ../workspace/browser/templates/roster-edit.pt:169
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:118
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:121
 msgid "Invite users to this workspace (via email)"
 msgstr "Gebruikers (per email) uitnodigen voor deze werkruimte"
 
-#: ../workspace/browser/templates/content_macros.pt:150
+#: ../workspace/browser/templates/content_macros.pt:156
 msgid "Invitees"
 msgstr ""
 
-#: ../workspace/browser/add_content.py:89
+#: ../workspace/browser/add_content.py:104
 msgid "Item created."
 msgstr ""
 
@@ -621,19 +620,19 @@ msgstr ""
 msgid "Item edited."
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:630
+#: ../workspace/browser/tiles/sidebar.py:629
 msgid "Items modified last month"
 msgstr "Afgelopen maand bewerkte items"
 
-#: ../workspace/browser/tiles/sidebar.py:624
+#: ../workspace/browser/tiles/sidebar.py:623
 msgid "Items modified last week"
 msgstr "Afgelopen week bewerkte items"
 
-#: ../workspace/browser/tiles/sidebar.py:618
+#: ../workspace/browser/tiles/sidebar.py:617
 msgid "Items modified today"
 msgstr "Vandaag bewerkte items "
 
-#: ../workspace/browser/tiles/sidebar.py:636
+#: ../workspace/browser/tiles/sidebar.py:635
 msgid "Items since ever"
 msgstr "Alle items ooit"
 
@@ -652,19 +651,19 @@ msgstr ""
 msgid "Join now"
 msgstr "Nu aanmelden"
 
-#: ../search/browser/templates/all_results.pt:38
+#: ../search/browser/templates/all_results.pt:34
 msgid "Last Modified"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:629
+#: ../workspace/browser/tiles/sidebar.py:628
 msgid "Last Month"
 msgstr "Afgelopen maand"
 
-#: ../workspace/browser/tiles/sidebar.py:623
+#: ../workspace/browser/tiles/sidebar.py:622
 msgid "Last Week"
 msgstr "Afgelopen week"
 
-#: ../search/browser/templates/all_results.pt:49
+#: ../search/browser/templates/all_results.pt:45
 msgid "Last month"
 msgstr ""
 
@@ -672,7 +671,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:46
+#: ../search/browser/templates/all_results.pt:42
 msgid "Last week"
 msgstr ""
 
@@ -684,7 +683,7 @@ msgstr "Laatste nieuws"
 msgid "Leave a comment"
 msgstr "Plaats een reactie"
 
-#: ../core/browser/tiles/templates/my_documents.pt:8
+#: ../core/browser/tiles/templates/my_documents.pt:9
 #: ../library/profiles/default/actions.xml
 msgid "Library"
 msgstr ""
@@ -732,16 +731,16 @@ msgstr "Markeer inhoud als \"verplicht leesvoer\" voor alle gebruikers."
 msgid "Member"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:168
+#: ../workspace/browser/tiles/sidebar.py:178
 msgid "Member(s) added"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:176
+#: ../workspace/browser/tiles/sidebar.py:183
 msgid "Member(s) removed"
 msgstr ""
 
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:20
-#: ../workspace/browser/tiles/templates/sidebar.pt:473
+#: ../workspace/browser/tiles/templates/sidebar.pt:498
 msgid "Members"
 msgstr "Leden"
 
@@ -787,7 +786,7 @@ msgstr "Modereren"
 msgid "More information about"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:185
+#: ../search/browser/templates/all_results.pt:175
 #: ../search/browser/templates/file_results.pt:32
 #: ../search/browser/templates/image_results.pt:32
 msgid "More results"
@@ -842,7 +841,7 @@ msgstr "Geen openstaande notificaties"
 msgid "No such user ${userid}."
 msgstr "Gebruiker ${userid} onbekend."
 
-#: ../layout/browser/templates/tasks-tile.pt:9
+#: ../layout/browser/templates/tasks-tile.pt:11
 msgid "No tasks available"
 msgstr ""
 
@@ -850,7 +849,6 @@ msgstr ""
 msgid "No token id given in sub-path.Use .../@@accept-token/tokenid"
 msgstr "Token-id ontbreekt in sub-pad. Gebruik .../@@accept-token/tokenid"
 
-#: ../search/browser/templates/all_results.pt:25
 #: ../workspace/browser/tiles/templates/navigation.pt:36
 msgid "None"
 msgstr ""
@@ -883,7 +881,7 @@ msgstr "Hela, hola! Je bent al lid"
 msgid "Ok"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:451
+#: ../workspace/browser/tiles/templates/sidebar.pt:476
 msgid "Older events"
 msgstr "Oudere evenementen"
 
@@ -891,7 +889,7 @@ msgstr "Oudere evenementen"
 msgid "Only administrators can add workspace members."
 msgstr "Alleen beheerders kunnen gebruikers aan een werkruimte toevoegen."
 
-#: ../todo/browser/templates/todo_view.pt:50
+#: ../todo/browser/templates/todo_view.pt:63
 #: ../workspace/policies.py:23
 msgid "Open"
 msgstr "Open"
@@ -918,7 +916,7 @@ msgstr "PDF is nog niet gegenereerd"
 msgid "Page"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:102
+#: ../workspace/browser/tiles/templates/sidebar.pt:106
 msgid "Paste"
 msgstr "Plakken"
 
@@ -953,7 +951,11 @@ msgstr ""
 msgid "Pick an initiator"
 msgstr ""
 
-#: ../workspace/browser/add_content.py:48
+#: ../todo/browser/templates/todo_view.pt:64
+msgid "Planned"
+msgstr ""
+
+#: ../workspace/browser/add_content.py:63
 msgid "Please specify which Case Template to use"
 msgstr ""
 
@@ -1009,15 +1011,19 @@ msgstr ""
 msgid "Remove role"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:360
+#: ../todo/browser/templates/todo_view.pt:71
+msgid "Reopen"
+msgstr ""
+
+#: ../workspace/browser/tiles/templates/sidebar.pt:383
 msgid "Reopen milestone"
 msgstr ""
 
-#: ../workspace/browser/templates/add_content.pt:15
+#: ../workspace/browser/templates/add_content.pt:17
 msgid "Rich text"
 msgstr "Text met opmaak"
 
-#: ../workspace/browser/tiles/sidebar.py:189
+#: ../workspace/browser/tiles/sidebar.py:190
 msgid "Role updated"
 msgstr ""
 
@@ -1025,13 +1031,13 @@ msgstr ""
 msgid "Roster updated."
 msgstr "Rooster geüpdatet"
 
-#: ../todo/browser/templates/todo_view.pt:56
+#: ../todo/browser/templates/todo_view.pt:77
 #: ../userprofile/browser/templates/userprofile-edit.pt:47
 #: ../workspace/basecontent/document.py:73
 msgid "Save"
 msgstr "Opslaan"
 
-#: ../workspace/basecontent/templates/event_view.pt:86
+#: ../workspace/basecontent/templates/event_view.pt:85
 msgid "Save this document"
 msgstr ""
 
@@ -1057,7 +1063,7 @@ msgstr ""
 msgid "Secret"
 msgstr "Geheim"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:477
+#: ../workspace/browser/tiles/templates/sidebar.pt:502
 msgid "Security"
 msgstr "Beveiliging"
 
@@ -1068,7 +1074,7 @@ msgstr "Selecteren"
 
 #: ../workspace/browser/tiles/templates/navigation.pt:35
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:36
-#: ../workspace/browser/tiles/templates/sidebar.pt:81
+#: ../workspace/browser/tiles/templates/sidebar.pt:85
 msgid "Select all"
 msgstr "Selecteer alles"
 
@@ -1100,17 +1106,17 @@ msgstr ""
 msgid "Settings"
 msgstr "Instellingen"
 
-#: ../workspace/basecontent/templates/document_view.pt:37
+#: ../workspace/basecontent/templates/document_view.pt:40
 msgid "Share"
 msgstr "Delen"
 
-#: ../workspace/basecontent/templates/document_view.pt:37
+#: ../workspace/basecontent/templates/document_view.pt:40
 msgid "Share this document"
 msgstr ""
 
 #: ../todo/browser/templates/todo_view.pt:43
-#: ../workspace/basecontent/templates/document_view.pt:38
-#: ../workspace/basecontent/templates/event_view.pt:63
+#: ../workspace/basecontent/templates/document_view.pt:41
+#: ../workspace/basecontent/templates/event_view.pt:62
 msgid "Show extra metadata fields"
 msgstr ""
 
@@ -1130,13 +1136,13 @@ msgstr ""
 msgid "Start date should be lower than end date"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:417
-msgid "Starts"
-msgstr "Begint"
-
 #: ../network/browser/templates/author.pt:29
 msgid "Status updates by ${fullname}:"
 msgstr "Statusupdate door ${fullname}:"
+
+#: ../layout/browser/templates/dashboard.pt:21
+msgid "Task centric view"
+msgstr ""
 
 #: ../todo/utils.py:31
 msgid "Task state changed"
@@ -1146,6 +1152,7 @@ msgstr ""
 msgid "Task title"
 msgstr ""
 
+#: ../layout/browser/templates/tasks-tile.pt:10
 #: ../workspace/browser/tiles/templates/workspace-tabs-tile.pt:22
 msgid "Tasks"
 msgstr "Taken"
@@ -1158,7 +1165,7 @@ msgstr "Beheerd door het team"
 msgid "Telephone Number"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:158
+#: ../workspace/browser/templates/content_macros.pt:164
 msgid "Tentative"
 msgstr ""
 
@@ -1278,7 +1285,7 @@ msgstr ""
 msgid "The workspace will only be accessible for team members. Any member can add a new team member. Once you're in the team, you can do pretty much anything. Nothing in this group will ever be visible to non-members."
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:294
+#: ../workspace/browser/tiles/sidebar.py:293
 msgid "There was a problem updating the content: %s."
 msgstr ""
 
@@ -1286,7 +1293,7 @@ msgstr ""
 msgid "There was a problem: %s"
 msgstr ""
 
-#: ../workspace/browser/add_content.py:95
+#: ../workspace/browser/add_content.py:110
 #: ../workspace/browser/edit_content.py:38
 msgid "There was a problem: %s."
 msgstr ""
@@ -1311,11 +1318,11 @@ msgstr ""
 msgid "Timeline"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:138
+#: ../workspace/browser/templates/content_macros.pt:144
 msgid "Timezone"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:123
+#: ../workspace/browser/templates/content_macros.pt:127
 msgid "To"
 msgstr ""
 
@@ -1323,8 +1330,8 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:43
-#: ../workspace/browser/tiles/sidebar.py:617
+#: ../search/browser/templates/all_results.pt:39
+#: ../workspace/browser/tiles/sidebar.py:616
 msgid "Today"
 msgstr "Vandaag"
 
@@ -1332,8 +1339,8 @@ msgid "Todo"
 msgstr ""
 
 #: ../todo/browser/templates/todo_view.pt:43
-#: ../workspace/basecontent/templates/document_view.pt:38
-#: ../workspace/basecontent/templates/event_view.pt:63
+#: ../workspace/basecontent/templates/document_view.pt:41
+#: ../workspace/basecontent/templates/event_view.pt:62
 msgid "Toggle extra metadata"
 msgstr ""
 
@@ -1342,15 +1349,15 @@ msgid "Token no longer valid"
 msgstr "Token is niet langer geldig"
 
 #: ../workspace/browser/templates/roster-edit.pt:176
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:124
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:127
 msgid "Transfer members to another workspace."
 msgstr "Verplaats deelnemer naar een andere werkruimte."
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:367
+#: ../workspace/browser/tiles/templates/sidebar.pt:390
 msgid "Unassigned"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:156
+#: ../workspace/browser/templates/content_macros.pt:162
 msgid "Undecided"
 msgstr ""
 
@@ -1358,7 +1365,7 @@ msgstr ""
 msgid "Unfollow"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:195
+#: ../workspace/browser/tiles/sidebar.py:193
 msgid "Unknown function"
 msgstr ""
 
@@ -1366,12 +1373,12 @@ msgstr ""
 msgid "Unlike"
 msgstr "Vind ik niet meer leuk"
 
-#: ../workspace/browser/tiles/templates/events.pt:9
-#: ../workspace/browser/tiles/templates/sidebar.pt:400
+#: ../workspace/browser/tiles/templates/events.pt:10
+#: ../workspace/browser/tiles/templates/sidebar.pt:423
 msgid "Upcoming events"
 msgstr "Aanstaande evenementen"
 
-#: ../userprofile/browser/templates/user_import_form.pt:25
+#: ../userprofile/browser/templates/user_import_form.pt:56
 msgid "Update details for existing users (matching on username)"
 msgstr ""
 
@@ -1380,9 +1387,13 @@ msgstr ""
 msgid "Updates"
 msgstr "Updates"
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:244
+#: ../workspace/browser/tiles/templates/sidebar.pt:248
 msgid "Upload file(s)"
 msgstr "Bestand(en) toevoegen"
+
+#: ../userprofile/browser/templates/user_import_form.pt:18
+msgid "User profile management"
+msgstr ""
 
 #: ../microblog/interfaces.py:17
 msgid "Userid"
@@ -1447,7 +1458,7 @@ msgstr "Werkplaatsdeelnemers kunnen inhoud lezen en publiceren. Ze kunnen geen i
 msgid "Workspace policy"
 msgstr "Werkplaatsbeleid"
 
-#: ../workspace/browser/tiles/sidebar.py:247
+#: ../workspace/browser/tiles/sidebar.py:246
 msgid "Workspace security policy changes saved"
 msgstr "Wijzigingen aan het werkplaatsbeleid zijn opgeslagen"
 
@@ -1476,7 +1487,7 @@ msgstr ""
 msgid "You can become a member of this workspace"
 msgstr "Je kan deelnemer worden aan deze werkplaats"
 
-#: ../workspace/browser/tiles/sidebar.py:160
+#: ../workspace/browser/tiles/sidebar.py:161
 msgid "You do not have permission to change the workspace policy"
 msgstr "Je bent niet bevoegd het werkplaatsbeleid te wijzigen"
 
@@ -1518,6 +1529,11 @@ msgstr ""
 msgid "date"
 msgstr "datum"
 
+#. Default: "Start time should be lower than end time. The system set the end time to: ${date}"
+#: ../workspace/browser/add_content.py:164
+msgid "dates_hijacked"
+msgstr ""
+
 #: ../workspace/browser/tiles/templates/navigation.pt:21
 #: ../workspace/browser/tiles/templates/sidebar.pt:37
 msgid "document type"
@@ -1529,7 +1545,7 @@ msgid "download"
 msgstr ""
 
 #. Default: "Drop files here or click to browse..."
-#: ../workspace/browser/tiles/sidebar.py:310
+#: ../workspace/browser/tiles/sidebar.py:309
 msgid "drop_files_here"
 msgstr "Sleep bestanden hierheen"
 
@@ -1549,7 +1565,7 @@ msgid "expand/reduce sidebar"
 msgstr ""
 
 #. Default: "External visibility"
-#: ../workspace/browser/tiles/sidebar.py:215
+#: ../workspace/browser/tiles/sidebar.py:214
 msgid "external_visibility_label"
 msgstr "Extern zichtbaar"
 
@@ -1593,14 +1609,14 @@ msgstr "Als de URL met unieke code wordt geopend, dan zal een gebruikersaccount 
 msgid "invititations"
 msgstr "uitnodigingen"
 
-#: ../search/browser/templates/all_results.pt:87
+#: ../search/browser/templates/all_results.pt:77
 #: ../search/browser/templates/image_results.pt:14
 #: ../search/browser/templates/people_results.pt:14
 msgid "items matched your search."
 msgstr ""
 
 #. Default: "Join policy"
-#: ../workspace/browser/tiles/sidebar.py:214
+#: ../workspace/browser/tiles/sidebar.py:213
 msgid "join_policy_label"
 msgstr "Toegangsbeleid"
 
@@ -1618,13 +1634,13 @@ msgstr ""
 msgid "label_name"
 msgstr ""
 
-#. Default: "News"
-#: ../layout/browser/templates/news-tile.pt:8
+#. Default: "<a href=\"${context/portal_url}/library/news\">News</a>"
+#: ../layout/browser/templates/news-tile.pt:9
 msgid "label_news"
 msgstr ""
 
 #. Default: "No events available"
-#: ../workspace/browser/tiles/templates/sidebar.pt:460
+#: ../workspace/browser/tiles/templates/sidebar.pt:485
 msgid "label_no_events_available"
 msgstr ""
 
@@ -1674,36 +1690,36 @@ msgid "leave_a_comment"
 msgstr "Plaats een reactie"
 
 #. Default: "More sharing options coming soon"
-#: ../workspace/basecontent/templates/document_view.pt:111
+#: ../workspace/basecontent/templates/document_view.pt:115
 msgid "more_sharing_soon"
 msgstr ""
 
 #. Default: "No tasks created yet"
-#: ../workspace/browser/tiles/templates/sidebar.pt:298
+#: ../workspace/browser/tiles/templates/sidebar.pt:302
 msgid "no-task-found"
 msgstr "Geen taak gevonden"
 
 #. Default: "${no_members} Members"
-#: ../workspace/workspacefolder.py:167
+#: ../workspace/workspacefolder.py:172
 msgid "number_of_members"
 msgstr ""
 
 #. Default: "Participant policy"
-#: ../workspace/browser/tiles/sidebar.py:217
+#: ../workspace/browser/tiles/sidebar.py:216
 msgid "participant_policy_label"
 msgstr "Deelnemersbeleid"
 
 #. Default: "Description"
-#: ../workspace/basecontent/templates/event_view.pt:101
+#: ../workspace/basecontent/templates/event_view.pt:100
 msgid "placeholder"
 msgstr ""
 
-#: ../workspace/browser/tiles/workspaces.py:109
+#: ../workspace/browser/tiles/workspaces.py:120
 msgid "posted"
 msgstr "Verzonden"
 
 #. Default: "Read more..."
-#: ../layout/browser/templates/news-tile.pt:19
+#: ../layout/browser/templates/news-tile.pt:20
 #: ../library/browser/templates/library.html:148
 msgid "read-more"
 msgstr ""
@@ -1715,13 +1731,13 @@ msgstr ""
 
 #. Default: "All"
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:36
-#: ../workspace/browser/tiles/templates/sidebar.pt:81
+#: ../workspace/browser/tiles/templates/sidebar.pt:85
 msgid "select_all"
 msgstr "selecteer alles"
 
 #. Default: "None"
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:37
-#: ../workspace/browser/tiles/templates/sidebar.pt:82
+#: ../workspace/browser/tiles/templates/sidebar.pt:86
 msgid "select_none"
 msgstr "deselecteer alles"
 
@@ -1733,6 +1749,16 @@ msgstr "Deelbeleid omschrijving"
 #: ../workspace/browser/tiles/templates/sidebar.pt:35
 msgid "tag"
 msgstr "tag"
+
+#. Cases
+#: ../layout/browser/templates/dashboard.pt
+msgid "tile_ploneintranet.workspace.case"
+msgstr ""
+
+#. Workspaces
+#: ../layout/browser/templates/dashboard.pt
+msgid "tile_ploneintranet.workspace.workspacefolder"
+msgstr ""
 
 #: ../network/browser/templates/maxiauthor_provider.pt:72
 #: ../network/browser/templates/miniauthor_provider.pt:38

--- a/src/ploneintranet/core/locales/ploneintranet.pot
+++ b/src/ploneintranet/core/locales/ploneintranet.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-08-28 08:33+0000\n"
+"POT-Creation-Date: 2015-10-01 12:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -53,11 +53,15 @@ msgstr ""
 msgid "A user with this username already exists"
 msgstr ""
 
+#: ../layout/browser/templates/dashboard.pt:18
+msgid "Activity centric view"
+msgstr ""
+
 #: ../messaging/browser/messaging.py:26
 msgid "Add a comment"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:91
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:94
 msgid "Add group"
 msgstr ""
 
@@ -74,7 +78,7 @@ msgstr ""
 msgid "Add tags"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:88
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:91
 msgid "Add user"
 msgstr ""
 
@@ -91,47 +95,46 @@ msgid "Admin-Managed"
 msgstr ""
 
 #: ../workspace/browser/templates/roster-edit.pt:167
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:116
-#: ../workspace/browser/tiles/templates/sidebar.pt:481
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:119
+#: ../workspace/browser/tiles/templates/sidebar.pt:506
 msgid "Advanced"
 msgstr ""
 
 #: ../workspace/browser/templates/roster-edit.pt:183
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:130
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:133
 msgid "Advanced permissions"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:24
 #: ../search/browser/templates/search_template.pt:24
 #: ../workspace/browser/tiles/templates/navigation.pt:35
 msgid "All"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:385
+#: ../workspace/browser/tiles/sidebar.py:384
 msgid "All Authors"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:381
+#: ../workspace/browser/tiles/sidebar.py:380
 msgid "All Dates"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:389
+#: ../workspace/browser/tiles/sidebar.py:388
 msgid "All Letters"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:383
+#: ../workspace/browser/tiles/sidebar.py:382
 msgid "All Tags"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:635
+#: ../workspace/browser/tiles/sidebar.py:634
 msgid "All Time"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:387
+#: ../workspace/browser/tiles/sidebar.py:386
 msgid "All Types"
 msgstr ""
 
-#: ../workspace/browser/tiles/events.py:49
+#: ../workspace/browser/tiles/events.py:52
 msgid "All day"
 msgstr ""
 
@@ -155,7 +158,7 @@ msgstr ""
 msgid "Any logged-in user is allowed to join the group and participate. Anything in this group is visible for any logged-in user, even if they're not a member."
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:40
+#: ../search/browser/templates/all_results.pt:36
 msgid "Any modification date"
 msgstr ""
 
@@ -182,15 +185,15 @@ msgstr ""
 msgid "Attach a file (or create a picture)"
 msgstr ""
 
-#: ../workspace/basecontent/templates/event_view.pt:60
+#: ../workspace/basecontent/templates/event_view.pt:59
 msgid "Attach documents"
 msgstr ""
 
-#: ../workspace/basecontent/templates/event_view.pt:60
+#: ../workspace/basecontent/templates/event_view.pt:59
 msgid "Attachments"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:286
+#: ../workspace/browser/tiles/sidebar.py:285
 msgid "Attributes changed."
 msgstr ""
 
@@ -198,19 +201,19 @@ msgstr ""
 msgid "Author name (for display)"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:200
+#: ../workspace/browser/tiles/templates/sidebar.pt:204
 msgid "Author of this document"
 msgstr ""
 
-#: ../userprofile/browser/templates/user_import_form.pt:39
+#: ../userprofile/browser/templates/user_import_form.pt:70
 msgid "Available fields/columns"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:391
+#: ../workspace/browser/tiles/sidebar.py:390
 msgid "Back"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:52
+#: ../search/browser/templates/all_results.pt:48
 msgid "Before last month"
 msgstr ""
 
@@ -218,16 +221,12 @@ msgstr ""
 msgid "Biography"
 msgstr ""
 
-#: ../userprofile/browser/templates/user_import_form.pt:13
-msgid "Bulk import users"
-msgstr ""
-
 msgid "CSV document"
 msgstr ""
 
 #: ../messaging/browser/send-message.pt:63
 #: ../workspace/basecontent/document.py:77
-#: ../workspace/browser/templates/add_content.pt:36
+#: ../workspace/browser/templates/add_content.pt:38
 msgid "Cancel"
 msgstr ""
 
@@ -252,7 +251,7 @@ msgid "Change role of member"
 msgstr ""
 
 #: ../todo/browser/templates/todo_view.pt:48
-#: ../workspace/basecontent/templates/document_view.pt:41
+#: ../workspace/basecontent/templates/document_view.pt:44
 msgid "Change the workflow state"
 msgstr ""
 
@@ -260,11 +259,11 @@ msgstr ""
 msgid "Changes applied"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:357
+#: ../workspace/browser/tiles/templates/sidebar.pt:380
 msgid "Close milestone"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:157
+#: ../workspace/browser/templates/content_macros.pt:163
 msgid "Confirmed"
 msgstr ""
 
@@ -281,25 +280,25 @@ msgstr ""
 msgid "Contact"
 msgstr ""
 
-#: ../userprofile/browser/tiles/templates/contacts_search.pt:9
+#: ../userprofile/browser/tiles/templates/contacts_search.pt:10
 msgid "Contacts"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:27
+#: ../search/browser/templates/all_results.pt:23
 msgid "Content types"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:95
+#: ../workspace/browser/tiles/templates/sidebar.pt:99
 msgid "Copy"
 msgstr ""
 
-#: ../workspace/browser/templates/add_content.pt:33
+#: ../workspace/browser/templates/add_content.pt:35
 #: ../workspace/browser/templates/add_folder.pt:20
 #: ../workspace/browser/templates/add_task.pt:24
 msgid "Create"
 msgstr ""
 
-#: ../workspace/browser/templates/workspaces.pt:24
+#: ../workspace/browser/templates/workspaces.pt:30
 msgid "Create a new workspace"
 msgstr ""
 
@@ -313,11 +312,11 @@ msgid "Create event"
 msgstr ""
 
 #: ../workspace/browser/templates/add_folder.pt:7
-#: ../workspace/browser/tiles/templates/sidebar.pt:221
+#: ../workspace/browser/tiles/templates/sidebar.pt:225
 msgid "Create folder"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:289
+#: ../workspace/browser/tiles/templates/sidebar.pt:293
 msgid "Create new task"
 msgstr ""
 
@@ -327,7 +326,7 @@ msgstr ""
 
 #: ../theme/browser/templates/workspaces.pt:25
 #: ../workspace/browser/templates/workspace-add.pt:11
-#: ../workspace/browser/templates/workspaces.pt:24
+#: ../workspace/browser/templates/workspaces.pt:30
 msgid "Create workspace"
 msgstr ""
 
@@ -335,30 +334,30 @@ msgstr ""
 msgid "Creation date"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:88
+#: ../workspace/browser/tiles/templates/sidebar.pt:92
 msgid "Cut"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:203
+#: ../workspace/browser/tiles/templates/sidebar.pt:207
 msgid "Date and time of the latest modification"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:159
+#: ../workspace/browser/templates/content_macros.pt:165
 msgid "Declined"
 msgstr ""
 
 #: ../todo/browser/templates/todo_view.pt:34
-#: ../workspace/basecontent/templates/document_view.pt:35
-#: ../workspace/basecontent/templates/event_view.pt:50
+#: ../workspace/basecontent/templates/document_view.pt:38
+#: ../workspace/basecontent/templates/event_view.pt:49
 msgid "Delete"
 msgstr ""
 
 #: ../todo/browser/templates/todo_view.pt:34
-#: ../workspace/basecontent/templates/document_view.pt:35
+#: ../workspace/basecontent/templates/document_view.pt:38
 msgid "Delete this document"
 msgstr ""
 
-#: ../workspace/basecontent/templates/event_view.pt:50
+#: ../workspace/basecontent/templates/event_view.pt:49
 msgid "Delete this event"
 msgstr ""
 
@@ -370,22 +369,22 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: ../workspace/browser/templates/add_content.pt:27
+#: ../workspace/browser/templates/add_content.pt:29
 #: ../workspace/browser/templates/add_folder.pt:15
 msgid "Description for search results (Optional)"
 msgstr ""
 
 #: ../workspace/browser/tiles/templates/navigation.pt:36
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:37
-#: ../workspace/browser/tiles/templates/sidebar.pt:82
+#: ../workspace/browser/tiles/templates/sidebar.pt:86
 msgid "Deslect all"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:91
+#: ../search/browser/templates/all_results.pt:81
 msgid "Did you mean"
 msgstr ""
 
-#: ../workspace/browser/templates/add_content.pt:25
+#: ../workspace/browser/templates/add_content.pt:27
 msgid "Document title"
 msgstr ""
 
@@ -393,11 +392,11 @@ msgstr ""
 msgid "Documents"
 msgstr ""
 
-#: ../todo/browser/templates/todo_view.pt:51
+#: ../todo/browser/templates/todo_view.pt:65
 msgid "Done"
 msgstr ""
 
-#: ../workspace/basecontent/templates/document_view.pt:109
+#: ../workspace/basecontent/templates/document_view.pt:113
 msgid "Download as"
 msgstr ""
 
@@ -414,7 +413,7 @@ msgstr ""
 msgid "Edit latest news portlet"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:146
+#: ../workspace/browser/tiles/templates/sidebar.pt:150
 msgid "Edit name/description"
 msgstr ""
 
@@ -424,10 +423,6 @@ msgstr ""
 
 #: ../userprofile/content/userprofile.py:45
 msgid "Email"
-msgstr ""
-
-#: ../workspace/browser/tiles/templates/sidebar.pt:422
-msgid "Ended"
 msgstr ""
 
 #: ../workspace/browser/templates/add_event.pt:25
@@ -463,6 +458,10 @@ msgstr ""
 
 #: ../core/browser/stream.py:56
 msgid "Explore"
+msgstr ""
+
+#: ../userprofile/sync.py:80
+msgid "External property sync complete."
 msgstr ""
 
 msgid "File"
@@ -513,7 +512,7 @@ msgstr ""
 msgid "For cases, security is managed by the case workflow. You cannot configure it here like in workspaces. Instead please just assign the correct roles to users and groups in the \"Members\" tab."
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:106
+#: ../workspace/browser/templates/content_macros.pt:109
 msgid "From"
 msgstr ""
 
@@ -529,11 +528,11 @@ msgstr ""
 msgid "Functions"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:469
+#: ../workspace/browser/tiles/templates/sidebar.pt:494
 msgid "General"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:296
+#: ../workspace/browser/tiles/templates/sidebar.pt:300
 msgid "General tasks"
 msgstr ""
 
@@ -562,7 +561,7 @@ msgstr ""
 msgid "If checked, users will be removed from workspace"
 msgstr ""
 
-#: ../workspace/browser/templates/add_content.pt:21
+#: ../workspace/browser/templates/add_content.pt:23
 msgid "Image"
 msgstr ""
 
@@ -575,7 +574,7 @@ msgstr ""
 msgid "Images"
 msgstr ""
 
-#: ../userprofile/browser/templates/user_import_form.pt:31
+#: ../userprofile/browser/templates/user_import_form.pt:62
 msgid "Import users from file"
 msgstr ""
 
@@ -604,15 +603,15 @@ msgid "Invitations"
 msgstr ""
 
 #: ../workspace/browser/templates/roster-edit.pt:169
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:118
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:121
 msgid "Invite users to this workspace (via email)"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:150
+#: ../workspace/browser/templates/content_macros.pt:156
 msgid "Invitees"
 msgstr ""
 
-#: ../workspace/browser/add_content.py:89
+#: ../workspace/browser/add_content.py:104
 msgid "Item created."
 msgstr ""
 
@@ -620,19 +619,19 @@ msgstr ""
 msgid "Item edited."
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:630
+#: ../workspace/browser/tiles/sidebar.py:629
 msgid "Items modified last month"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:624
+#: ../workspace/browser/tiles/sidebar.py:623
 msgid "Items modified last week"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:618
+#: ../workspace/browser/tiles/sidebar.py:617
 msgid "Items modified today"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:636
+#: ../workspace/browser/tiles/sidebar.py:635
 msgid "Items since ever"
 msgstr ""
 
@@ -651,19 +650,19 @@ msgstr ""
 msgid "Join now"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:38
+#: ../search/browser/templates/all_results.pt:34
 msgid "Last Modified"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:629
+#: ../workspace/browser/tiles/sidebar.py:628
 msgid "Last Month"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:623
+#: ../workspace/browser/tiles/sidebar.py:622
 msgid "Last Week"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:49
+#: ../search/browser/templates/all_results.pt:45
 msgid "Last month"
 msgstr ""
 
@@ -671,7 +670,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:46
+#: ../search/browser/templates/all_results.pt:42
 msgid "Last week"
 msgstr ""
 
@@ -683,7 +682,7 @@ msgstr ""
 msgid "Leave a comment"
 msgstr ""
 
-#: ../core/browser/tiles/templates/my_documents.pt:8
+#: ../core/browser/tiles/templates/my_documents.pt:9
 #: ../library/profiles/default/actions.xml
 msgid "Library"
 msgstr ""
@@ -731,16 +730,16 @@ msgstr ""
 msgid "Member"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:168
+#: ../workspace/browser/tiles/sidebar.py:178
 msgid "Member(s) added"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:176
+#: ../workspace/browser/tiles/sidebar.py:183
 msgid "Member(s) removed"
 msgstr ""
 
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:20
-#: ../workspace/browser/tiles/templates/sidebar.pt:473
+#: ../workspace/browser/tiles/templates/sidebar.pt:498
 msgid "Members"
 msgstr ""
 
@@ -786,7 +785,7 @@ msgstr ""
 msgid "More information about"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:185
+#: ../search/browser/templates/all_results.pt:175
 #: ../search/browser/templates/file_results.pt:32
 #: ../search/browser/templates/image_results.pt:32
 msgid "More results"
@@ -841,7 +840,7 @@ msgstr ""
 msgid "No such user ${userid}."
 msgstr ""
 
-#: ../layout/browser/templates/tasks-tile.pt:9
+#: ../layout/browser/templates/tasks-tile.pt:11
 msgid "No tasks available"
 msgstr ""
 
@@ -849,7 +848,6 @@ msgstr ""
 msgid "No token id given in sub-path.Use .../@@accept-token/tokenid"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:25
 #: ../workspace/browser/tiles/templates/navigation.pt:36
 msgid "None"
 msgstr ""
@@ -882,7 +880,7 @@ msgstr ""
 msgid "Ok"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:451
+#: ../workspace/browser/tiles/templates/sidebar.pt:476
 msgid "Older events"
 msgstr ""
 
@@ -890,7 +888,7 @@ msgstr ""
 msgid "Only administrators can add workspace members."
 msgstr ""
 
-#: ../todo/browser/templates/todo_view.pt:50
+#: ../todo/browser/templates/todo_view.pt:63
 #: ../workspace/policies.py:23
 msgid "Open"
 msgstr ""
@@ -917,7 +915,7 @@ msgstr ""
 msgid "Page"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:102
+#: ../workspace/browser/tiles/templates/sidebar.pt:106
 msgid "Paste"
 msgstr ""
 
@@ -952,7 +950,11 @@ msgstr ""
 msgid "Pick an initiator"
 msgstr ""
 
-#: ../workspace/browser/add_content.py:48
+#: ../todo/browser/templates/todo_view.pt:64
+msgid "Planned"
+msgstr ""
+
+#: ../workspace/browser/add_content.py:63
 msgid "Please specify which Case Template to use"
 msgstr ""
 
@@ -1008,15 +1010,19 @@ msgstr ""
 msgid "Remove role"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:360
+#: ../todo/browser/templates/todo_view.pt:71
+msgid "Reopen"
+msgstr ""
+
+#: ../workspace/browser/tiles/templates/sidebar.pt:383
 msgid "Reopen milestone"
 msgstr ""
 
-#: ../workspace/browser/templates/add_content.pt:15
+#: ../workspace/browser/templates/add_content.pt:17
 msgid "Rich text"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:189
+#: ../workspace/browser/tiles/sidebar.py:190
 msgid "Role updated"
 msgstr ""
 
@@ -1024,13 +1030,13 @@ msgstr ""
 msgid "Roster updated."
 msgstr ""
 
-#: ../todo/browser/templates/todo_view.pt:56
+#: ../todo/browser/templates/todo_view.pt:77
 #: ../userprofile/browser/templates/userprofile-edit.pt:47
 #: ../workspace/basecontent/document.py:73
 msgid "Save"
 msgstr ""
 
-#: ../workspace/basecontent/templates/event_view.pt:86
+#: ../workspace/basecontent/templates/event_view.pt:85
 msgid "Save this document"
 msgstr ""
 
@@ -1056,7 +1062,7 @@ msgstr ""
 msgid "Secret"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:477
+#: ../workspace/browser/tiles/templates/sidebar.pt:502
 msgid "Security"
 msgstr ""
 
@@ -1067,7 +1073,7 @@ msgstr ""
 
 #: ../workspace/browser/tiles/templates/navigation.pt:35
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:36
-#: ../workspace/browser/tiles/templates/sidebar.pt:81
+#: ../workspace/browser/tiles/templates/sidebar.pt:85
 msgid "Select all"
 msgstr ""
 
@@ -1099,17 +1105,17 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: ../workspace/basecontent/templates/document_view.pt:37
+#: ../workspace/basecontent/templates/document_view.pt:40
 msgid "Share"
 msgstr ""
 
-#: ../workspace/basecontent/templates/document_view.pt:37
+#: ../workspace/basecontent/templates/document_view.pt:40
 msgid "Share this document"
 msgstr ""
 
 #: ../todo/browser/templates/todo_view.pt:43
-#: ../workspace/basecontent/templates/document_view.pt:38
-#: ../workspace/basecontent/templates/event_view.pt:63
+#: ../workspace/basecontent/templates/document_view.pt:41
+#: ../workspace/basecontent/templates/event_view.pt:62
 msgid "Show extra metadata fields"
 msgstr ""
 
@@ -1129,12 +1135,12 @@ msgstr ""
 msgid "Start date should be lower than end date"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:417
-msgid "Starts"
-msgstr ""
-
 #: ../network/browser/templates/author.pt:29
 msgid "Status updates by ${fullname}:"
+msgstr ""
+
+#: ../layout/browser/templates/dashboard.pt:21
+msgid "Task centric view"
 msgstr ""
 
 #: ../todo/utils.py:31
@@ -1145,6 +1151,7 @@ msgstr ""
 msgid "Task title"
 msgstr ""
 
+#: ../layout/browser/templates/tasks-tile.pt:10
 #: ../workspace/browser/tiles/templates/workspace-tabs-tile.pt:22
 msgid "Tasks"
 msgstr ""
@@ -1157,7 +1164,7 @@ msgstr ""
 msgid "Telephone Number"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:158
+#: ../workspace/browser/templates/content_macros.pt:164
 msgid "Tentative"
 msgstr ""
 
@@ -1277,7 +1284,7 @@ msgstr ""
 msgid "The workspace will only be accessible for team members. Any member can add a new team member. Once you're in the team, you can do pretty much anything. Nothing in this group will ever be visible to non-members."
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:294
+#: ../workspace/browser/tiles/sidebar.py:293
 msgid "There was a problem updating the content: %s."
 msgstr ""
 
@@ -1285,7 +1292,7 @@ msgstr ""
 msgid "There was a problem: %s"
 msgstr ""
 
-#: ../workspace/browser/add_content.py:95
+#: ../workspace/browser/add_content.py:110
 #: ../workspace/browser/edit_content.py:38
 msgid "There was a problem: %s."
 msgstr ""
@@ -1310,11 +1317,11 @@ msgstr ""
 msgid "Timeline"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:138
+#: ../workspace/browser/templates/content_macros.pt:144
 msgid "Timezone"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:123
+#: ../workspace/browser/templates/content_macros.pt:127
 msgid "To"
 msgstr ""
 
@@ -1322,8 +1329,8 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:43
-#: ../workspace/browser/tiles/sidebar.py:617
+#: ../search/browser/templates/all_results.pt:39
+#: ../workspace/browser/tiles/sidebar.py:616
 msgid "Today"
 msgstr ""
 
@@ -1331,8 +1338,8 @@ msgid "Todo"
 msgstr ""
 
 #: ../todo/browser/templates/todo_view.pt:43
-#: ../workspace/basecontent/templates/document_view.pt:38
-#: ../workspace/basecontent/templates/event_view.pt:63
+#: ../workspace/basecontent/templates/document_view.pt:41
+#: ../workspace/basecontent/templates/event_view.pt:62
 msgid "Toggle extra metadata"
 msgstr ""
 
@@ -1341,15 +1348,15 @@ msgid "Token no longer valid"
 msgstr ""
 
 #: ../workspace/browser/templates/roster-edit.pt:176
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:124
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:127
 msgid "Transfer members to another workspace."
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:367
+#: ../workspace/browser/tiles/templates/sidebar.pt:390
 msgid "Unassigned"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:156
+#: ../workspace/browser/templates/content_macros.pt:162
 msgid "Undecided"
 msgstr ""
 
@@ -1357,7 +1364,7 @@ msgstr ""
 msgid "Unfollow"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:195
+#: ../workspace/browser/tiles/sidebar.py:193
 msgid "Unknown function"
 msgstr ""
 
@@ -1365,12 +1372,12 @@ msgstr ""
 msgid "Unlike"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/events.pt:9
-#: ../workspace/browser/tiles/templates/sidebar.pt:400
+#: ../workspace/browser/tiles/templates/events.pt:10
+#: ../workspace/browser/tiles/templates/sidebar.pt:423
 msgid "Upcoming events"
 msgstr ""
 
-#: ../userprofile/browser/templates/user_import_form.pt:25
+#: ../userprofile/browser/templates/user_import_form.pt:56
 msgid "Update details for existing users (matching on username)"
 msgstr ""
 
@@ -1379,8 +1386,12 @@ msgstr ""
 msgid "Updates"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:244
+#: ../workspace/browser/tiles/templates/sidebar.pt:248
 msgid "Upload file(s)"
+msgstr ""
+
+#: ../userprofile/browser/templates/user_import_form.pt:18
+msgid "User profile management"
 msgstr ""
 
 #: ../microblog/interfaces.py:17
@@ -1446,7 +1457,7 @@ msgstr ""
 msgid "Workspace policy"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:247
+#: ../workspace/browser/tiles/sidebar.py:246
 msgid "Workspace security policy changes saved"
 msgstr ""
 
@@ -1475,7 +1486,7 @@ msgstr ""
 msgid "You can become a member of this workspace"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:160
+#: ../workspace/browser/tiles/sidebar.py:161
 msgid "You do not have permission to change the workspace policy"
 msgstr ""
 
@@ -1517,6 +1528,11 @@ msgstr ""
 msgid "date"
 msgstr ""
 
+#. Default: "Start time should be lower than end time. The system set the end time to: ${date}"
+#: ../workspace/browser/add_content.py:164
+msgid "dates_hijacked"
+msgstr ""
+
 #: ../workspace/browser/tiles/templates/navigation.pt:21
 #: ../workspace/browser/tiles/templates/sidebar.pt:37
 msgid "document type"
@@ -1528,7 +1544,7 @@ msgid "download"
 msgstr ""
 
 #. Default: "Drop files here or click to browse..."
-#: ../workspace/browser/tiles/sidebar.py:310
+#: ../workspace/browser/tiles/sidebar.py:309
 msgid "drop_files_here"
 msgstr ""
 
@@ -1548,7 +1564,7 @@ msgid "expand/reduce sidebar"
 msgstr ""
 
 #. Default: "External visibility"
-#: ../workspace/browser/tiles/sidebar.py:215
+#: ../workspace/browser/tiles/sidebar.py:214
 msgid "external_visibility_label"
 msgstr ""
 
@@ -1587,14 +1603,14 @@ msgstr ""
 msgid "invititations"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:87
+#: ../search/browser/templates/all_results.pt:77
 #: ../search/browser/templates/image_results.pt:14
 #: ../search/browser/templates/people_results.pt:14
 msgid "items matched your search."
 msgstr ""
 
 #. Default: "Join policy"
-#: ../workspace/browser/tiles/sidebar.py:214
+#: ../workspace/browser/tiles/sidebar.py:213
 msgid "join_policy_label"
 msgstr ""
 
@@ -1612,13 +1628,13 @@ msgstr ""
 msgid "label_name"
 msgstr ""
 
-#. Default: "News"
-#: ../layout/browser/templates/news-tile.pt:8
+#. Default: "<a href=\"${context/portal_url}/library/news\">News</a>"
+#: ../layout/browser/templates/news-tile.pt:9
 msgid "label_news"
 msgstr ""
 
 #. Default: "No events available"
-#: ../workspace/browser/tiles/templates/sidebar.pt:460
+#: ../workspace/browser/tiles/templates/sidebar.pt:485
 msgid "label_no_events_available"
 msgstr ""
 
@@ -1668,36 +1684,36 @@ msgid "leave_a_comment"
 msgstr ""
 
 #. Default: "More sharing options coming soon"
-#: ../workspace/basecontent/templates/document_view.pt:111
+#: ../workspace/basecontent/templates/document_view.pt:115
 msgid "more_sharing_soon"
 msgstr ""
 
 #. Default: "No tasks created yet"
-#: ../workspace/browser/tiles/templates/sidebar.pt:298
+#: ../workspace/browser/tiles/templates/sidebar.pt:302
 msgid "no-task-found"
 msgstr ""
 
 #. Default: "${no_members} Members"
-#: ../workspace/workspacefolder.py:167
+#: ../workspace/workspacefolder.py:172
 msgid "number_of_members"
 msgstr ""
 
 #. Default: "Participant policy"
-#: ../workspace/browser/tiles/sidebar.py:217
+#: ../workspace/browser/tiles/sidebar.py:216
 msgid "participant_policy_label"
 msgstr ""
 
 #. Default: "Description"
-#: ../workspace/basecontent/templates/event_view.pt:101
+#: ../workspace/basecontent/templates/event_view.pt:100
 msgid "placeholder"
 msgstr ""
 
-#: ../workspace/browser/tiles/workspaces.py:109
+#: ../workspace/browser/tiles/workspaces.py:120
 msgid "posted"
 msgstr ""
 
 #. Default: "Read more..."
-#: ../layout/browser/templates/news-tile.pt:19
+#: ../layout/browser/templates/news-tile.pt:20
 #: ../library/browser/templates/library.html:148
 msgid "read-more"
 msgstr ""
@@ -1709,13 +1725,13 @@ msgstr ""
 
 #. Default: "All"
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:36
-#: ../workspace/browser/tiles/templates/sidebar.pt:81
+#: ../workspace/browser/tiles/templates/sidebar.pt:85
 msgid "select_all"
 msgstr ""
 
 #. Default: "None"
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:37
-#: ../workspace/browser/tiles/templates/sidebar.pt:82
+#: ../workspace/browser/tiles/templates/sidebar.pt:86
 msgid "select_none"
 msgstr ""
 
@@ -1726,6 +1742,16 @@ msgstr ""
 
 #: ../workspace/browser/tiles/templates/sidebar.pt:35
 msgid "tag"
+msgstr ""
+
+#. Cases
+#: ../layout/browser/templates/dashboard.pt
+msgid "tile_ploneintranet.workspace.case"
+msgstr ""
+
+#. Workspaces
+#: ../layout/browser/templates/dashboard.pt
+msgid "tile_ploneintranet.workspace.workspacefolder"
 msgstr ""
 
 #: ../network/browser/templates/maxiauthor_provider.pt:72

--- a/src/ploneintranet/core/locales/pt_BR/LC_MESSAGES/ploneintranet.po
+++ b/src/ploneintranet/core/locales/pt_BR/LC_MESSAGES/ploneintranet.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-08-28 08:33+0000\n"
+"POT-Creation-Date: 2015-10-01 12:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -50,11 +50,15 @@ msgstr ""
 msgid "A user with this username already exists"
 msgstr ""
 
+#: ../layout/browser/templates/dashboard.pt:18
+msgid "Activity centric view"
+msgstr ""
+
 #: ../messaging/browser/messaging.py:26
 msgid "Add a comment"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:91
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:94
 msgid "Add group"
 msgstr ""
 
@@ -71,7 +75,7 @@ msgstr ""
 msgid "Add tags"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:88
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:91
 msgid "Add user"
 msgstr ""
 
@@ -88,47 +92,46 @@ msgid "Admin-Managed"
 msgstr ""
 
 #: ../workspace/browser/templates/roster-edit.pt:167
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:116
-#: ../workspace/browser/tiles/templates/sidebar.pt:481
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:119
+#: ../workspace/browser/tiles/templates/sidebar.pt:506
 msgid "Advanced"
 msgstr ""
 
 #: ../workspace/browser/templates/roster-edit.pt:183
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:130
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:133
 msgid "Advanced permissions"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:24
 #: ../search/browser/templates/search_template.pt:24
 #: ../workspace/browser/tiles/templates/navigation.pt:35
 msgid "All"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:385
+#: ../workspace/browser/tiles/sidebar.py:384
 msgid "All Authors"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:381
+#: ../workspace/browser/tiles/sidebar.py:380
 msgid "All Dates"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:389
+#: ../workspace/browser/tiles/sidebar.py:388
 msgid "All Letters"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:383
+#: ../workspace/browser/tiles/sidebar.py:382
 msgid "All Tags"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:635
+#: ../workspace/browser/tiles/sidebar.py:634
 msgid "All Time"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:387
+#: ../workspace/browser/tiles/sidebar.py:386
 msgid "All Types"
 msgstr ""
 
-#: ../workspace/browser/tiles/events.py:49
+#: ../workspace/browser/tiles/events.py:52
 msgid "All day"
 msgstr ""
 
@@ -152,7 +155,7 @@ msgstr ""
 msgid "Any logged-in user is allowed to join the group and participate. Anything in this group is visible for any logged-in user, even if they're not a member."
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:40
+#: ../search/browser/templates/all_results.pt:36
 msgid "Any modification date"
 msgstr ""
 
@@ -179,15 +182,15 @@ msgstr ""
 msgid "Attach a file (or create a picture)"
 msgstr ""
 
-#: ../workspace/basecontent/templates/event_view.pt:60
+#: ../workspace/basecontent/templates/event_view.pt:59
 msgid "Attach documents"
 msgstr ""
 
-#: ../workspace/basecontent/templates/event_view.pt:60
+#: ../workspace/basecontent/templates/event_view.pt:59
 msgid "Attachments"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:286
+#: ../workspace/browser/tiles/sidebar.py:285
 msgid "Attributes changed."
 msgstr ""
 
@@ -195,19 +198,19 @@ msgstr ""
 msgid "Author name (for display)"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:200
+#: ../workspace/browser/tiles/templates/sidebar.pt:204
 msgid "Author of this document"
 msgstr ""
 
-#: ../userprofile/browser/templates/user_import_form.pt:39
+#: ../userprofile/browser/templates/user_import_form.pt:70
 msgid "Available fields/columns"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:391
+#: ../workspace/browser/tiles/sidebar.py:390
 msgid "Back"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:52
+#: ../search/browser/templates/all_results.pt:48
 msgid "Before last month"
 msgstr ""
 
@@ -215,16 +218,12 @@ msgstr ""
 msgid "Biography"
 msgstr ""
 
-#: ../userprofile/browser/templates/user_import_form.pt:13
-msgid "Bulk import users"
-msgstr ""
-
 msgid "CSV document"
 msgstr ""
 
 #: ../messaging/browser/send-message.pt:63
 #: ../workspace/basecontent/document.py:77
-#: ../workspace/browser/templates/add_content.pt:36
+#: ../workspace/browser/templates/add_content.pt:38
 msgid "Cancel"
 msgstr ""
 
@@ -249,7 +248,7 @@ msgid "Change role of member"
 msgstr ""
 
 #: ../todo/browser/templates/todo_view.pt:48
-#: ../workspace/basecontent/templates/document_view.pt:41
+#: ../workspace/basecontent/templates/document_view.pt:44
 msgid "Change the workflow state"
 msgstr ""
 
@@ -257,11 +256,11 @@ msgstr ""
 msgid "Changes applied"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:357
+#: ../workspace/browser/tiles/templates/sidebar.pt:380
 msgid "Close milestone"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:157
+#: ../workspace/browser/templates/content_macros.pt:163
 msgid "Confirmed"
 msgstr ""
 
@@ -278,25 +277,25 @@ msgstr ""
 msgid "Contact"
 msgstr ""
 
-#: ../userprofile/browser/tiles/templates/contacts_search.pt:9
+#: ../userprofile/browser/tiles/templates/contacts_search.pt:10
 msgid "Contacts"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:27
+#: ../search/browser/templates/all_results.pt:23
 msgid "Content types"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:95
+#: ../workspace/browser/tiles/templates/sidebar.pt:99
 msgid "Copy"
 msgstr ""
 
-#: ../workspace/browser/templates/add_content.pt:33
+#: ../workspace/browser/templates/add_content.pt:35
 #: ../workspace/browser/templates/add_folder.pt:20
 #: ../workspace/browser/templates/add_task.pt:24
 msgid "Create"
 msgstr ""
 
-#: ../workspace/browser/templates/workspaces.pt:24
+#: ../workspace/browser/templates/workspaces.pt:30
 msgid "Create a new workspace"
 msgstr ""
 
@@ -310,11 +309,11 @@ msgid "Create event"
 msgstr ""
 
 #: ../workspace/browser/templates/add_folder.pt:7
-#: ../workspace/browser/tiles/templates/sidebar.pt:221
+#: ../workspace/browser/tiles/templates/sidebar.pt:225
 msgid "Create folder"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:289
+#: ../workspace/browser/tiles/templates/sidebar.pt:293
 msgid "Create new task"
 msgstr ""
 
@@ -324,7 +323,7 @@ msgstr ""
 
 #: ../theme/browser/templates/workspaces.pt:25
 #: ../workspace/browser/templates/workspace-add.pt:11
-#: ../workspace/browser/templates/workspaces.pt:24
+#: ../workspace/browser/templates/workspaces.pt:30
 msgid "Create workspace"
 msgstr ""
 
@@ -332,30 +331,30 @@ msgstr ""
 msgid "Creation date"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:88
+#: ../workspace/browser/tiles/templates/sidebar.pt:92
 msgid "Cut"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:203
+#: ../workspace/browser/tiles/templates/sidebar.pt:207
 msgid "Date and time of the latest modification"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:159
+#: ../workspace/browser/templates/content_macros.pt:165
 msgid "Declined"
 msgstr ""
 
 #: ../todo/browser/templates/todo_view.pt:34
-#: ../workspace/basecontent/templates/document_view.pt:35
-#: ../workspace/basecontent/templates/event_view.pt:50
+#: ../workspace/basecontent/templates/document_view.pt:38
+#: ../workspace/basecontent/templates/event_view.pt:49
 msgid "Delete"
 msgstr ""
 
 #: ../todo/browser/templates/todo_view.pt:34
-#: ../workspace/basecontent/templates/document_view.pt:35
+#: ../workspace/basecontent/templates/document_view.pt:38
 msgid "Delete this document"
 msgstr ""
 
-#: ../workspace/basecontent/templates/event_view.pt:50
+#: ../workspace/basecontent/templates/event_view.pt:49
 msgid "Delete this event"
 msgstr ""
 
@@ -367,22 +366,22 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: ../workspace/browser/templates/add_content.pt:27
+#: ../workspace/browser/templates/add_content.pt:29
 #: ../workspace/browser/templates/add_folder.pt:15
 msgid "Description for search results (Optional)"
 msgstr ""
 
 #: ../workspace/browser/tiles/templates/navigation.pt:36
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:37
-#: ../workspace/browser/tiles/templates/sidebar.pt:82
+#: ../workspace/browser/tiles/templates/sidebar.pt:86
 msgid "Deslect all"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:91
+#: ../search/browser/templates/all_results.pt:81
 msgid "Did you mean"
 msgstr ""
 
-#: ../workspace/browser/templates/add_content.pt:25
+#: ../workspace/browser/templates/add_content.pt:27
 msgid "Document title"
 msgstr ""
 
@@ -390,11 +389,11 @@ msgstr ""
 msgid "Documents"
 msgstr ""
 
-#: ../todo/browser/templates/todo_view.pt:51
+#: ../todo/browser/templates/todo_view.pt:65
 msgid "Done"
 msgstr ""
 
-#: ../workspace/basecontent/templates/document_view.pt:109
+#: ../workspace/basecontent/templates/document_view.pt:113
 msgid "Download as"
 msgstr ""
 
@@ -411,7 +410,7 @@ msgstr ""
 msgid "Edit latest news portlet"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:146
+#: ../workspace/browser/tiles/templates/sidebar.pt:150
 msgid "Edit name/description"
 msgstr ""
 
@@ -421,10 +420,6 @@ msgstr ""
 
 #: ../userprofile/content/userprofile.py:45
 msgid "Email"
-msgstr ""
-
-#: ../workspace/browser/tiles/templates/sidebar.pt:422
-msgid "Ended"
 msgstr ""
 
 #: ../workspace/browser/templates/add_event.pt:25
@@ -460,6 +455,10 @@ msgstr ""
 
 #: ../core/browser/stream.py:56
 msgid "Explore"
+msgstr ""
+
+#: ../userprofile/sync.py:80
+msgid "External property sync complete."
 msgstr ""
 
 msgid "File"
@@ -510,7 +509,7 @@ msgstr ""
 msgid "For cases, security is managed by the case workflow. You cannot configure it here like in workspaces. Instead please just assign the correct roles to users and groups in the \"Members\" tab."
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:106
+#: ../workspace/browser/templates/content_macros.pt:109
 msgid "From"
 msgstr ""
 
@@ -526,11 +525,11 @@ msgstr ""
 msgid "Functions"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:469
+#: ../workspace/browser/tiles/templates/sidebar.pt:494
 msgid "General"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:296
+#: ../workspace/browser/tiles/templates/sidebar.pt:300
 msgid "General tasks"
 msgstr ""
 
@@ -559,7 +558,7 @@ msgstr ""
 msgid "If checked, users will be removed from workspace"
 msgstr ""
 
-#: ../workspace/browser/templates/add_content.pt:21
+#: ../workspace/browser/templates/add_content.pt:23
 msgid "Image"
 msgstr ""
 
@@ -572,7 +571,7 @@ msgstr ""
 msgid "Images"
 msgstr ""
 
-#: ../userprofile/browser/templates/user_import_form.pt:31
+#: ../userprofile/browser/templates/user_import_form.pt:62
 msgid "Import users from file"
 msgstr ""
 
@@ -601,15 +600,15 @@ msgid "Invitations"
 msgstr ""
 
 #: ../workspace/browser/templates/roster-edit.pt:169
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:118
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:121
 msgid "Invite users to this workspace (via email)"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:150
+#: ../workspace/browser/templates/content_macros.pt:156
 msgid "Invitees"
 msgstr ""
 
-#: ../workspace/browser/add_content.py:89
+#: ../workspace/browser/add_content.py:104
 msgid "Item created."
 msgstr ""
 
@@ -617,19 +616,19 @@ msgstr ""
 msgid "Item edited."
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:630
+#: ../workspace/browser/tiles/sidebar.py:629
 msgid "Items modified last month"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:624
+#: ../workspace/browser/tiles/sidebar.py:623
 msgid "Items modified last week"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:618
+#: ../workspace/browser/tiles/sidebar.py:617
 msgid "Items modified today"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:636
+#: ../workspace/browser/tiles/sidebar.py:635
 msgid "Items since ever"
 msgstr ""
 
@@ -648,19 +647,19 @@ msgstr ""
 msgid "Join now"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:38
+#: ../search/browser/templates/all_results.pt:34
 msgid "Last Modified"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:629
+#: ../workspace/browser/tiles/sidebar.py:628
 msgid "Last Month"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:623
+#: ../workspace/browser/tiles/sidebar.py:622
 msgid "Last Week"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:49
+#: ../search/browser/templates/all_results.pt:45
 msgid "Last month"
 msgstr ""
 
@@ -668,7 +667,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:46
+#: ../search/browser/templates/all_results.pt:42
 msgid "Last week"
 msgstr ""
 
@@ -680,7 +679,7 @@ msgstr ""
 msgid "Leave a comment"
 msgstr ""
 
-#: ../core/browser/tiles/templates/my_documents.pt:8
+#: ../core/browser/tiles/templates/my_documents.pt:9
 #: ../library/profiles/default/actions.xml
 msgid "Library"
 msgstr ""
@@ -728,16 +727,16 @@ msgstr ""
 msgid "Member"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:168
+#: ../workspace/browser/tiles/sidebar.py:178
 msgid "Member(s) added"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:176
+#: ../workspace/browser/tiles/sidebar.py:183
 msgid "Member(s) removed"
 msgstr ""
 
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:20
-#: ../workspace/browser/tiles/templates/sidebar.pt:473
+#: ../workspace/browser/tiles/templates/sidebar.pt:498
 msgid "Members"
 msgstr ""
 
@@ -783,7 +782,7 @@ msgstr ""
 msgid "More information about"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:185
+#: ../search/browser/templates/all_results.pt:175
 #: ../search/browser/templates/file_results.pt:32
 #: ../search/browser/templates/image_results.pt:32
 msgid "More results"
@@ -838,7 +837,7 @@ msgstr ""
 msgid "No such user ${userid}."
 msgstr ""
 
-#: ../layout/browser/templates/tasks-tile.pt:9
+#: ../layout/browser/templates/tasks-tile.pt:11
 msgid "No tasks available"
 msgstr ""
 
@@ -846,7 +845,6 @@ msgstr ""
 msgid "No token id given in sub-path.Use .../@@accept-token/tokenid"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:25
 #: ../workspace/browser/tiles/templates/navigation.pt:36
 msgid "None"
 msgstr ""
@@ -879,7 +877,7 @@ msgstr ""
 msgid "Ok"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:451
+#: ../workspace/browser/tiles/templates/sidebar.pt:476
 msgid "Older events"
 msgstr ""
 
@@ -887,7 +885,7 @@ msgstr ""
 msgid "Only administrators can add workspace members."
 msgstr ""
 
-#: ../todo/browser/templates/todo_view.pt:50
+#: ../todo/browser/templates/todo_view.pt:63
 #: ../workspace/policies.py:23
 msgid "Open"
 msgstr ""
@@ -914,7 +912,7 @@ msgstr ""
 msgid "Page"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:102
+#: ../workspace/browser/tiles/templates/sidebar.pt:106
 msgid "Paste"
 msgstr ""
 
@@ -949,7 +947,11 @@ msgstr ""
 msgid "Pick an initiator"
 msgstr ""
 
-#: ../workspace/browser/add_content.py:48
+#: ../todo/browser/templates/todo_view.pt:64
+msgid "Planned"
+msgstr ""
+
+#: ../workspace/browser/add_content.py:63
 msgid "Please specify which Case Template to use"
 msgstr ""
 
@@ -1005,15 +1007,19 @@ msgstr ""
 msgid "Remove role"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:360
+#: ../todo/browser/templates/todo_view.pt:71
+msgid "Reopen"
+msgstr ""
+
+#: ../workspace/browser/tiles/templates/sidebar.pt:383
 msgid "Reopen milestone"
 msgstr ""
 
-#: ../workspace/browser/templates/add_content.pt:15
+#: ../workspace/browser/templates/add_content.pt:17
 msgid "Rich text"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:189
+#: ../workspace/browser/tiles/sidebar.py:190
 msgid "Role updated"
 msgstr ""
 
@@ -1021,13 +1027,13 @@ msgstr ""
 msgid "Roster updated."
 msgstr ""
 
-#: ../todo/browser/templates/todo_view.pt:56
+#: ../todo/browser/templates/todo_view.pt:77
 #: ../userprofile/browser/templates/userprofile-edit.pt:47
 #: ../workspace/basecontent/document.py:73
 msgid "Save"
 msgstr ""
 
-#: ../workspace/basecontent/templates/event_view.pt:86
+#: ../workspace/basecontent/templates/event_view.pt:85
 msgid "Save this document"
 msgstr ""
 
@@ -1053,7 +1059,7 @@ msgstr ""
 msgid "Secret"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:477
+#: ../workspace/browser/tiles/templates/sidebar.pt:502
 msgid "Security"
 msgstr ""
 
@@ -1064,7 +1070,7 @@ msgstr ""
 
 #: ../workspace/browser/tiles/templates/navigation.pt:35
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:36
-#: ../workspace/browser/tiles/templates/sidebar.pt:81
+#: ../workspace/browser/tiles/templates/sidebar.pt:85
 msgid "Select all"
 msgstr ""
 
@@ -1096,17 +1102,17 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: ../workspace/basecontent/templates/document_view.pt:37
+#: ../workspace/basecontent/templates/document_view.pt:40
 msgid "Share"
 msgstr ""
 
-#: ../workspace/basecontent/templates/document_view.pt:37
+#: ../workspace/basecontent/templates/document_view.pt:40
 msgid "Share this document"
 msgstr ""
 
 #: ../todo/browser/templates/todo_view.pt:43
-#: ../workspace/basecontent/templates/document_view.pt:38
-#: ../workspace/basecontent/templates/event_view.pt:63
+#: ../workspace/basecontent/templates/document_view.pt:41
+#: ../workspace/basecontent/templates/event_view.pt:62
 msgid "Show extra metadata fields"
 msgstr ""
 
@@ -1126,12 +1132,12 @@ msgstr ""
 msgid "Start date should be lower than end date"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:417
-msgid "Starts"
-msgstr ""
-
 #: ../network/browser/templates/author.pt:29
 msgid "Status updates by ${fullname}:"
+msgstr ""
+
+#: ../layout/browser/templates/dashboard.pt:21
+msgid "Task centric view"
 msgstr ""
 
 #: ../todo/utils.py:31
@@ -1142,6 +1148,7 @@ msgstr ""
 msgid "Task title"
 msgstr ""
 
+#: ../layout/browser/templates/tasks-tile.pt:10
 #: ../workspace/browser/tiles/templates/workspace-tabs-tile.pt:22
 msgid "Tasks"
 msgstr ""
@@ -1154,7 +1161,7 @@ msgstr ""
 msgid "Telephone Number"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:158
+#: ../workspace/browser/templates/content_macros.pt:164
 msgid "Tentative"
 msgstr ""
 
@@ -1274,7 +1281,7 @@ msgstr ""
 msgid "The workspace will only be accessible for team members. Any member can add a new team member. Once you're in the team, you can do pretty much anything. Nothing in this group will ever be visible to non-members."
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:294
+#: ../workspace/browser/tiles/sidebar.py:293
 msgid "There was a problem updating the content: %s."
 msgstr ""
 
@@ -1282,7 +1289,7 @@ msgstr ""
 msgid "There was a problem: %s"
 msgstr ""
 
-#: ../workspace/browser/add_content.py:95
+#: ../workspace/browser/add_content.py:110
 #: ../workspace/browser/edit_content.py:38
 msgid "There was a problem: %s."
 msgstr ""
@@ -1307,11 +1314,11 @@ msgstr ""
 msgid "Timeline"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:138
+#: ../workspace/browser/templates/content_macros.pt:144
 msgid "Timezone"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:123
+#: ../workspace/browser/templates/content_macros.pt:127
 msgid "To"
 msgstr ""
 
@@ -1319,8 +1326,8 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:43
-#: ../workspace/browser/tiles/sidebar.py:617
+#: ../search/browser/templates/all_results.pt:39
+#: ../workspace/browser/tiles/sidebar.py:616
 msgid "Today"
 msgstr ""
 
@@ -1328,8 +1335,8 @@ msgid "Todo"
 msgstr ""
 
 #: ../todo/browser/templates/todo_view.pt:43
-#: ../workspace/basecontent/templates/document_view.pt:38
-#: ../workspace/basecontent/templates/event_view.pt:63
+#: ../workspace/basecontent/templates/document_view.pt:41
+#: ../workspace/basecontent/templates/event_view.pt:62
 msgid "Toggle extra metadata"
 msgstr ""
 
@@ -1338,15 +1345,15 @@ msgid "Token no longer valid"
 msgstr ""
 
 #: ../workspace/browser/templates/roster-edit.pt:176
-#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:124
+#: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:127
 msgid "Transfer members to another workspace."
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:367
+#: ../workspace/browser/tiles/templates/sidebar.pt:390
 msgid "Unassigned"
 msgstr ""
 
-#: ../workspace/browser/templates/content_macros.pt:156
+#: ../workspace/browser/templates/content_macros.pt:162
 msgid "Undecided"
 msgstr ""
 
@@ -1354,7 +1361,7 @@ msgstr ""
 msgid "Unfollow"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:195
+#: ../workspace/browser/tiles/sidebar.py:193
 msgid "Unknown function"
 msgstr ""
 
@@ -1362,12 +1369,12 @@ msgstr ""
 msgid "Unlike"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/events.pt:9
-#: ../workspace/browser/tiles/templates/sidebar.pt:400
+#: ../workspace/browser/tiles/templates/events.pt:10
+#: ../workspace/browser/tiles/templates/sidebar.pt:423
 msgid "Upcoming events"
 msgstr ""
 
-#: ../userprofile/browser/templates/user_import_form.pt:25
+#: ../userprofile/browser/templates/user_import_form.pt:56
 msgid "Update details for existing users (matching on username)"
 msgstr ""
 
@@ -1376,8 +1383,12 @@ msgstr ""
 msgid "Updates"
 msgstr ""
 
-#: ../workspace/browser/tiles/templates/sidebar.pt:244
+#: ../workspace/browser/tiles/templates/sidebar.pt:248
 msgid "Upload file(s)"
+msgstr ""
+
+#: ../userprofile/browser/templates/user_import_form.pt:18
+msgid "User profile management"
 msgstr ""
 
 #: ../microblog/interfaces.py:17
@@ -1443,7 +1454,7 @@ msgstr ""
 msgid "Workspace policy"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:247
+#: ../workspace/browser/tiles/sidebar.py:246
 msgid "Workspace security policy changes saved"
 msgstr ""
 
@@ -1472,7 +1483,7 @@ msgstr ""
 msgid "You can become a member of this workspace"
 msgstr ""
 
-#: ../workspace/browser/tiles/sidebar.py:160
+#: ../workspace/browser/tiles/sidebar.py:161
 msgid "You do not have permission to change the workspace policy"
 msgstr ""
 
@@ -1514,6 +1525,11 @@ msgstr ""
 msgid "date"
 msgstr ""
 
+#. Default: "Start time should be lower than end time. The system set the end time to: ${date}"
+#: ../workspace/browser/add_content.py:164
+msgid "dates_hijacked"
+msgstr ""
+
 #: ../workspace/browser/tiles/templates/navigation.pt:21
 #: ../workspace/browser/tiles/templates/sidebar.pt:37
 msgid "document type"
@@ -1525,7 +1541,7 @@ msgid "download"
 msgstr ""
 
 #. Default: "Drop files here or click to browse..."
-#: ../workspace/browser/tiles/sidebar.py:310
+#: ../workspace/browser/tiles/sidebar.py:309
 msgid "drop_files_here"
 msgstr ""
 
@@ -1545,7 +1561,7 @@ msgid "expand/reduce sidebar"
 msgstr ""
 
 #. Default: "External visibility"
-#: ../workspace/browser/tiles/sidebar.py:215
+#: ../workspace/browser/tiles/sidebar.py:214
 msgid "external_visibility_label"
 msgstr ""
 
@@ -1584,14 +1600,14 @@ msgstr ""
 msgid "invititations"
 msgstr ""
 
-#: ../search/browser/templates/all_results.pt:87
+#: ../search/browser/templates/all_results.pt:77
 #: ../search/browser/templates/image_results.pt:14
 #: ../search/browser/templates/people_results.pt:14
 msgid "items matched your search."
 msgstr ""
 
 #. Default: "Join policy"
-#: ../workspace/browser/tiles/sidebar.py:214
+#: ../workspace/browser/tiles/sidebar.py:213
 msgid "join_policy_label"
 msgstr ""
 
@@ -1609,13 +1625,13 @@ msgstr ""
 msgid "label_name"
 msgstr ""
 
-#. Default: "News"
-#: ../layout/browser/templates/news-tile.pt:8
+#. Default: "<a href=\"${context/portal_url}/library/news\">News</a>"
+#: ../layout/browser/templates/news-tile.pt:9
 msgid "label_news"
 msgstr ""
 
 #. Default: "No events available"
-#: ../workspace/browser/tiles/templates/sidebar.pt:460
+#: ../workspace/browser/tiles/templates/sidebar.pt:485
 msgid "label_no_events_available"
 msgstr ""
 
@@ -1665,36 +1681,36 @@ msgid "leave_a_comment"
 msgstr ""
 
 #. Default: "More sharing options coming soon"
-#: ../workspace/basecontent/templates/document_view.pt:111
+#: ../workspace/basecontent/templates/document_view.pt:115
 msgid "more_sharing_soon"
 msgstr ""
 
 #. Default: "No tasks created yet"
-#: ../workspace/browser/tiles/templates/sidebar.pt:298
+#: ../workspace/browser/tiles/templates/sidebar.pt:302
 msgid "no-task-found"
 msgstr ""
 
 #. Default: "${no_members} Members"
-#: ../workspace/workspacefolder.py:167
+#: ../workspace/workspacefolder.py:172
 msgid "number_of_members"
 msgstr ""
 
 #. Default: "Participant policy"
-#: ../workspace/browser/tiles/sidebar.py:217
+#: ../workspace/browser/tiles/sidebar.py:216
 msgid "participant_policy_label"
 msgstr ""
 
 #. Default: "Description"
-#: ../workspace/basecontent/templates/event_view.pt:101
+#: ../workspace/basecontent/templates/event_view.pt:100
 msgid "placeholder"
 msgstr ""
 
-#: ../workspace/browser/tiles/workspaces.py:109
+#: ../workspace/browser/tiles/workspaces.py:120
 msgid "posted"
 msgstr ""
 
 #. Default: "Read more..."
-#: ../layout/browser/templates/news-tile.pt:19
+#: ../layout/browser/templates/news-tile.pt:20
 #: ../library/browser/templates/library.html:148
 msgid "read-more"
 msgstr ""
@@ -1706,13 +1722,13 @@ msgstr ""
 
 #. Default: "All"
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:36
-#: ../workspace/browser/tiles/templates/sidebar.pt:81
+#: ../workspace/browser/tiles/templates/sidebar.pt:85
 msgid "select_all"
 msgstr ""
 
 #. Default: "None"
 #: ../workspace/browser/tiles/templates/sidebar-settings-members.pt:37
-#: ../workspace/browser/tiles/templates/sidebar.pt:82
+#: ../workspace/browser/tiles/templates/sidebar.pt:86
 msgid "select_none"
 msgstr ""
 
@@ -1723,6 +1739,16 @@ msgstr ""
 
 #: ../workspace/browser/tiles/templates/sidebar.pt:35
 msgid "tag"
+msgstr ""
+
+#. Cases
+#: ../layout/browser/templates/dashboard.pt
+msgid "tile_ploneintranet.workspace.case"
+msgstr ""
+
+#. Workspaces
+#: ../layout/browser/templates/dashboard.pt
+msgid "tile_ploneintranet.workspace.workspacefolder"
 msgstr ""
 
 #: ../network/browser/templates/maxiauthor_provider.pt:72

--- a/src/ploneintranet/workspace/browser/tiles/templates/workspaces.pt
+++ b/src/ploneintranet/workspace/browser/tiles/templates/workspaces.pt
@@ -8,7 +8,7 @@
       <div class="content">
         <h2 class="portlet-title">
           <a tal:attributes="href string:${here/@@plone_portal_state/navigation_root_url}/workspaces.html"
-             i18n:translate="" tal:content="view/workspace_type"></a></h2>
+             i18n:translate="" tal:content="string:tile_${view/workspace_type}"></a></h2>
           <ul class="links">
             <tal:workspace repeat="workspace workspaces">
               <li class="workspace" tal:attributes="title workspace/description">


### PR DESCRIPTION
In e3078070 the logic for the workspace tiles was refactored, but the
workspace_type parameter was also being used for the tile heading so the
headings were no longer translated.

I re-ran the synci18n.sh script to update the translations which also
includes some extra changes:

The following msgids were removed:

```
#: ../userprofile/browser/templates/user_import_form.pt:13
msgid "Bulk import users"
msgstr ""

#: ../workspace/browser/tiles/templates/sidebar.pt:417
msgid "Starts"
msgstr ""

#: ../workspace/browser/tiles/templates/sidebar.pt:422
msgid "Ended"
msgstr ""
```

This is correct, since the sidebar was updated in 9c41141da and
user_import_form was updated in 3544add4.
