### PR TITLE
815 stream markup

### DIFF
--- a/src/ploneintranet/activitystream/browser/prototype/post.html
+++ b/src/ploneintranet/activitystream/browser/prototype/post.html
@@ -59,37 +59,54 @@
     <p tal:content="structure view/statusupdate_view/decorated_text">Comment text</p>
   </section>
 
-  <section class="document preview">
+  <tal:comment condition="nothing">
+  prototype distinguishes:
+  - content shares (link, download, view) versus status attachments (download)
+  - files (with title, description) versus images (fullwidth)
+  - has preview  versus no preview versus preview in progress
+  
+  Please study prototype/./_includes/post.html when making changes here.
+  </tal:comment>
 
-    <figure tal:repeat="attachment view/statusupdate_view/attachments">
-      <a href="/incredibly-boring-document" tal:attributes="href attachment/link">
-        <img src="/media/preview_thumb_1.jpg" alt=""
-             tal:attributes="src string:${attachment/img_src}">
-      </a>
-          <figcaption>
-            <strong class="title">
-              <a tal:attributes="href attachment/link; alt attachment/alt" href="/projection-material" alt="Projection Material">
-                <tal:r replace="attachment/title">Projection Material</tal:r> <!--span class="page-counter icon-docs">3x</span-->
-              </a>
-              <!-- This needs exposure of all generated thumbs. We can do that and have them accessible, it is just not added here yet. -->
-              <!--span class="functions">
-                <a href="#" class="icon iconified icon-download" i18n:attributes="title" title="Download this file" tal:attributes="href attachment/link">Download</a>
-                <nav class="pat-gallery">
-                  <a class="icon iconified icon-eye" href="http://lorempixel.com/1280/720/business/" title="Preview this file">Preview</a>
-                  <a hidden="" href="http://lorempixel.com/1280/720/sports/" class="icon iconified icon-eye" title="Preview this file">Page 2</a>
-                  <a hidden="" href="http://lorempixel.com/1280/720/food/" title="Preview this file">Page 3</a>
-                  <a hidden="" href="http://lorempixel.com/1280/720/cats/" title="Preview this file">Page 4</a>
-                </nav>
-              </span-->
-            </strong>
-            <a href="/projection-material" alt="Projection Material">
-              <em class="byline">Description goes here</em>
-            </a>
-          </figcaption>
+  <tal:attachments repeat="attachment view/statusupdate_view/attachments">
+    <tal:def define="is_content python:False;
+                     is_image attachment/is_image;
+                     has_preview attachment/img_src|nothing">
 
-    </figure>
+      <tal:streamonly condition="not:is_content">
+        <tal:stream_document condition="not:is_image">
+          <section class="document preview"
+                   tal:attributes="class python:has_preview and 'document preview' or 'document preview not-possible'">
+            <figure>
+              <img src="/media/preview_thumb_1.jpg" alt=""
+                   tal:condition="has_preview"
+                   tal:attributes="src string:${attachment/img_src}" />
+              <figcaption>
+                <strong class="title">
+                  <tal:r replace="attachment/title">Projection Material</tal:r>
+                  <!-- This needs exposure of all generated thumbs. We can do that and have them accessible, it is just not added here yet. -->
+                  <!--span class="page-counter icon-docs">3x</span-->
+                  <span class="functions">
+                      <a href="#" class="icon iconified icon-download" i18n:attributes="title" title="Download this file" tal:attributes="href attachment/link">Download</a>
+                      <!--nav class="pat-gallery">
+                        <a class="icon iconified icon-eye" href="http://lorempixel.com/1280/720/business/" title="Preview this file">Preview</a>
+                        <a hidden="" href="http://lorempixel.com/1280/720/sports/" class="icon iconified icon-eye" title="Preview this file">Page 2</a>
+                        <a hidden="" href="http://lorempixel.com/1280/720/food/" title="Preview this file">Page 3</a>
+                        <a hidden="" href="http://lorempixel.com/1280/720/cats/" title="Preview this file">Page 4</a>
+                      </nav-->
+</span>
+                </strong>
+                <em class="byline">&nbsp;
+                  <!-- Need description for vertical space-->
+                </em>
+              </figcaption>
+            </figure>
+          </section>
+        </tal:stream_document>
+      </tal:streamonly>
 
-  </section>
+    </tal:def>
+  </tal:attachments>
 
   <div class="functions">
     <!-- XXX: This is not yet implemented -->

--- a/src/ploneintranet/activitystream/browser/prototype/post.html
+++ b/src/ploneintranet/activitystream/browser/prototype/post.html
@@ -66,6 +66,10 @@
   - has preview  versus no preview versus preview in progress
   
   Please study prototype/./_includes/post.html when making changes here.
+
+  NB the prototype assumes that multiple attachments are either all images
+  or else are all files. Implementation will need to split that into
+  a multi-file + multi-image renderer.
   </tal:comment>
 
   <tal:attachments repeat="attachment view/statusupdate_view/attachments">
@@ -74,13 +78,14 @@
                      has_preview attachment/img_src|nothing">
 
       <tal:streamonly condition="not:is_content">
+
         <tal:stream_document condition="not:is_image">
           <section class="document preview"
                    tal:attributes="class python:has_preview and 'document preview' or 'document preview not-possible'">
             <figure>
               <img src="/media/preview_thumb_1.jpg" alt=""
                    tal:condition="has_preview"
