### PR TITLE
Refs #12692 Case: treat a WF state not in the MMap as a future state

### DIFF
--- a/src/ploneintranet/todo/content/todo.py
+++ b/src/ploneintranet/todo/content/todo.py
@@ -38,7 +38,14 @@ class Todo(Item):
             if milestone:
                 case_state = wft.getInfoFor(workspace, 'review_state')
                 mm = IMetroMap(workspace).metromap_sequence.keys()
-                future = mm.index(milestone) > mm.index(case_state)
+                # A case could be set to a state which isn't included in the
+                # metromap e.g. on-hold, rejected. If that happens we can treat
+                # the case_state as a future state and set all open tasks to
+                # planned
+                future = (
+                    case_state not in mm or
+                    mm.index(milestone) > mm.index(case_state)
+                )
                 current_or_past = not future
                 if current_or_past and todo_state != 'open':
                     api.content.transition(self, 'set_to_open')

--- a/src/ploneintranet/todo/content/todo.py
+++ b/src/ploneintranet/todo/content/todo.py
@@ -40,10 +40,10 @@ class Todo(Item):
                 mm = IMetroMap(workspace).metromap_sequence.keys()
                 # A case could be set to a state which isn't included in the
                 # metromap e.g. on-hold, rejected. If that happens we can treat
-                # the case_state as a future state and set all open tasks to
-                # planned
+                # it as a future state and set all open tasks to planned
+                mm_states = case_state in mm and milestone in mm
                 future = (
-                    case_state not in mm or
+                    not mm_states or
                     mm.index(milestone) > mm.index(case_state)
                 )
                 current_or_past = not future

--- a/src/ploneintranet/workspace/tests/test_todos.py
+++ b/src/ploneintranet/workspace/tests/test_todos.py
@@ -146,3 +146,28 @@ class TestTodos(BaseTestCase):
         self.assertEquals(wft.getInfoFor(case_todo, 'review_state'), 'planned')
         api.content.transition(case2, 'assign')
         self.assertEquals(wft.getInfoFor(case_todo, 'review_state'), 'open')
+
+    def test_reject_case(self):
+        """
+        Rejecting a Case should set 'open' Todo items to 'planned'
+        """
+        wft = self.portal.portal_workflow
+        case_todo = api.content.create(
+            type='todo',
+            title='case_todo',
+            container=self.case,
+            milestone='new',
+        )
+        self.assertEquals(wft.getInfoFor(case_todo, 'review_state'), 'open')
+
+        api.content.transition(self.case, 'reject')
+        self.assertEquals(wft.getInfoFor(case_todo, 'review_state'), 'planned')
+
+        case_todo.milestone = 'bogus'
+        api.content.transition(self.case, 'reset')
+        self.assertEquals(wft.getInfoFor(case_todo, 'review_state'), 'planned')
+
+        api.content.transition(self.case, 'reject')
+        case_todo.milestone = 'new'
+        api.content.transition(self.case, 'reset')
+        self.assertEquals(wft.getInfoFor(case_todo, 'review_state'), 'open')


### PR DESCRIPTION
To allow extra workflow states which aren't used by the MetroMap
e.g. on-hold or rejected, we can treat these states the same as future
states in the MetroMap and set the WF state of currently Open
tasks to Planned, so that they don't appear on the Dashboard.

(cherry picked from commit 173235f918b6cd2029276f9e4ea1b5d40743f8f4)
