### PR TITLE
Use ISiteSearch (i.e. solr if available) in sidebar search

### DIFF
--- a/buildout.d/solr.cfg
+++ b/buildout.d/solr.cfg
@@ -38,6 +38,7 @@ index =
     name:Description            type:text copyfield:default copyfield:spelling stored:true
     name:SearchableText         type:text copyfield:default copyfield:spelling stored:false
     name:tags                   type:string copyfield:default stored:true multivalued:true
+    name:Subject                type:string stored:true indexed:false multivalued:true
     name:Title                  type:text copyfield:default copyfield:spelling stored:true
     name:UID                    type:string stored:true required:true
     name:allowedRolesAndUsers   type:string stored:false multivalued:true
@@ -46,6 +47,7 @@ index =
     name:expires                type:date stored:true
     name:email                  type:string stored:true
     name:friendly_type_name     type:string stored:true indexed:true
+    name:getId                  type:string stored:true indexed:false
     name:has_thumbs             type:boolean indexed:true
     name:modified               type:date stored:true
     name:path_depth             type:integer indexed:true stored:false

--- a/src/ploneintranet/search/base.py
+++ b/src/ploneintranet/search/base.py
@@ -90,6 +90,7 @@ class SearchResult(object):
         self.portal_type = context['portal_type']
         self.contact_email = context.get('email')
         self.contact_telephone = context.get('telephone')
+        self.mimetype = context.get('mimetype', None)
         if context['has_thumbs']:  # indexer in docconv
             # can occur in workspaces AND library
             if self.portal_type in ('Image', 'Document', 'News Item'):
@@ -135,6 +136,12 @@ class SearchResult(object):
     def path(self):
         """Return the path URI to the object represented."""
 
+    def getPath(self):
+        return self.path
+
+    def getId(self):
+        return self.context['getId']
+
     @property
     def url(self):
         """Generate the absolute URL for the indexed document.
@@ -149,6 +156,9 @@ class SearchResult(object):
             url = '{}/view'.format(url)
         return url
 
+    def getURL(self):
+        return self.url
+
     @property
     def preview_image_url(self):
         """
@@ -158,6 +168,15 @@ class SearchResult(object):
         :rtype: str
         """
         return self._path_to_url(self.preview_image_path)
+
+    def __getitem__(self, key):
+        return self.context[key]
+
+    def get(self, key, default=None):
+        try:
+            return self[key]
+        except KeyError:
+            return default
 
 
 class SearchResponse(collections.Iterable):

--- a/src/ploneintranet/workspace/browser/tiles/sidebar.py
+++ b/src/ploneintranet/workspace/browser/tiles/sidebar.py
@@ -17,12 +17,14 @@ from plone import api
 from plone.app.contenttypes.interfaces import IEvent
 from plone.app.event.base import localized_now
 from plone.i18n.normalizer import idnormalizer
+from ploneintranet.search.interfaces import ISiteSearch
 from ploneintranet.todo.utils import update_task_status
 from Products.CMFPlone.utils import safe_unicode
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from Products.statusmessages.interfaces import IStatusMessage
 from zope.component import getAdapter
 from zope.component import getMultiAdapter
+from zope.component import getUtility
 from zope.event import notify
 from zope.lifecycleevent import ObjectModifiedEvent
 from zope.publisher.browser import BrowserView
@@ -452,7 +454,7 @@ class Sidebar(BaseTile):
                 url=url,
                 creator=api.user.get(username=r['Creator']),
                 modified=r['modified'],
-                subject=r['Subject'],
+                subject=r.get('Subject', ()),
                 UID=r['UID'],
                 path=r.getPath()
             ))
@@ -482,7 +484,6 @@ class Sidebar(BaseTile):
         It returns the items based on the selected grouping (and later may
         take sorting, archiving etc into account)
         """
-        catalog = api.portal.get_tool("portal_catalog")
         current_path = '/'.join(self.context.getPhysicalPath())
         sidebar_search = self.request.get('sidebar-search', None)
         query = {}
@@ -502,11 +503,14 @@ class Sidebar(BaseTile):
         if sidebar_search:
             # User has typed a search query
 
+            sitesearch = getUtility(ISiteSearch)
+            query['path'] = current_path
             # XXX plone only allows * as postfix.
             # With solr we might want to do real substr
-            query['SearchableText'] = '%s*' % sidebar_search
-            query['path'] = current_path
-            results = self._extract_attrs(catalog.searchResults(query))
+            response = sitesearch.query(phrase='%s*' % sidebar_search,
+                                        filters=query,
+                                        step=99999)
+            results = self._extract_attrs(response)
 
         elif self.request.get('groupname'):
             # User has clicked on a specific group header


### PR DESCRIPTION
This is another prerequisite for dropping SearchableText from the portal_catalog, s.a. #872.

Includes some changes to SearchResult, making it more like a catalog brain.
