### PR TITLE
Set default body text for Documents

### DIFF
--- a/src/ploneintranet/workspace/configure.zcml
+++ b/src/ploneintranet/workspace/configure.zcml
@@ -131,6 +131,12 @@
      handler=".subscribers.content_object_moved"
      />
 
+  <subscriber
+     for="plone.app.contenttypes.interfaces.IDocument
+          zope.lifecycleevent.interfaces.IObjectAddedEvent"
+     handler=".subscribers.set_default_body_text"
+     />
+
   <genericsetup:registerProfile
       name="default"
       title="Plone Intranet: -- [Workspace]"

--- a/src/ploneintranet/workspace/subscribers.py
+++ b/src/ploneintranet/workspace/subscribers.py
@@ -1,8 +1,10 @@
+# -*- coding: utf-8 -*-
 import logging
 from zope.annotation.interfaces import IAnnotations
 from AccessControl.SecurityManagement import newSecurityManager
 from collective.workspace.interfaces import IWorkspace
 from plone import api
+from plone.app.textfield.value import RichTextValue
 from Products.CMFPlacefulWorkflow.PlacefulWorkflowTool \
     import WorkflowPolicyConfig_id
 from zope.globalrequest import getRequest
@@ -229,3 +231,8 @@ def update_todos_state(obj, event):
 def _update_todo_state(todo):
     todo.set_appropriate_state()
     todo.reindexObject()
+
+
+def set_default_body_text(obj, event):
+    default_text = obj.translate(_(u'Add text here'))
+    obj.text = RichTextValue(raw=u'<p>{} …</p>'.format(default_text))


### PR DESCRIPTION
Previously we injected content into the body of a Document if it was
empty so that a user has an area available in the editor where they can
click to start editing. This triggered a change to the document which
showed a confirmation dialog when a user navigated away from the
Document, (because of unsaved changes).

This change sets the default text on creation to avoid this issue.