-                   tal:attributes="src string:${attachment/img_src}" />
+                   tal:attributes="src attachment/img_src" />
               <figcaption>
                 <strong class="title">
                   <tal:r replace="attachment/title">Projection Material</tal:r>
@@ -88,21 +93,28 @@
                   <!--span class="page-counter icon-docs">3x</span-->
                   <span class="functions">
                       <a href="#" class="icon iconified icon-download" i18n:attributes="title" title="Download this file" tal:attributes="href attachment/link">Download</a>
-                      <!--nav class="pat-gallery">
-                        <a class="icon iconified icon-eye" href="http://lorempixel.com/1280/720/business/" title="Preview this file">Preview</a>
-                        <a hidden="" href="http://lorempixel.com/1280/720/sports/" class="icon iconified icon-eye" title="Preview this file">Page 2</a>
-                        <a hidden="" href="http://lorempixel.com/1280/720/food/" title="Preview this file">Page 3</a>
-                        <a hidden="" href="http://lorempixel.com/1280/720/cats/" title="Preview this file">Page 4</a>
-                      </nav-->
-</span>
+                      <!-- XXX gallery not implemented yet -- >
                 </strong>
-                <em class="byline">&nbsp;
-                  <!-- Need description for vertical space-->
-                </em>
+                <!-- no description byline for status attachments -->
               </figcaption>
             </figure>
           </section>
         </tal:stream_document>
+
+        <tal:stream_image condition="is_image">
+	  <section class="image preview">
+	    <figure>
+              <img src="/media/preview_thumb_1.jpg" alt=""
+                   tal:condition="has_preview"
+                   tal:attributes="src attachment/img_src" />
+	    </figure>
+	    <p class="overlay" tal:condition="nothing">
+              <!-- XXX images gallery view not implemented yet -->
+              <!-- XXX images zip download not implemented yet -->
+	    </p>
+	  </section>
+        </tal:stream_image>
+
       </tal:streamonly>
 
     </tal:def>

--- a/src/ploneintranet/activitystream/browser/statusupdate.py
+++ b/src/ploneintranet/activitystream/browser/statusupdate.py
@@ -193,9 +193,11 @@ class StatusUpdateView(BrowserView):
             self.attachment_base_url,
             item.getId(),
         ))
+        is_image = False
         if pi_api.previews.get(item):
             url = '/'.join((item_url, 'small'))
         elif isinstance(item, Image):
+            is_image = True
             images = api.content.get_view(
                 'images',
                 item.aq_base,
@@ -206,13 +208,10 @@ class StatusUpdateView(BrowserView):
                 images.scale(scale='preview').url.lstrip('/'),
             ))
         else:
-            # We need a better fallback image. See #122
-            url = '/'.join((
-                api.portal.get().absolute_url(),
-                '++theme++ploneintranet.theme/generated/media/logo.svg'
-            ))
+            url = None
 
-        return {'img_src': url,
+        return {'is_image': is_image,
+                'img_src': url,
                 'link': item_url,
                 'alt': item.id,
                 'title': item.id}

--- a/src/ploneintranet/activitystream/browser/statusupdate.py
+++ b/src/ploneintranet/activitystream/browser/statusupdate.py
@@ -194,19 +194,23 @@ class StatusUpdateView(BrowserView):
             item.getId(),
         ))
         is_image = False
-        if pi_api.previews.get(item):
-            url = '/'.join((item_url, 'small'))
-        elif isinstance(item, Image):
+        if isinstance(item, Image):
             is_image = True
-            images = api.content.get_view(
-                'images',
-                item.aq_base,
-                self.request,
-            )
-            url = '/'.join((
-                item_url,
-                images.scale(scale='preview').url.lstrip('/'),
-            ))
+            # # this suffers from a bug
+            # # 'large' should return 768x768 but instead returns 400x400
+            # images = api.content.get_view(
+            #     'images',
+            #     item.aq_base,
+            #     self.request,
+            # )
+            # url = '/'.join((
+            #     item_url,
+            #     images.scale(scale='large').url.lstrip('/'),
+            # ))
+            # # use unscaled instead
+            url = item_url
+        elif pi_api.previews.get(item):
+            url = '/'.join((item_url, 'small'))
         else:
             url = None
 

--- a/src/ploneintranet/api/previews.py
+++ b/src/ploneintranet/api/previews.py
@@ -43,7 +43,9 @@ def get_preview_urls(obj, scale='normal'):
 
 
 def fallback_image(obj):
-    """Return a fallback image for use if there are no previews.
+    """DEPRECATED: Return a fallback image for use if there are no previews.
+
+    Prototype does not use fallback image anymore, instead offers css solution.
 
     :param obj: The Plone object to get previews for
     :type obj: A Plone content object
@@ -54,7 +56,9 @@ def fallback_image(obj):
 
 
 def fallback_image_url(obj):
-    """Return a fallback image URL for use if there are no previews.
+    """DEPRECATED: Return a fallback image URL for use if there are no previews.
+
+    Prototype does not use fallback image anymore, instead offers css solution.
 
     :param obj: The Plone object to get previews for
     :type obj: A Plone content object


### PR DESCRIPTION
Fix the stream so stream attachments are only linked via the download icon, not the title.
Also show uploaded images in full glory.

If somebody can get the 'large' scale to work that would speed up user performance.
