### PR TITLE
Case bugfix: set the creation_date to now()

### DIFF
--- a/src/ploneintranet/workspace/case.py
+++ b/src/ploneintranet/workspace/case.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from plone import api
 from ploneintranet.attachments.attachments import IAttachmentStoragable
 from zope.interface import implementer
@@ -53,4 +54,5 @@ def create_case_from_template(template_id, target_id=None):
                 id=target_id,
                 safe_id=True,
             )
+            new.creation_date = datetime.now()
             return new


### PR DESCRIPTION
Otherwise all Case objects get the creation date of the template case.
