### PR TITLE
dexterity_update: only update fields in request.form

### DIFF
--- a/src/ploneintranet/workspace/basecontent/utils.py
+++ b/src/ploneintranet/workspace/basecontent/utils.py
@@ -53,6 +53,9 @@ def dexterity_update(obj, request=None):
     errors = []
     for schema in get_dexterity_schemas(context=obj):
         for name in getFieldNames(schema):
+            # Only update fields which are included in the form
+            if name not in request.form:
+                continue
             field = schema[name]
             widget = component.getMultiAdapter(
                 (field, request), IFieldWidget)


### PR DESCRIPTION
Without this change dexterity_update will reset fields which aren't
specified in the request. For example: when the workflow state is
changed, dexterity_update gets called with only the 
workflow_action in request.form so, the other fields e.g. tags get
removed.
