### PR TITLE
Metromap transition fixes

### DIFF
--- a/src/ploneintranet/workspace/adapters.py
+++ b/src/ploneintranet/workspace/adapters.py
@@ -301,12 +301,16 @@ class MetroMap(object):
 
             # only current state can be closed
             if (state == current_state and can_manage and not open_tasks):
-                next_transition = wfstep.get('next_transition', None)
+                next_transition_enabled = True
             else:
-                next_transition = None
-            if next_transition:
+                next_transition_enabled = False
+
+            # get the id and title of the next transition, for display on the
+            # metromap
+            next_transition_id = metromap_list[index].get('next_transition')
+            if next_transition_id:
                 transition_title = _(
-                    cwf.transitions.get(next_transition).title)
+                    cwf.transitions.get(next_transition_id).title)
             else:
                 transition_title = ''
 
@@ -323,7 +327,8 @@ class MetroMap(object):
 
             sequence[state] = {
                 'title': _(cwf.states.get(state).title),
-                'transition_id': next_transition,
+                'transition_enabled': next_transition_enabled,
+                'transition_id': next_transition_id,
                 'transition_title': transition_title,
                 'reopen_transition': reopen_transition,
                 'is_current': is_current,

--- a/src/ploneintranet/workspace/browser/tiles/templates/sidebar.pt
+++ b/src/ploneintranet/workspace/browser/tiles/templates/sidebar.pt
@@ -379,7 +379,7 @@ Supported types include (class names):
                          tal:attributes="href string:${ws/absolute_url}/add_task?milestone=${milestone_id}"
                          tal:condition="view/can_add" i18n:translate="">Create new task</a>
                       <a class="small icon-stage success button pat-inject"
-                         tal:condition="python:milestone['transition_id']"
+                         tal:condition="python:milestone['transition_enabled']"
                          tal:attributes="href python:'{0}/content_status_modify?workflow_action={1}&_authenticator={2}'.format(ws.absolute_url(), milestone['transition_id'], token);" data-pat-inject="source:#workspace-tickets; target:#workspace-tickets" i18n:translate="">Close milestone</a>
                       <a class="small icon-stage success button pat-inject"
                          tal:condition="python:milestone['reopen_transition']"

--- a/src/ploneintranet/workspace/tests/test_caseworkspace.py
+++ b/src/ploneintranet/workspace/tests/test_caseworkspace.py
@@ -65,3 +65,15 @@ class TestCaseWorkspace(FunctionalBaseTestCase):
             container=workspaces,
         )
         self.assertTrue(queryAdapter(workspace, IMetroMap) is None)
+
+    def test_metromap_transition_titles(self):
+        """
+        All Case workflow transitions except for the very last one should have
+        titles. These are displayed in the metromap.
+        """
+        mm_seq = IMetroMap(self.case).metromap_sequence
+        titles = [mm_seq[i]['transition_title'] for i in mm_seq]
+        titles_but_last = titles[:-1]
+        self.assertTrue(
+            set([i is not '' for i in titles_but_last]), set([True]))
+

--- a/src/ploneintranet/workspace/tests/test_caseworkspace.py
+++ b/src/ploneintranet/workspace/tests/test_caseworkspace.py
@@ -76,4 +76,3 @@ class TestCaseWorkspace(FunctionalBaseTestCase):
         titles_but_last = titles[:-1]
         self.assertTrue(
             set([i is not '' for i in titles_but_last]), set([True]))
-


### PR DESCRIPTION
We lost the metromap transition titles and icons in the case-refactor. This re-adds them.
