### PR TITLE
Spelling suggestions (Fixes #852.)

### DIFF
--- a/src/ploneintranet/search/solr/adapters.py
+++ b/src/ploneintranet/search/solr/adapters.py
@@ -56,12 +56,8 @@ class SearchResponse(base.SearchResponse):
         suggestions = spellcheck.get('suggestions', [])
         if len(suggestions) < 1:
             return None
-        query_params = self.context.query_params
-        orig_phrase = query_params['phrase']
-        collation = spellcheck['collations'][-1]
-        suggested = u''.join(x.upper() if y.isupper() else x
-                             for (x, y) in zip(collation, orig_phrase))
-        return suggested
+        collated = spellcheck['collations'][-1]
+        return collated
 
     @property
     def facets(self):

--- a/src/ploneintranet/search/tests/base.py
+++ b/src/ploneintranet/search/tests/base.py
@@ -318,11 +318,12 @@ class SiteSearchTestsMixin(SiteSearchContentsTestMixin):
 
         # These corrected spellings should work (depending on configuration.
         self._check_spellcheck_response(u'anathar', u'another')
-        self._check_spellcheck_response(u'Rcichad', u'Richard')
-        self._check_spellcheck_response(u'Anather', u'Another')
-        self._check_spellcheck_response(u'Perplaxed', u'Perplexed')
-        self._check_spellcheck_response(u"Reining cots n' dags",
-                                        u"Raining cats n' dogs")
+        self._check_spellcheck_response(u'Rcichad', u'richard')
+        self._check_spellcheck_response(u'Anather', u'another')
+        self._check_spellcheck_response(u'Perplaxed', u'perplexed')
+        self._check_spellcheck_response(u'Peplexed', u'perplexed')
+        self._check_spellcheck_response(u"reining cots n' dags",
+                                        u"raining cats n' dogs")
 
     def test_date_range_query(self):
         util = self._make_utility()


### PR DESCRIPTION
This was caused to trying to provide spelling suggestions in the same
case as the input query string (trying to be as clever as google).

This addresses the issue by always returning the spelling suggestions in lower-case.

Resolves #852
