### PR TITLE
Update quickstart.rst

### DIFF
--- a/docs/installation/quickstart.rst
+++ b/docs/installation/quickstart.rst
@@ -20,7 +20,7 @@ Prepare the Operating System Environment
 Plone Intranet has quite a number of OS-level dependencies:
 
 - ruby (for docsplit) and docsplit
-- java (for Solr)
+- java (for Solr - requires Java 7 or greater)
 - redis-server
 
 We maintain an exact description of these requirements in the form of a Ubuntu 14.04


### PR DESCRIPTION
Apache Solr requires java version 7 or greater. This was not clearly stated and I attempted to install the system using Java 6, and ran into issues..
