### PR TITLE
853 comment ordering fix

### DIFF
--- a/src/ploneintranet/activitystream/browser/statusupdate.py
+++ b/src/ploneintranet/activitystream/browser/statusupdate.py
@@ -231,10 +231,12 @@ class StatusUpdateView(BrowserView):
     def comment_views(self):
         ''' Return the way we can reply to this activity
         '''
-        return [
+        replies = list(self.context.replies())
+        replies.reverse()
+        replies_rendered = [
             api.content.get_view(
                 'statusupdate_view',
                 reply,
-                self.request,
-            ).as_comment for reply in self.context.replies()
-        ]
+                self.request).as_comment
+            for reply in replies]
+        return replies_rendered

--- a/src/ploneintranet/microblog/statuscontainer.py
+++ b/src/ploneintranet/microblog/statuscontainer.py
@@ -384,7 +384,7 @@ class BaseStatusContainer(Persistent, Explicit):
         mapping = self._threadid_mapping.get(thread_id) or [thread_id]
         mapping = self.secure(mapping)
         return longkeysortreverse(mapping,
-                                  min, max, limit, reverse=False)
+                                  min, max, limit)
 
     # --- USER ACCESSORS ---
 

--- a/src/ploneintranet/microblog/tests/test_statuscontainer_threaded.py
+++ b/src/ploneintranet/microblog/tests/test_statuscontainer_threaded.py
@@ -72,7 +72,8 @@ class TestStatusContainer_Tags(unittest.TestCase):
         container.add(sc)
         # get all thread items from parent status.id
         keys = [x for x in container.thread_keys(thread_id=status.id)]
-        self.assertEqual([status.id, sa.id, sb.id, sc.id], keys)
+        # comments are reversed by default (like status updates)
+        self.assertEqual([sc.id, sb.id, sa.id, status.id], keys)
 
     def test_values(self):
         container = StatusContainer()
@@ -91,7 +92,8 @@ class TestStatusContainer_Tags(unittest.TestCase):
         container.add(sc)
         # get all thread items from parent status.id
         values = [x for x in container.thread_values(thread_id=status.id)]
-        self.assertEqual([status, sa, sb, sc], values)
+        # comments are reversed by default (like status updates)
+        self.assertEqual([sc, sb, sa, status], values)
 
     def test_items(self):
         container = StatusContainer()
@@ -110,7 +112,7 @@ class TestStatusContainer_Tags(unittest.TestCase):
         container.add(sc)
         # get all thread items from parent status.id
         values = [x[1] for x in container.thread_items(thread_id=status.id)]
-        self.assertEqual([status, sa, sb, sc], values)
+        self.assertEqual([sc, sb, sa, status], values)
 
     def test_get_thread_by_thread_item(self):
         container = StatusContainer()
@@ -132,7 +134,7 @@ class TestStatusContainer_Tags(unittest.TestCase):
         if getattr(si, 'thread_id'):
             values = [x[1] for x in
                       container.thread_items(thread_id=si.thread_id)]
-            self.assertEqual([status, sa, sb, sc], values)
+            self.assertEqual([sc, sb, sa, status], values)
 
     def test_get_nothing_by_none_thread_item(self):
         container = StatusContainer()

--- a/src/ploneintranet/microblog/utils.py
+++ b/src/ploneintranet/microblog/utils.py
@@ -3,7 +3,7 @@ from BTrees import LLBTree
 
 
 def longkeysortreverse(
-        btreeish, minv=None, maxv=None, limit=None, reverse=True):
+        btreeish, minv=None, maxv=None, limit=None):
     """Performance optimized keyspace accessor.
     Returns an iterable of btreeish keys, reverse sorted by key.
     Expects a btreeish with long(microsec) keys.
@@ -19,8 +19,7 @@ def longkeysortreverse(
         # no optimization
         keys = [x for x in accessor(min=minv, max=maxv)]
         keys.sort()
-        if reverse:
-            keys.reverse()
+        keys.reverse()
         for key in keys:
             yield key
             i += 1
@@ -34,8 +33,7 @@ def longkeysortreverse(
         tmin = long(tmax - 3600 * 1e6)
         keys = [x for x in accessor(min=tmin, max=tmax)]
         keys.sort()
-        if reverse:
-            keys.reverse()
+        keys.reverse()
         for key in keys:
             yield key
             i += 1
@@ -47,8 +45,7 @@ def longkeysortreverse(
         tmin = long(tmax - 23 * 3600 * 1e6)
         keys = [x for x in accessor(min=tmin, max=tmax)]
         keys.sort()
-        if reverse:
-            keys.reverse()
+        keys.reverse()
         for key in keys:
             yield key
             i += 1
@@ -59,8 +56,7 @@ def longkeysortreverse(
         tmax = tmin
         keys = [x for x in accessor(max=tmax)]
         keys.sort()
-        if reverse:
-            keys.reverse()
+        keys.reverse()
         for key in keys:
             yield key
             i += 1


### PR DESCRIPTION
Fixes #853 

The reason comments were coming out of order was due to the "reverse" keyword argument that had previously been added to longkeysprtreverse(). This had the effect of reversing each "set" of results (last hour, last day, rest) but still maintaining that order.

To fix the related issue, the reverse has been done in the required place.
