### PR TITLE
Power search library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ docs/make.bat
 eggs/
 Gemfile.lock
 include/
-lib/
+./lib/
 libreoffice/
 local/
 node_modules/

--- a/src/ploneintranet/library/browser/views.py
+++ b/src/ploneintranet/library/browser/views.py
@@ -189,7 +189,7 @@ class LibraryTagView(LibraryBaseView):
                 _query = _query.filter(subquery)
             else:
                 _query = _query.filter(Q(**{key: value}))
-        _query.facet_by(fields=(u'tags'))
+        _query = _query.facet_by('tags')
         _query = _query.sort_by('Title')
         # print _query.query_obj
         # print _query.options()

--- a/src/ploneintranet/library/browser/views.py
+++ b/src/ploneintranet/library/browser/views.py
@@ -228,12 +228,10 @@ class LibraryTagView(LibraryBaseView):
                            content=[])
             if self.request_tag:
                 section['content'] = self._content_children(path, _tag)
-                section['count'] = len(section['content'])
             else:
                 section['subtags'] = self._subtags_children(path, _tag)
-                section['count'] = len(section['subtags'])
             struct.append(section)
-        return sorted(struct, key=lambda x: x['count'])
+        return struct
 
     def _subtags_children(self, path, tag):
         """List tags co-occurring with <tag>"""
@@ -264,7 +262,7 @@ class LibraryTagView(LibraryBaseView):
     def _tags_facet(self, searchresponse):
         """
         ZCatalog returns <str> Solr returns <unicode>.
-        We force everything into unicode.
+        We force everything into unicode and sort abc.
         """
-        return [safe_unicode(t)
-                for t in searchresponse.facets.get('tags', [])]
+        return sorted([safe_unicode(t)
+                       for t in searchresponse.facets.get('tags', [])])

--- a/src/ploneintranet/suite/tests/acceptance/case.robot
+++ b/src/ploneintranet/suite/tests/acceptance/case.robot
@@ -158,4 +158,3 @@ The manager can invite Alice to join the Example Case from the menu
 *** Keywords ***
 
 # See lib/keywords.robot in the section "case related keywords"
-

--- a/src/ploneintranet/suite/tests/lib/keywords.robot
+++ b/src/ploneintranet/suite/tests/lib/keywords.robot
@@ -498,11 +498,11 @@ I cannot edit an event because of validation
 Then I can delete an event
     [arguments]  ${title}
     Click link  jquery=a:contains("${title}")
+    Wait Until Page Contains Element  css=div.event-details
     ### The following sleep statement addresses the StaleElementReferenceException that sometimes occurs
     ### Solutions proposed on the web address this programmatically with a combination of looping
     ### and exception handling. I wouldn't know of an equivalent solution in robot.
     sleep  2
-    Wait Until Page Contains Element  css=div.event-details
     Wait until element is visible  css=.meta-bar .icon-trash
     Click Element  css=.meta-bar .icon-trash
     Wait until page contains element    xpath=//div[@class='panel-content']//button[@name='form.buttons.Delete']

--- a/src/ploneintranet/suite/tests/lib/keywords.robot
+++ b/src/ploneintranet/suite/tests/lib/keywords.robot
@@ -770,23 +770,31 @@ I mark a new task complete
 
 I select the task check box
     [arguments]  ${title}
+    Wait until Page Contains Element  xpath=(//label[@class='unchecked']//a[@title='${title}'])
     Select Checkbox  xpath=(//a[@title='${title}'])/preceding-sibling::input[1]
+    ### Without the following sleep statement the 'Wait until' statement that follows it
+    ### is executed quickly and selenium sometimes leaves the page before autosave can happen.
+    ### This leads to errors later on when the box is assumed to be checked.
+    sleep  4
     Wait until Page Contains Element  xpath=(//label[@class='checked']//a[@title='${title}'])
 
 I unselect the task check box
     [arguments]  ${title}
+    Wait until Page Contains Element  xpath=(//label[@class='checked']//a[@title='${title}'])
     Unselect Checkbox  xpath=(//a[@title='${title}'])/preceding-sibling::input[1]
+    ### Without the following sleep statement the 'Wait until' statement that follows it
+    ### is executed quickly and selenium sometimes leaves the page before autosave can happen.
+    ### This leads to errors later on when the box is assumed to be checked.
+    sleep  4
     Wait until Page Contains Element  xpath=(//label[@class='unchecked']//a[@title='${title}'])
 
 I see a task is complete
     [arguments]  ${title}
-    Wait until Page Contains Element  xpath=(//label[@class='checked']//a[@title='${title}'])/preceding-sibling::input[1]
-    Checkbox Should Be Selected  xpath=(//label[@class='checked']//a[@title='${title}'])/preceding-sibling::input[1]
+    Wait until Page Contains Element  xpath=(//label[@class='checked']//a[@title='${title}'])
 
 I see a task is open
     [arguments]  ${title}
-    Wait until Page Contains Element  xpath=(//label[@class='unchecked']//a[@title='${title}'])/preceding-sibling::input[1]
-    Checkbox Should Not Be Selected  xpath=(//label[@class='unchecked']//a[@title='${title}'])/preceding-sibling::input[1]
+    Wait until Page Contains Element  xpath=(//label[@class='unchecked']//a[@title='${title}'])
 
 I see the task quality check has state
     [arguments]  ${state}
@@ -817,6 +825,7 @@ I can add a new task
 I can close a milestone
     [arguments]  ${milestone}
     I can open a milestone task panel  ${milestone}
+    Wait Until Page Contains Element  xpath=//fieldset[@id='milestone-${milestone}']//a[text()='Close milestone']
     Click Link  xpath=//fieldset[@id='milestone-${milestone}']//a[text()='Close milestone']
     # auto-closes current, reopen
     I can open a milestone task panel  ${milestone}
@@ -834,6 +843,10 @@ I can reopen a milestone
     Click Link  xpath=//fieldset[@id='milestone-${milestone}']//a[text()='Reopen milestone']
     # auto-closes current, reopen
     I can open a milestone task panel  ${milestone}
+    ### The following sleep statement addresses the StaleElementReferenceException that sometimes occurs
+    ### Solutions proposed on the web address this programmatically with a combination of looping
+    ### and exception handling. I wouldn't know of an equivalent solution in robot.
+    sleep  2
     Wait until element is visible  xpath=//fieldset[@id='milestone-${milestone}']//h4[contains(@class, 'state-finished')]
 
 I can open a milestone task panel

--- a/src/ploneintranet/suite/tests/lib/keywords.robot
+++ b/src/ploneintranet/suite/tests/lib/keywords.robot
@@ -498,6 +498,10 @@ I cannot edit an event because of validation
 Then I can delete an event
     [arguments]  ${title}
     Click link  jquery=a:contains("${title}")
+    ### The following sleep statement addresses the StaleElementReferenceException that sometimes occurs
+    ### Solutions proposed on the web address this programmatically with a combination of looping
+    ### and exception handling. I wouldn't know of an equivalent solution in robot.
+    sleep  2
     Wait Until Page Contains Element  css=div.event-details
     Wait until element is visible  css=.meta-bar .icon-trash
     Click Element  css=.meta-bar .icon-trash


### PR DESCRIPTION
This builds on the work done in #861 to remove a weird workaround for tag faceting. Also fixes #862 by sorting the tag facets alphabetically, rather than by number of child items. @pilz this one is for you - note that the abc sorting gets rather mucked up by the masonry pattern. Works great on mobile though :-).
